### PR TITLE
bump version number, just to get about page in sync

### DIFF
--- a/src/server_manager/electron_app/config.json
+++ b/src/server_manager/electron_app/config.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.2",
   "releaseDataUrl": "https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/release/release_data.json"
 }

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-manager",
   "productName": "Outline Manager",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Create and manage access to Outline servers",
   "homepage": "https://getoutline.org/",
   "author": {


### PR DESCRIPTION
*sigh*

Turns out I need to update the version number in two places (see https://github.com/Jigsaw-Code/outline-server/pull/8).