### PR TITLE
Bump version number to v1.1.1

### DIFF
--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-manager",
   "productName": "Outline Manager",
-  "version": "1.0.7",
+  "version": "1.1.1",
   "description": "Create and manage access to Outline servers",
   "homepage": "https://getoutline.org/",
   "author": {


### PR DESCRIPTION
* Updates to 1.1.1 for consistency with the deprecated update mechanism.