### PR TITLE
less extreme message for auto-update migration

### DIFF
--- a/release/release_data.json
+++ b/release/release_data.json
@@ -1,24 +1,24 @@
 {
   "__COMMENTS__": [
-    "There is no version 100; this file exists now only to prompt users of versions 1.0.5 and ",
+    "This file exists now only to prompt users of versions 1.0.5 and ",
     "earlier to update to the latest, auto-updates-by-electron-builder, version."
   ],
   "latestVersions": {
     "outline-manager-darwin-x64": {
       "location": "https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/Outline-Manager.dmg",
-      "version": "100.0.0"
+      "version": "1.1.0"
     },
     "outline-manager-linux-ia32": {
       "location": "https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/Outline-Manager.AppImage",
-      "version": "100.0.0"
+      "version": "1.1.0"
     },
     "outline-manager-linux-x64": {
       "location": "https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/Outline-Manager.AppImage",
-      "version": "100.0.0"
+      "version": "1.1.0"
     },
     "outline-manager-win32-ia32": {
       "location": "https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/Outline-Manager.exe",
-      "version": "100.0.0"
+      "version": "1.1.0"
     }
   }
 }


### PR DESCRIPTION
Turns out the old auto-update system shows the new version number. 100 looks weird and may be alarming to some users. Instead, use 1.1.0 (which will surely come soon for real anyway).

@alalamav Merging TBR