### PR TITLE
Switch invite link from index.html to invite.html

### DIFF
--- a/src/server_manager/ui_components/outline-server-view.html
+++ b/src/server_manager/ui_components/outline-server-view.html
@@ -553,7 +553,7 @@
       getS3InviteUrl: function(accessUrl) {
         // If updating this URL, must also update it in outline-share-dialog.html.
         // TODO: deduplicate and move this to the TypeScript app code.
-        return 'https://s3.amazonaws.com/outline-vpn/invite.html?admin_embed#/invite/' +
+        return 'https://s3.amazonaws.com/outline-vpn/invite.html?admin_embed#' +
             encodeURIComponent(accessUrl);
       },
       // initHelpBubbles should be called after this outline-server-view

--- a/src/server_manager/ui_components/outline-server-view.html
+++ b/src/server_manager/ui_components/outline-server-view.html
@@ -553,7 +553,7 @@
       getS3InviteUrl: function(accessUrl) {
         // If updating this URL, must also update it in outline-share-dialog.html.
         // TODO: deduplicate and move this to the TypeScript app code.
-        return 'https://s3.amazonaws.com/outline-vpn/index.html?admin_embed#/invite/' +
+        return 'https://s3.amazonaws.com/outline-vpn/invite.html?admin_embed#/invite/' +
             encodeURIComponent(accessUrl);
       },
       // initHelpBubbles should be called after this outline-server-view

--- a/src/server_manager/ui_components/outline-share-dialog.html
+++ b/src/server_manager/ui_components/outline-share-dialog.html
@@ -133,7 +133,7 @@
       open: function(accessUrl) {
         this.accessUrl = accessUrl;
         // If updating this URL, must also update it in outline-server-view.html. TODO: deduplicate
-        this.s3Url = 'https://s3.amazonaws.com/outline-vpn/index.html#/invite/' +
+        this.s3Url = 'https://s3.amazonaws.com/outline-vpn/invite.html#/invite/' +
             encodeURIComponent(accessUrl);
         this.$.copyText.setAttribute('hidden', true);
         this.$.dialog.open();

--- a/src/server_manager/ui_components/outline-share-dialog.html
+++ b/src/server_manager/ui_components/outline-share-dialog.html
@@ -133,7 +133,7 @@
       open: function(accessUrl) {
         this.accessUrl = accessUrl;
         // If updating this URL, must also update it in outline-server-view.html. TODO: deduplicate
-        this.s3Url = 'https://s3.amazonaws.com/outline-vpn/invite.html#/invite/' +
+        this.s3Url = 'https://s3.amazonaws.com/outline-vpn/invite.html#' +
             encodeURIComponent(accessUrl);
         this.$.copyText.setAttribute('hidden', true);
         this.$.dialog.open();


### PR DESCRIPTION
This is useful because it allows the Android client to distinguish invite URLs from non-invite URLs.

Blocked by https://github.com/Jigsaw-Code/outline-website/pull/86.
See also https://github.com/Jigsaw-Code/outline-client/pull/147.