### PR TITLE
remove the unused geo ip lookups

### DIFF
--- a/src/shadowbox/infrastructure/ip_location.spec.ts
+++ b/src/shadowbox/infrastructure/ip_location.spec.ts
@@ -15,25 +15,28 @@
 import * as ip_location from './ip_location';
 
 function testIpLocationService(name: string, service: ip_location.IpLocationService) {
-  describe(
-      name, () => {
-        it('returns ZZ on unknown country', (done) => {
-            service.countryForIp('127.0.0.1').then((countryCode) => {
-                expect(countryCode).toEqual('ZZ');
-                done();
-            }).catch((e) => {
-                done.fail(e);
-            });
-        });
-        it('returns AU for 1.0.0.1', (done) => {
-            service.countryForIp('1.0.0.1').then((countryCode) => {
-                expect(countryCode).toEqual('AU');
-                done();
-            }).catch((e) => {
-                done.fail(e);
-            });
-        });
-      });
+  describe(name, () => {
+    it('returns ZZ on unknown country', (done) => {
+      service.countryForIp('127.0.0.1')
+          .then((countryCode) => {
+            expect(countryCode).toEqual('ZZ');
+            done();
+          })
+          .catch((e) => {
+            done.fail(e);
+          });
+    });
+    it('returns AU for 1.0.0.1', (done) => {
+      service.countryForIp('1.0.0.1')
+          .then((countryCode) => {
+            expect(countryCode).toEqual('AU');
+            done();
+          })
+          .catch((e) => {
+            done.fail(e);
+          });
+    });
+  });
 }
 
 const testDbPath = 'third_party/maxmind/GeoLite2-Country_20180327/GeoLite2-Country.mmdb';

--- a/src/shadowbox/infrastructure/ip_location.spec.ts
+++ b/src/shadowbox/infrastructure/ip_location.spec.ts
@@ -39,5 +39,7 @@ function testIpLocationService(name: string, service: ip_location.IpLocationServ
   });
 }
 
-const testDbPath = 'third_party/maxmind/GeoLite2-Country_20180327/GeoLite2-Country.mmdb';
-testIpLocationService('MmdbLocationService', new ip_location.MmdbLocationService(testDbPath));
+testIpLocationService(
+    'MmdbLocationService',
+    new ip_location.MmdbLocationService(
+        'third_party/maxmind/GeoLite2-Country_20180327/GeoLite2-Country.mmdb'));

--- a/src/shadowbox/infrastructure/ip_location.spec.ts
+++ b/src/shadowbox/infrastructure/ip_location.spec.ts
@@ -36,6 +36,5 @@ function testIpLocationService(name: string, service: ip_location.IpLocationServ
       });
 }
 
-testIpLocationService('IpInfoIpLocationService', new ip_location.IpInfoIpLocationService());
 const testDbPath = 'third_party/maxmind/GeoLite2-Country_20180327/GeoLite2-Country.mmdb';
 testIpLocationService('MmdbLocationService', new ip_location.MmdbLocationService(testDbPath));

--- a/src/shadowbox/infrastructure/ip_location.ts
+++ b/src/shadowbox/infrastructure/ip_location.ts
@@ -80,22 +80,3 @@ export class MmdbLocationService implements IpLocationService {
     });
   }
 }
-
-// An IpLocationService that caches the responses of another IpLocationService.
-export class CachedIpLocationService implements IpLocationService {
-  // TODO: Make this cache bounded in size. Possibly use lru-cache.
-  private countryCache: Map<string, Promise<string>>;
-
-  constructor(private locationService: IpLocationService) {
-    this.countryCache = new Map<string, Promise<string>>();
-  }
-
-  countryForIp(ipAddress: string): Promise<string> {
-    if (this.countryCache.has(ipAddress)) {
-      return this.countryCache.get(ipAddress);
-    }
-    const promise = this.locationService.countryForIp(ipAddress);
-    this.countryCache.set(ipAddress, promise);
-    return promise;
-  }
-}

--- a/src/shadowbox/infrastructure/ip_location.ts
+++ b/src/shadowbox/infrastructure/ip_location.ts
@@ -12,38 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as https from 'https';
 import * as maxmind from 'maxmind';
 
 export interface IpLocationService {
   // Returns the 2-digit country code for the IP address.
   countryForIp(ipAddress: string): Promise<string>;
-}
-
-// An IpLocationService that uses the ipinfo.io service.
-// See https://ipinfo.io/developers for API.
-export class IpInfoIpLocationService implements IpLocationService {
-  countryForIp(ipAddress: string): Promise<string> {
-    const countryPromise = new Promise<string>((fulfill, reject) => {
-      const url = `https://ipinfo.io/${encodeURIComponent(ipAddress)}/country`;
-      https.get(url, (response) => {
-        if (500 <= response.statusCode && response.statusCode <= 599) {
-          reject(new Error(`Got server error ${response.statusCode} from ipinfo.io`));
-          response.resume();
-          return;
-        }
-        let body = '';
-        response.on('data', (data) => { body += data; });
-        response.on('end', () => {
-          // ZZ is user-assigned and used by CLDR for "Uknown" regions.
-          fulfill(body.trim() || 'ZZ');
-        });
-      }).on('error', (e) => {
-        reject(new Error(`Failed to contact ipinfo.io: ${e}`));
-      });
-    });
-    return countryPromise;
-  }
 }
 
 // An IpLocationService that uses the node-maxmind package.

--- a/src/shadowbox/infrastructure/ip_location.ts
+++ b/src/shadowbox/infrastructure/ip_location.ts
@@ -23,12 +23,9 @@ export interface IpLocationService {
 // The database is downloaded by scripts/update_mmdb.sh.
 // The Dockerfile runs this script on boot and configures the system to run it weekly.
 export class MmdbLocationService implements IpLocationService {
-  private db: Promise<maxmind.Reader>;
+  private readonly db: Promise<maxmind.Reader>;
 
-  constructor(filename?: string) {
-    if (!filename) {
-      filename = '/var/lib/libmaxminddb/GeoLite2-Country.mmdb';
-    }
+  constructor(filename = '/var/lib/libmaxminddb/GeoLite2-Country.mmdb') {
     this.db = new Promise<maxmind.Reader>((fulfill, reject) => {
       // TODO: Change type to maxmind.Options once the type definition is updated
       // with these fields.
@@ -43,7 +40,7 @@ export class MmdbLocationService implements IpLocationService {
     });
   }
 
-  countryForIp(ipAddress: string): Promise<string> {
+  countryForIp(ipAddress) {
     return this.db.then((lookup) => {
       if (!maxmind.validate(ipAddress)) {
         throw new Error('Invalid IP address');


### PR DESCRIPTION
I'm seeing the ipinfo.io-based test fail from time to time; since it's not used anywhere - or the caching lookup - let's remove. Also a couple of tiny TypeScript things since this code is fresh in my mind.