### PR TITLE
Prepare for macOS release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,12 @@ jobs:
             electronuserland/builder:wine
             /bin/bash -c "yarn do server_manager/electron_app/package_only_windows" || travis_terminate $?
 
+    - stage: deploy
+      env:
+        - DESC=macos manager
+      os: osx
+      script: yarn do server_manager/electron_app/package_macos
+
     # Note that because we cannot currently sign Windows binaries on Travis,
     # these must be manually built and uploaded to the releases page.
     - stage: release

--- a/src/server_manager/electron_app/config.json
+++ b/src/server_manager/electron_app/config.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "releaseDataUrl": "https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/release/release_data.json"
 }

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-manager",
   "productName": "Outline Manager",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Create and manage access to Outline servers",
   "homepage": "https://getoutline.org/",
   "author": {


### PR DESCRIPTION
* Adds macOS manager to Travis daily build.
* Increases the app's version number.