### PR TITLE
Set default metrics url

### DIFF
--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -31,12 +31,11 @@ const DEFAULT_STATE_DIR = '/root/shadowbox/persisted-state';
 function main() {
   const verbose = process.env.LOG_LEVEL === 'debug';
   const publicAddress = process.env.SB_PUBLIC_IP;
-  const metricsUrl = process.env.SB_METRICS_URL;
-  if (!metricsUrl) {
-    // Default to production metrics, as some old Docker images may not have
-    // SB_METRICS_URL properly set.
+  // Default to production metrics, as some old Docker images may not have
+  // SB_METRICS_URL properly set.
+  const metricsUrl = process.env.SB_METRICS_URL || 'https://metrics-prod.uproxy.org';
+  if (!process.env.SB_METRICS_URL) {
     console.warn('process.env.SB_METRICS_URL not set, using default');
-    metricsUrl = 'https://metrics-prod.uproxy.org';
   }
 
   if (!publicAddress) {


### PR DESCRIPTION
Set default metrics url to work around docker issue discussed yesterday.

The issues we have found are:
1. Our Dockerfile sets the start command to `CMD SB_PUBLIC_IP=${SB_PUBLIC_IP:-$(curl https://ipinfo.io/ip)} SB_METRICS_URL=${SB_METRICS_URL:-https://metrics-prod.uproxy.org} sh -c 'ulimit -n 32768; node app/server/main.js'` - this makes it look like SB_METRICS_URL might be set for the `node` as well as the `ulimit` command. However docker actually runs with this command `SB_PUBLIC_IP=${SB_PUBLIC_IP:-$(curl https://ipinfo.io/ip)} SB_METRICS_URL=${SB_METRICS_URL:-https://metrics-prod.uproxy.org} ulimit -n 32768; node app/server/main.js` (`sh -c` is removed), where the default SB_METRICS_URL value doesn't apply to the `node` command
2. watchtower does not seem to be updating the default docker CMD, so even if we changed our Dockerfile we can't be certain that these changes will propagate to existing servers.  This will require a bit more research to understand how watchtower works.