### PR TITLE
fix digitalocean installer

### DIFF
--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-manager",
   "productName": "Outline Manager",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Create and manage access to Outline servers",
   "homepage": "https://getoutline.org/",
   "author": {


### PR DESCRIPTION
https://github.com/Jigsaw-Code/outline-server/pull/109 broke the DigitalOcean installer; it turns out the CloudInit environment has no concept of users and groups:
* no `$USER` environment variable
* no `docker` group

My solution is to use `$UID` to test whether we're running as `root` and, if so, to run Docker commands without the help of `sg`. The latter part was surprisingly difficult: I spent several hours unsuccessfully trying to extend `safe_docker` to "do nothing" when called by root. The problem is **escaping parameters with spaces**; to avoid this headache (BTW, escaping is subtly different in the shell used by the CloudInit environment), I introduced a `DOCKER_CMD` which is set to plain old `docker` for root and `safe_docker` for all other users  - even then, you'll see I had to switch `safe_docker` from `$@` to `$*`).