### PR TITLE
use explicit path to yarn, to work around base image issue

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -37,7 +37,9 @@ WORKDIR /root/shadowbox
 COPY build/shadowbox/app app/
 COPY src/shadowbox/package.json .
 COPY src/shadowbox/yarn.lock .
-RUN yarn install --prod
+# TODO: Replace with plain old "yarn" once the base image is fixed:
+#       https://github.com/nodejs/docker-node/pull/639
+RUN /opt/yarn-v$YARN_VERSION/bin/yarn install --prod
 
 # Create default state directory.
 RUN mkdir -p /root/shadowbox/persisted-state


### PR DESCRIPTION
Spotted on yesterday's daily: our base image is broken due to this change:
https://github.com/nodejs/docker-node/pull/639

This does not inspire a tremendous amount of confidence in this base image.

@fortuna FYI