### PR TITLE
Collapse advanced install output into a single line

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -442,13 +442,10 @@ install_shadowbox() {
 
 CONGRATULATIONS! Your Outline server is up and running.
 
-To manage your Outline server, please copy the following text (including curly
+To manage your Outline server, please copy the following line (including curly
 brackets) into Step 2 of the Outline Manager interface:
 
-{
-  "apiUrl": "$(get_field_value apiUrl)",
-  "certSha256": "$(get_field_value certSha256)"
-}
+$(echo -e "\033[1;32m{\"apiUrl\":\"$(get_field_value apiUrl)\",\"certSha256\":\"$(get_field_value certSha256)\"}\033[0m")
 
 ${FIREWALL_STATUS}
 END_OF_SERVER_OUTPUT

--- a/src/server_manager/ui_components/outline-manual-server-entry.html
+++ b/src/server_manager/ui_components/outline-manual-server-entry.html
@@ -131,7 +131,8 @@
         errorText: String,
         placeholderText: {
           type: String,
-          value: '{\n  "apiUrl": "https://xxxxxxxxxxxxxxxxx...”,\n  "certSha256": “xxxxxxxxxxxxxxxxxxxxxx...”\n}'
+          value: '{"apiUrl":"https://xxx.xxx.xxx.xxx:xxxxx/xxxxxxxxxxxxxxxxxxxxxx","certSha256":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
+
         },
         showConnection: Boolean
       },


### PR DESCRIPTION
* Prints the advanced install script output as a single green line to make it easier to copy.
* Updates the advanced mode input placeholder.