### PR TITLE
Automate Docker error handling in install script

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -94,12 +94,14 @@ function log_for_sentry() {
 # Check to see if docker is installed.
 function verify_docker_installed() {
   if ! command_exists docker; then
-    log_error "Docker not installed."
+    log_error "FAILED"
     echo -n "> Would you like to install Docker? [Y/n] "
     if ! run_step_with_user_confirmation "Installing Docker" install_docker; then
       log_error "Docker installation failed, please visit https://docs.docker.com/install for instructions."
       exit 1
     fi
+    echo -n "> Verifying Docker installation................ "
+    command_exists docker
   fi
 }
 


### PR DESCRIPTION
* Prompts the user to recover from known Docker errors, namely (1) Docker not installed, (2) user not having permissions to run Docker, and (3) Docker containers already running.
* Tested in Amazon EC2 (Ubuntu 16.04 LTS), GCE (g1-small), Vultr (Ubuntu 16.04), and Linode ()
* Sample execution with automated Docker error handling:

> $ ./install_server.sh 
> Verifying that Docker is installed .......... FAILED
> Would you like to install Docker? [Y/n] 
> Installing Docker ........................... OK
> Docker installed............................. OK
> Verifying Docker permissions ................ FAILED
> It seems like you may not have permission to run Docker. To solve this, we will attempt to add your user to the docker group. Would you like to proceed? [Y/n] 
> Adding ubuntu to docker group ............... OK
> Docker ready................................. OK
> Verifying that Docker daemon is running ..... OK
> Creating persistent state dir ............... OK
> Generating secret key ....................... OK
> Generating TLS certificate .................. OK
> Generating SHA-256 certificate fingerprint .. OK
> Starting Shadowbox .......................... FAILED
> The container name "shadowbox" is already in use by another container. This may happen when running this script multiple times. We will attempt to remove the existing container and and restart it. Would you like to proceed? [Y/n]
> Removing shadowbox container ................ OK
> Restarting shadowbox ........................ OK
> Starting Watchtower ......................... FAILED
> The container name "watchtower" is already in use by another container. This may happen when running this script multiple times. We will attempt to remove the existing container and and restart it. Would you like to proceed? [Y/n]
> Removing watchtower container ............... OK
> Restarting watchtower ........................ OK
> Waiting for Outline server to be healthy .... OK
> Creating first user ......................... OK
> Adding API URL to config .................... OK
> Checking host firewall ...................... OK
> CONGRATULATIONS! Your Outline server is up and running.


