### PR TITLE
suppress network errors for data usage requests

### DIFF
--- a/src/server_manager/infrastructure/errors.ts
+++ b/src/server_manager/infrastructure/errors.ts
@@ -44,9 +44,14 @@ export class ServerInstallFailedError extends OutlineError {
 }
 
 // Thrown when a Shadowbox API request fails.
-// Response will be present if the server was contacted; if absent, a network error occurred.
 export class ServerApiError extends OutlineError {
   constructor(message: string, public readonly response?: Response) {
     super(message);
+  }
+
+  // Returns true if no response was received, i.e. a network error was encountered.
+  // Can be used to distinguish between client and server-side issues.
+  isNetworkError() {
+    return !(this.response);
   }
 }

--- a/src/server_manager/infrastructure/errors.ts
+++ b/src/server_manager/infrastructure/errors.ts
@@ -42,3 +42,11 @@ export class ServerInstallFailedError extends OutlineError {
     super(message);
   }
 }
+
+// Thrown when a Shadowbox API request fails.
+// Response will be present if the server was contacted; if absent, a network error occurred.
+export class ServerApiError extends OutlineError {
+  constructor(message: string, public readonly response?: Response) {
+    super(message);
+  }
+}

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -624,12 +624,17 @@ export class App {
               serverView.updateAccessKeyRow(accessKeyId, {transferredBytes, relativeTraffic});
             }
           },
-          (e: errors.ServerApiError) => {
-            // Since failure is invisible to users, allow non-network errors percolate to the top
-            // so that a Sentry report will be generated.
-            if (e.response) {
-              throw e;
+          (e) => {
+            // Since failures are invisible to users we generally want exceptions here to bubble
+            // up and trigger a Sentry report. The exception is network errors, about which we can't
+            // do much (note: ShadowboxServer generates a breadcrumb for failures regardless, for
+            // anyone who explicitly submits feedback).
+            if (e instanceof errors.ServerApiError) {
+              if (!e.response) {
+                return;
+              }
             }
+            throw e;
           });
     };
     refreshTransferStats();

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -627,12 +627,10 @@ export class App {
           (e) => {
             // Since failures are invisible to users we generally want exceptions here to bubble
             // up and trigger a Sentry report. The exception is network errors, about which we can't
-            // do much (note: ShadowboxServer generates a breadcrumb for failures regardless, for
-            // anyone who explicitly submits feedback).
-            if (e instanceof errors.ServerApiError) {
-              if (!e.response) {
-                return;
-              }
+            // do much (note: ShadowboxServer generates a breadcrumb for failures regardless which
+            // will show up when someone explicitly submits feedback).
+            if (e instanceof errors.ServerApiError && e.isNetworkError()) {
+              return;
             }
             throw e;
           });

--- a/src/server_manager/web_app/shadowbox_server.ts
+++ b/src/server_manager/web_app/shadowbox_server.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as errors from '../infrastructure/errors';
 import * as server from '../model/server';
 import {SentryErrorReporter} from './error_reporter';
 
@@ -177,11 +178,10 @@ export class ShadowboxServer implements server.Server {
           .then(
               (response) => {
                 if (!response.ok) {
-                  const msg = `API request to ${path} failed with status ${response.status}, type ${
-                      response.type}`;
+                  const msg = `API request to ${path} failed with status ${response.status}`;
                   console.error(msg);
                   SentryErrorReporter.logError(msg);
-                  throw new Error(msg);
+                  throw new errors.ServerApiError(msg, response);
                 }
                 console.debug(`API request to ${path} succeeded`);
                 return response.text();
@@ -190,7 +190,7 @@ export class ShadowboxServer implements server.Server {
                 const msg = `API request to ${path} failed due to network error`;
                 console.error(msg, error);
                 SentryErrorReporter.logError(msg);
-                throw error;
+                throw new errors.ServerApiError(msg);
               })
           .then((body) => {
             if (!body) {


### PR DESCRIPTION
Lots of work we could do on our error reporting...but this should reduce the noise we've been seeing in Sentry due to network errors on data usage fetches.