### PR TITLE
fix the "show me where" links

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -27,7 +27,8 @@ const shell = electron.shell;
 
 const debugMode = process.env.OUTLINE_DEBUG === 'true';
 
-const IMAGES_URL = `file://${path.join(__dirname, 'server_manager', 'web_app')}`;
+const IMAGES_BASENAME =
+    `${path.join(__dirname.replace('app.asar', 'app.asar.unpacked'), 'server_manager', 'web_app')}`;
 
 interface IpcEvent {
   returnValue: {};
@@ -186,12 +187,10 @@ function main() {
   });
 
   ipcMain.on('open-image', (event: IpcEvent, args: string[]) => {
-    if (!args || args.length === 0) {
-      console.error('open-image event received no image path.');
-      return;
+    const p = path.join(IMAGES_BASENAME, args[0]);
+    if (!shell.openItem(p)) {
+      console.error(`could not open image at ${p}`);
     }
-    const imagePath = args[0];
-    shell.openExternal(path.join(IMAGES_URL, imagePath));
   });
 
   app.on('activate', () => {

--- a/src/server_manager/electron_app/package_linux_action.sh
+++ b/src/server_manager/electron_app/package_linux_action.sh
@@ -20,6 +20,7 @@ yarn do server_manager/electron_app/build
 # https://github.com/electron-userland/electron-builder/issues/2498
 $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
   --projectDir=build/server_manager/electron_app/static \
+  --config.asarUnpack=server_manager/web_app/images \
   --publish=never \
   --config.publish.provider=generic \
   --config.publish.url=https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/ \
@@ -32,6 +33,7 @@ $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
 for arch in ia32 x64; do
   $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
     --projectDir=build/server_manager/electron_app/static \
+    --config.asarUnpack=server_manager/web_app/images \
     --publish=never \
     --$arch \
     --linux deb rpm tar.gz \

--- a/src/server_manager/electron_app/package_macos_action.sh
+++ b/src/server_manager/electron_app/package_macos_action.sh
@@ -19,6 +19,7 @@ yarn do server_manager/electron_app/build
 # Produces dmg and zip images. The latter is required for auto-update.
 $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
   --projectDir=build/server_manager/electron_app/static \
+  --config.asarUnpack=server_manager/web_app/images \
   --publish=never \
   --config.publish.provider=generic \
   --config.publish.url=https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/ \

--- a/src/server_manager/electron_app/package_only_windows_action.sh
+++ b/src/server_manager/electron_app/package_only_windows_action.sh
@@ -20,6 +20,7 @@
 
 $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
   --projectDir=build/server_manager/electron_app/static \
+  --config.asarUnpack=server_manager/web_app/images \
   --publish=never \
   --config.publish.provider=generic \
   --config.publish.url=https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/ \

--- a/src/server_manager/electron_app/release_windows_action.sh
+++ b/src/server_manager/electron_app/release_windows_action.sh
@@ -18,6 +18,7 @@ yarn do server_manager/electron_app/build
 
 $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
   --projectDir=build/server_manager/electron_app/static \
+  --config.asarUnpack=server_manager/web_app/images \
   --publish=never \
   --config.publish.provider=generic \
   --config.publish.url=https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/ \


### PR DESCRIPTION
Dammit, these weren't working for two reasons:
- need to "unpack" the images (just like we do in the client for the binaries we launch)
- `showItem` is needed for Windows (and no `file://` prefix)

This time, it's been tested on macOS, Linux, and Windows with the final binaries (not just `yarn do electron/run`.