### PR TITLE
Re-enable password-based SSH access on DigitalOcean

### DIFF
--- a/src/server_manager/install_scripts/do_install_server.sh
+++ b/src/server_manager/install_scripts/do_install_server.sh
@@ -26,6 +26,10 @@
 
 set -euxo pipefail
 
+# Re-enable password login, since DigitalOcean disables it when we create a server
+# with a SSH key.
+sed -i 's/PasswordAuthentication no/# PasswordAuthentication no  # Commented out by the Outline installer/' /etc/ssh/sshd_config
+
 export SHADOWBOX_DIR="${SHADOWBOX_DIR:-${HOME:-/root}/shadowbox}"
 mkdir -p $SHADOWBOX_DIR
 


### PR DESCRIPTION
We create Droplets with the SSH key option so the admin doesn't get the confusing email with the root password. However, that unintentionally also disables the possibility of access the server via SSH. This effectively locks admins out of their machines, who only have the option to destroy the server if things go wrong.

With this change, you will be able to use the "Reset root password" feature on the droplet dashboard at any time, and access the server for maintenance. This is not really a user-facing feature: it's mostly a escape hatch in case things go wrong with the server and need to be fixed with manual intervention.

This is how the bottom of `/etc/ssh/sshd_config` looks before the change:
```
# Added by DigitalOcean build process
ClientAliveInterval 120
ClientAliveCountMax 2

PasswordAuthentication no
```

This is is with the change:
```
# Added by DigitalOcean build process
ClientAliveInterval 120
ClientAliveCountMax 2

# PasswordAuthentication no  # Commented out by the Outline installer
```