### PR TITLE
Retry droplet creation on DigitalOcean account not-yet-finalized error

### DIFF
--- a/src/server_manager/cloud/digitalocean_api.ts
+++ b/src/server_manager/cloud/digitalocean_api.ts
@@ -148,9 +148,12 @@ class RestApiSession implements DigitalOceanSession {
             })
             .then(fulfill)
             .catch((e) => {
-              const ABUSE_ERROR_TEXT = 'We\'re finalizing your account setup. Please try again in 30 seconds.';
-              if (e.message === ABUSE_ERROR_TEXT &&
-                  requestCount < MAX_REQUESTS) {
+              const ACCOUNT_NOT_YET_FINALIZED_ERROR =
+                  'We\'re finalizing your account setup. Please try again in 30 seconds.';
+              if (e.message === ACCOUNT_NOT_YET_FINALIZED_ERROR && requestCount < MAX_REQUESTS) {
+                // DigitalOcean is still validating this account and may take
+                // up to 30 seconds.  We can retry more frequently to see when
+                // this error goes away.
                 const RETRY_TIMEOUT_MS = 5000;
                 setTimeout(makeRequestRecursive, RETRY_TIMEOUT_MS);
               } else {


### PR DESCRIPTION
Retry droplet creation on DigitalOcean account not-yet-finalized error.  The logic here is that we attempt to create a droplet, and if it fails with the `ACCOUNT_NOT_YET_FINALIZED_ERROR` message, we retry again in 5 seconds, up to 10 times.  Any other error stills fails as before.

Currently this has been tested by temporarily modifying the droplet request to fail, and temporarily modifying the error string we search for, then verifying that the retry logic works as expected.  We should not merge this in until we can test for real with the new error.