### PR TITLE
use font-roboto-local

### DIFF
--- a/src/server_manager/bower.json
+++ b/src/server_manager/bower.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#^2.0.4",
+    "font-roboto": "PolymerElements/font-roboto-local#^1.1.0",
     "iron-autogrow-textarea": "PolymerElements/iron-autogrow-textarea#^2.1.1",
     "iron-icons": "PolymerElements/iron-icons#^2.0.1",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^2.1.0",

--- a/src/server_manager/electron_app/digital_ocean_modifications.ts
+++ b/src/server_manager/electron_app/digital_ocean_modifications.ts
@@ -333,8 +333,9 @@ function addDigitalOceanSignupBanner(text?: string) {
   // we should not rely on any frameworks like Polymer, as they might conflict with
   // existing frameworks on those pages.
   // All class names should begin with Outline to ensure no collisions.
+  // The outline:// protocol should be marked secure to avoid mixed content warnings.
   bannerDiv.innerHTML = `
-      <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+      <link href="outline://web_app/bower_components/font-roboto/roboto.html" rel="stylesheet">
       <style>
         #outlineBanner {
           font-family: "Roboto", sans-serif;

--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -30,7 +30,8 @@ const debugMode = process.env.OUTLINE_DEBUG === 'true';
 // prevent window being garbage collected
 let mainWindow: Electron.BrowserWindow;
 
-electron.protocol.registerStandardSchemes(['outline']);
+// Mark secure to avoid mixed content warnings when loading DigitalOcean pages via https://.
+electron.protocol.registerStandardSchemes(['outline'], {secure: true});
 
 app.on('ready', () => {
   const menuTemplate = menu.getMenuTemplate(debugMode);


### PR DESCRIPTION
Addresses:
https://github.com/Jigsaw-Code/outline-server/issues/67#issuecomment-381012609

From eyeballing it on my macOS laptop, the app looks identical before and after this change.