### PR TITLE
Add confirmation before automatically deleting server on failed installs

### DIFF
--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -397,27 +397,25 @@ export class App {
             // it again.
             return;
           }
-          if (managedServer.isInstallCompleted()) {
-            // This server has already been successfully installed, however
-            // we may have failed to reach it - this could be due to bad wifi,
-            // firewalls, etc.  Notify the user and only delete if the user requests it.
-            this.appRoot.showModalDialog(
-                null,  // Don't display any title.
-                'We are unable to reach your Outline server at the moment.',
-                ['Delete this server', 'Try again'])
-            .then((clickedButtonIndex: number) => {
-              if (clickedButtonIndex === 0) {  // user clicked 'Delete this server'
-                this.cancelServerCreation(managedServer);
-              } else if (clickedButtonIndex === 1) {  // user clicked 'Try again'.
-                this.showManagedServer(managedServer, true);
-              }
-            });
-            return;
-          }
-          // An error occured while installing this server.
-          // Show an error and cancel the server creation (e.g. delete the droplet).
-          this.handleServerCreationFailure('Got an error while waiting on server installation', e);
-          this.cancelServerCreation(managedServer);
+          // This server has already been successfully installed, however
+          // we may have failed to reach it - this could be due to bad wifi,
+          // firewalls, etc.  Notify the user and only delete if the user requests it.
+          const errorMessage = managedServer.isInstallCompleted()
+              ? 'We are unable to connect to your Outline server at the moment.  This may be due to a firewall on your network or temporary connectivity issues with digitalocean.com.'
+              : 'There was an error creating your Outline server.  This may be due to a firewall on your network or temporary connectivity issues with digitalocean.com.';
+          this.appRoot.showModalDialog(
+              null,  // Don't display any title.
+              errorMessage,
+              ['Delete this server', 'Try again'])
+          .then((clickedButtonIndex: number) => {
+            if (clickedButtonIndex === 0) {  // user clicked 'Delete this server'
+              managedServer.getHost().delete().then(() => {
+                this.showCreateServer();
+              });
+            } else if (clickedButtonIndex === 1) {  // user clicked 'Try again'.
+              this.showManagedServer(managedServer, true);
+            }
+          });
         });
   }
 
@@ -432,10 +430,10 @@ export class App {
           this.showManagedServer(managedServer);
         })
         .catch((e) => {
-          // Don't show a dialog on the login screen.
-          if (!(e instanceof digitalocean_api.XhrError)) {
-            this.handleServerCreationFailure('Failed to create DigitalOcean server', e);
-          }
+          // Sanity check - this error is not expected to occur, as showManagedServer
+          // has it's own error handling.
+          console.error('error from showManagedServer', e);
+          return Promise.reject(e);
         });
   }
 


### PR DESCRIPTION
Add confirmation before automatically deleting server on failed installs.

In the past, if a server failed to install (either a server-side issue, or a client side network/firewall issue) we would immediately delete the droplet and show an error asking the user if they would like to submit feedback.  Now, to avoid accidentally deleting already working servers, we show a confirmation message with delete and try again options (try again may be useful if the problem is client-side):
<img width="356" alt="screen shot 2018-04-05 at 3 36 43 pm" src="https://user-images.githubusercontent.com/6494307/38388597-b225612e-38e9-11e8-9078-6405922b0835.png">
We removed the "Submit Feedback" action from this dialog, because if the user clicked submit feedback it wasn't clear what should happen after the feedback screen completes (do they still have the droplet?  what screen should they see?).  Users can already submit feedback via the settings drawer so this isn't much of a loss.

For already created servers we have updated the error message a little:
<img width="356" alt="screen shot 2018-04-05 at 3 35 33 pm" src="https://user-images.githubusercontent.com/6494307/38388658-dfe7bc7e-38e9-11e8-89a4-ea62a5d628ce.png">

This also adds Sentry logging to help us debug the different failure cases.