### PR TITLE
Rename Managed -> Server

### DIFF
--- a/src/shadowbox/infrastructure/filesystem_text_file.ts
+++ b/src/shadowbox/infrastructure/filesystem_text_file.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as fs from 'fs';
-import { TextFile } from '../model/text_file';
+import {TextFile} from '../model/text_file';
 
 // Reads a text file if it exists, or null if the file is not found.
 // Throws any other error except file not found.

--- a/src/shadowbox/infrastructure/follow_redirects.ts
+++ b/src/shadowbox/infrastructure/follow_redirects.ts
@@ -16,7 +16,7 @@ import * as request from 'request-lite';
 
 interface Response {
   statusCode: number;
-  headers: { location?: string };
+  headers: {location?: string};
 }
 
 interface Options {
@@ -40,8 +40,7 @@ export function requestFollowRedirectsWithSameMethodAndBody(
   modifiedOptions.followAllRedirects = false;
   modifiedOptions.followRedirect = false;
   request(modifiedOptions, (error, response, body) => {
-    if (!error &&
-        response.statusCode >= 300 && response.statusCode < 400 &&
+    if (!error && response.statusCode >= 300 && response.statusCode < 400 &&
         response.headers.location) {
       // Request has been redirected, try again at the new location.
       modifiedOptions.url = response.headers.location;

--- a/src/shadowbox/infrastructure/get_port.ts
+++ b/src/shadowbox/infrastructure/get_port.ts
@@ -27,7 +27,7 @@ export function getRandomUnusedPort(
   return isPortUsed(port).then((isUsed) => {
     if (!isUsed && !reservedPorts.has(port)) {
       return Promise.resolve(port);
-    } else if (maxRetries ===  0) {
+    } else if (maxRetries === 0) {
       return Promise.reject(new Error('Could not find available port'));
     }
     return getRandomUnusedPort(reservedPorts, generatePort, isPortUsed, maxRetries - 1);

--- a/src/shadowbox/infrastructure/logging.ts
+++ b/src/shadowbox/infrastructure/logging.ts
@@ -41,9 +41,11 @@ type LevelPrefix = 'E'|'W'|'I'|'D';
 // I2018-08-16T16:46:21.577Z 167288 main.js:86] ...
 function makeLogMessage(level: LevelPrefix, callsite: Callsite, message: string): string {
   // This creates a string in the UTC timezone
-  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+  // See
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
   const timeStr = new Date().toISOString();
-  return `${level}${timeStr} ${process.pid} ${path.basename(callsite.getFileName())}:${callsite.getLineNumber()}] ${message}`;
+  return `${level}${timeStr} ${process.pid} ${path.basename(callsite.getFileName())}:${
+      callsite.getLineNumber()}] ${message}`;
 }
 
 export function error(message: string) {

--- a/src/shadowbox/model/metrics.ts
+++ b/src/shadowbox/model/metrics.ts
@@ -14,7 +14,9 @@
 
 import {AccessKeyId} from './access_key';
 
-export type LastHourMetricsReadyCallback = (startDatetime: Date, endDatetime: Date, lastHourUserStats: Map<AccessKeyId, PerUserStats>) => void;
+export type LastHourMetricsReadyCallback =
+    (startDatetime: Date, endDatetime: Date, lastHourUserStats: Map<AccessKeyId, PerUserStats>) =>
+        void;
 
 // TODO: replace "user" with "access key" in metrics.  This may also require changing
 // - the metrics server
@@ -27,7 +29,8 @@ export interface Stats {
   // clients - we do not know the breakdown of how many bytes were transferred
   // per IP address, due to limitations of the ss-server.  ipAddresses are only
   // used for recording which countries clients are connecting from.
-  recordBytesTransferred(userId: AccessKeyId, metricsUserId: AccessKeyId, numBytes: number, ipAddresses: string[]);
+  recordBytesTransferred(
+      userId: AccessKeyId, metricsUserId: AccessKeyId, numBytes: number, ipAddresses: string[]);
   // Get 30 day data usage, broken down by userId.
   get30DayByteTransfer(): DataUsageByUser;
   // Register callback for hourly metrics report.

--- a/src/shadowbox/server/libev_shadowsocks_server.ts
+++ b/src/shadowbox/server/libev_shadowsocks_server.ts
@@ -16,8 +16,7 @@ import * as child_process from 'child_process';
 import * as dgram from 'dgram';
 import * as dns from 'dns';
 import * as events from 'events';
-
-import {SIP002_URI, makeConfig} from 'ShadowsocksConfig/shadowsocks_config';
+import {makeConfig, SIP002_URI} from 'ShadowsocksConfig/shadowsocks_config';
 
 import * as logging from '../infrastructure/logging';
 import {ShadowsocksInstance, ShadowsocksServer} from '../model/shadowsocks_server';
@@ -87,9 +86,9 @@ class LibevShadowsocksServerInstance implements ShadowsocksInstance {
   private INBOUND_BYTES_EVENT = 'inboundBytes';
 
   constructor(
-      private childProcess: child_process.ChildProcess,
-      public portNumber: number, public password, public encryptionMethod: string,
-      public accessUrl: string, private statsSocket: dgram.Socket) {}
+      private childProcess: child_process.ChildProcess, public portNumber: number, public password,
+      public encryptionMethod: string, public accessUrl: string,
+      private statsSocket: dgram.Socket) {}
 
   public stop() {
     logging.info(`Stopping server on port ${this.portNumber}`);
@@ -140,14 +139,14 @@ class LibevShadowsocksServerInstance implements ShadowsocksInstance {
     });
   }
 
-  private getConnectedClientIPAddresses() :Promise<string[]> {
+  private getConnectedClientIPAddresses(): Promise<string[]> {
     const lsofCommand = `lsof -i tcp:${this.portNumber} -n -P -Fn ` +
-      " | grep '\\->'" +        // only look at connection lines (e.g. skips "p8855" and "f60")
-      " | sed 's/:\\d*$//g'" +  // remove p
-      " | sed 's/n\\S*->//g'" + // remove first part of address
-      " | sed 's/\\[//g'" +     // remove [] (used by ipv6)
-      " | sed 's/\\]//g'" +     // remove ] (used by ipv6)
-      " | sort | uniq";         // remove duplicates
+        ' | grep \'\\->\'' +         // only look at connection lines (e.g. skips "p8855" and "f60")
+        ' | sed \'s/:\\d*$//g\'' +   // remove p
+        ' | sed \'s/n\\S*->//g\'' +  // remove first part of address
+        ' | sed \'s/\\[//g\'' +      // remove [] (used by ipv6)
+        ' | sed \'s/\\]//g\'' +      // remove ] (used by ipv6)
+        ' | sort | uniq';            // remove duplicates
     return this.execCmd(lsofCommand).then((output: string) => {
       return output.split('\n');
     });

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -22,9 +22,9 @@ import * as ip_location from '../infrastructure/ip_location';
 import * as logging from '../infrastructure/logging';
 
 import {LibevShadowsocksServer} from './libev_shadowsocks_server';
-import {createManagedAccessKeyRepository} from './managed_access_key';
 import {bindService, ShadowsocksManagerService} from './manager_service';
 import * as metrics from './metrics';
+import {createServerAccessKeyRepository} from './server_access_key';
 import * as server_config from './server_config';
 
 const DEFAULT_STATE_DIR = '/root/shadowbox/persisted-state';
@@ -81,7 +81,7 @@ function main() {
 
   logging.info('Starting...');
   const userConfigFilename = getPersistentFilename('shadowbox_config.json');
-  createManagedAccessKeyRepository(
+  createServerAccessKeyRepository(
       proxyHostname, new FilesystemTextFile(userConfigFilename), shadowsocksServer, stats)
       .then((managedAccessKeyRepository) => {
         const managerService = new ShadowsocksManagerService(

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -83,9 +83,9 @@ function main() {
   const userConfigFilename = getPersistentFilename('shadowbox_config.json');
   createServerAccessKeyRepository(
       proxyHostname, new FilesystemTextFile(userConfigFilename), shadowsocksServer, stats)
-      .then((managedAccessKeyRepository) => {
+      .then((accessKeyRepository) => {
         const managerService =
-            new ShadowsocksManagerService(serverConfig, managedAccessKeyRepository, stats);
+            new ShadowsocksManagerService(serverConfig, accessKeyRepository, stats);
         const certificateFilename = process.env.SB_CERTIFICATE_FILE;
         const privateKeyFilename = process.env.SB_PRIVATE_KEY_FILE;
 

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -84,12 +84,13 @@ function main() {
   createServerAccessKeyRepository(
       proxyHostname, new FilesystemTextFile(userConfigFilename), shadowsocksServer, stats)
       .then((managedAccessKeyRepository) => {
-        const managerService = new ShadowsocksManagerService(
-            serverConfig, managedAccessKeyRepository, stats);
+        const managerService =
+            new ShadowsocksManagerService(serverConfig, managedAccessKeyRepository, stats);
         const certificateFilename = process.env.SB_CERTIFICATE_FILE;
         const privateKeyFilename = process.env.SB_PRIVATE_KEY_FILE;
 
-        // TODO(bemasc): Remove casts once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15229 lands
+        // TODO(bemasc): Remove casts once
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15229 lands
         const apiServer = restify.createServer({
           certificate: fs.readFileSync(certificateFilename),
           key: fs.readFileSync(privateKeyFilename)

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -69,22 +69,25 @@ describe('ShadowsocksManagerService', () => {
     const service = new ShadowsocksManagerService(null, repo, null);
 
     // Create 2 access keys with names.
-    Promise.all([
-      createNewAccessKeyWithName(repo, 'keyName1'),
-      createNewAccessKeyWithName(repo, 'keyName2')
-    ]).then((keys) => {
-      // Verify that response returns keys in correct order with correct names.
-      const res = {send: (httpCode, data) => {
-        expect(httpCode).toEqual(200);
-        expect(data.accessKeys.length).toEqual(2);
-        expect(data.accessKeys[0].name).toEqual(keys[0].name);
-        expect(data.accessKeys[0].id).toEqual(keys[0].id);
-        expect(data.accessKeys[1].name).toEqual(keys[1].name);
-        expect(data.accessKeys[1].id).toEqual(keys[1].id);
-        responseProcessed = true;  // required for afterEach to pass.
-      }};
-      service.listAccessKeys({params: {}}, res, done);
-    });
+    Promise
+        .all([
+          createNewAccessKeyWithName(repo, 'keyName1'), createNewAccessKeyWithName(repo, 'keyName2')
+        ])
+        .then((keys) => {
+          // Verify that response returns keys in correct order with correct names.
+          const res = {
+            send: (httpCode, data) => {
+              expect(httpCode).toEqual(200);
+              expect(data.accessKeys.length).toEqual(2);
+              expect(data.accessKeys[0].name).toEqual(keys[0].name);
+              expect(data.accessKeys[0].id).toEqual(keys[0].id);
+              expect(data.accessKeys[1].name).toEqual(keys[1].name);
+              expect(data.accessKeys[1].id).toEqual(keys[1].id);
+              responseProcessed = true;  // required for afterEach to pass.
+            }
+          };
+          service.listAccessKeys({params: {}}, res, done);
+        });
   });
 
   it('creates keys', (done) => {
@@ -92,12 +95,14 @@ describe('ShadowsocksManagerService', () => {
     const service = new ShadowsocksManagerService(null, repo, null);
 
     // Verify that response returns a key with the expected properties.
-    const res = {send: (httpCode, data) => {
-      expect(httpCode).toEqual(201);
-      const expectedProperties = ['id', 'name', 'password', 'port', 'method', 'accessUrl'];
-      expect(Object.keys(data).sort()).toEqual(expectedProperties.sort());
-      responseProcessed = true;  // required for afterEach to pass.
-    }};
+    const res = {
+      send: (httpCode, data) => {
+        expect(httpCode).toEqual(201);
+        const expectedProperties = ['id', 'name', 'password', 'port', 'method', 'accessUrl'];
+        expect(Object.keys(data).sort()).toEqual(expectedProperties.sort());
+        responseProcessed = true;  // required for afterEach to pass.
+      }
+    };
     service.createNewAccessKey({params: {}}, res, done);
   });
 
@@ -106,19 +111,22 @@ describe('ShadowsocksManagerService', () => {
     const service = new ShadowsocksManagerService(null, repo, null);
 
     // Create 2 access keys with names.
-    Promise.all([
-      createNewAccessKeyWithName(repo, 'keyName1'),
-      createNewAccessKeyWithName(repo, 'keyName2')
-    ]).then((keys) => {
-      const res = {send: (httpCode, data) => {
-        expect(httpCode).toEqual(204);
-        // expect that the only remaining key is the 2nd key we created.
-        expect(getFirstAccessKey(repo).id === keys[1].id);
-        responseProcessed = true;  // required for afterEach to pass.
-      }};
-      // remove the 1st key.
-      service.removeAccessKey({params: {id: keys[0].id}}, res, done);
-    });
+    Promise
+        .all([
+          createNewAccessKeyWithName(repo, 'keyName1'), createNewAccessKeyWithName(repo, 'keyName2')
+        ])
+        .then((keys) => {
+          const res = {
+            send: (httpCode, data) => {
+              expect(httpCode).toEqual(204);
+              // expect that the only remaining key is the 2nd key we created.
+              expect(getFirstAccessKey(repo).id === keys[1].id);
+              responseProcessed = true;  // required for afterEach to pass.
+            }
+          };
+          // remove the 1st key.
+          service.removeAccessKey({params: {id: keys[0].id}}, res, done);
+        });
   });
 
   it('renames keys', (done) => {
@@ -129,11 +137,13 @@ describe('ShadowsocksManagerService', () => {
 
     createNewAccessKeyWithName(repo, OLD_NAME).then((key) => {
       expect(getFirstAccessKey(repo).name === OLD_NAME);
-      const res = {send: (httpCode, data) => {
-        expect(httpCode).toEqual(204);
-        expect(getFirstAccessKey(repo).name === NEW_NAME);
-        responseProcessed = true;  // required for afterEach to pass.
-      }};
+      const res = {
+        send: (httpCode, data) => {
+          expect(httpCode).toEqual(204);
+          expect(getFirstAccessKey(repo).name === NEW_NAME);
+          responseProcessed = true;  // required for afterEach to pass.
+        }
+      };
       service.renameAccessKey({params: {id: key.id, name: NEW_NAME}}, res, done);
     });
   });
@@ -187,8 +197,7 @@ function getFirstAccessKey(repo: AccessKeyRepository) {
   return repo.listAccessKeys().next().value;
 }
 
-function createNewAccessKeyWithName(
-    repo: AccessKeyRepository, name: string): Promise<AccessKey> {
+function createNewAccessKeyWithName(repo: AccessKeyRepository, name: string): Promise<AccessKey> {
   return repo.createNewAccessKey().then((key) => {
     key.name = name;
     return key;

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -16,7 +16,7 @@ import * as restify from 'restify';
 import {makeConfig, SIP002_URI} from 'ShadowsocksConfig/shadowsocks_config';
 
 import * as logging from '../infrastructure/logging';
-import { AccessKey, AccessKeyRepository } from '../model/access_key';
+import {AccessKey, AccessKeyRepository} from '../model/access_key';
 import * as metrics_model from '../model/metrics';
 import * as metrics from './metrics';
 import * as server_config from './server_config';

--- a/src/shadowbox/server/metrics.spec.ts
+++ b/src/shadowbox/server/metrics.spec.ts
@@ -67,8 +67,7 @@ describe('getHourlyServerMetricsReport', () => {
   });
   it('Does not include duplicate countries', (done) => {
     const lastHourUserStats = new Map();
-    lastHourUserStats.set(USER_ID_1,
-        getPerUserStats([IP_ADDRESS_IN_US_1, IP_ADDRESS_IN_US_2]));
+    lastHourUserStats.set(USER_ID_1, getPerUserStats([IP_ADDRESS_IN_US_1, IP_ADDRESS_IN_US_2]));
 
     metrics
         .getHourlyServerMetricsReport(
@@ -83,8 +82,7 @@ describe('getHourlyServerMetricsReport', () => {
   });
   it('userReports matches input size for unsanctioned countries', (done) => {
     const lastHourUserStats = new Map();
-    lastHourUserStats.set(USER_ID_1,
-        getPerUserStats([IP_ADDRESS_IN_US_1]));
+    lastHourUserStats.set(USER_ID_1, getPerUserStats([IP_ADDRESS_IN_US_1]));
     lastHourUserStats.set(USER_ID_2, getPerUserStats([IP_ADDRESS_IN_US_2]));
 
     metrics
@@ -102,8 +100,8 @@ describe('getHourlyServerMetricsReport', () => {
   });
   it('Filters sanctioned countries from userReports', (done) => {
     const lastHourUserStats = new Map();
-    lastHourUserStats.set(USER_ID_1,
-        getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA, IP_ADDRESS_IN_US_1]));
+    lastHourUserStats.set(
+        USER_ID_1, getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA, IP_ADDRESS_IN_US_1]));
     lastHourUserStats.set(USER_ID_2, getPerUserStats([IP_ADDRESS_IN_US_1]));
 
     metrics
@@ -121,8 +119,8 @@ describe('getHourlyServerMetricsReport', () => {
   });
   it('Removes userReports that contain only sanctioned countries', (done) => {
     const lastHourUserStats = new Map();
-    lastHourUserStats.set(USER_ID_1,
-        getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA, IP_ADDRESS_IN_CUBA]));
+    lastHourUserStats.set(
+        USER_ID_1, getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA, IP_ADDRESS_IN_CUBA]));
     lastHourUserStats.set(USER_ID_2, getPerUserStats([IP_ADDRESS_IN_US_1]));
 
     metrics
@@ -138,10 +136,9 @@ describe('getHourlyServerMetricsReport', () => {
   });
   it('Does not generate any report if all users in sanctioned countries', (done) => {
     const lastHourUserStats = new Map();
-    lastHourUserStats.set(USER_ID_1,
-        getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA, IP_ADDRESS_IN_CUBA]));
-    lastHourUserStats.set(USER_ID_2,
-        getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA]));
+    lastHourUserStats.set(
+        USER_ID_1, getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA, IP_ADDRESS_IN_CUBA]));
+    lastHourUserStats.set(USER_ID_2, getPerUserStats([IP_ADDRESS_IN_NORTH_KOREA]));
 
     metrics
         .getHourlyServerMetricsReport(
@@ -164,7 +161,8 @@ describe('getHourlyServerMetricsReport', () => {
           expect(report.userReports[0].countries.length).toEqual(1);
           expect(report.userReports[0].countries[0]).toEqual('ERROR');
           done();
-        }).catch((e) => {
+        })
+        .catch((e) => {
           done.fail(e);
         });
   });
@@ -180,17 +178,15 @@ describe('getHourlyServerMetricsReport', () => {
           expect(report.userReports[0].countries.length).toEqual(1);
           expect(report.userReports[0].countries[0]).toEqual('ERROR');
           done();
-        }).catch((e) => {
+        })
+        .catch((e) => {
           done.fail(e);
         });
   });
 });
 
 function getPerUserStats(ipAddresses: string[]): PerUserStats {
-  return {
-    bytesTransferred: 123,
-    anonymizedIpAddresses: new Set(ipAddresses)
-  };
+  return {bytesTransferred: 123, anonymizedIpAddresses: new Set(ipAddresses)};
 }
 
 class HardcodedIpLocationService implements ip_location.IpLocationService {
@@ -211,13 +207,17 @@ class HardcodedIpLocationService implements ip_location.IpLocationService {
 class FailConnectionIpLocationService implements ip_location.IpLocationService {
   countryForIp(ipAddress: string): Promise<string> {
     const countryPromise = new Promise<string>((fulfill, reject) => {
-      https.get('https://0.0.0.0', (response) => {
-        response.on('end', () => {
-          fulfill('SHOULD_NOT_HAPPEN');
-        });
-      }).on('error', (e) => {
-        reject(new Error(`Failed to contact location service: ${e}`));
-      });
+      https
+          .get(
+              'https://0.0.0.0',
+              (response) => {
+                response.on('end', () => {
+                  fulfill('SHOULD_NOT_HAPPEN');
+                });
+              })
+          .on('error', (e) => {
+            reject(new Error(`Failed to contact location service: ${e}`));
+          });
     });
     return countryPromise;
   }

--- a/src/shadowbox/server/metrics.ts
+++ b/src/shadowbox/server/metrics.ts
@@ -16,9 +16,9 @@ import * as events from 'events';
 import * as fs from 'fs';
 import * as url from 'url';
 
-import * as ip_location from '../infrastructure/ip_location';
 import * as file_read from '../infrastructure/file_read';
 import * as follow_redirects from '../infrastructure/follow_redirects';
+import * as ip_location from '../infrastructure/ip_location';
 import * as logging from '../infrastructure/logging';
 import {AccessKeyId} from '../model/access_key';
 import {DataUsageByUser, LastHourMetricsReadyCallback, PerUserStats, Stats} from '../model/metrics';
@@ -62,7 +62,8 @@ export class PersistentStats implements Stats {
     setHourlyInterval(this.generateHourlyReport.bind(this));
   }
 
-  public recordBytesTransferred(userId: AccessKeyId, metricsUserId: AccessKeyId, numBytes: number, ipAddresses: string[]) {
+  public recordBytesTransferred(
+      userId: AccessKeyId, metricsUserId: AccessKeyId, numBytes: number, ipAddresses: string[]) {
     // Pass the userId (sequence number) to transferStats as this data is returned to the Outline
     // manager which relies on the userId sequence number.
     this.transferStats.recordBytesTransferred(userId, numBytes);
@@ -117,8 +118,7 @@ export class PersistentStats implements Stats {
     }
 
     this.eventEmitter.emit(
-        PersistentStats.LAST_HOUR_METRICS_READY_EVENT,
-        this.connectionStats.startDatetime,
+        PersistentStats.LAST_HOUR_METRICS_READY_EVENT, this.connectionStats.startDatetime,
         new Date(),  // endDatetime is the current date and time.
         this.connectionStats.lastHourUserStats);
 
@@ -260,10 +260,7 @@ class ConnectionStats {
         anonymizedIpAddresses: [...perUserStats.anonymizedIpAddresses]
       };
     });
-    return {
-      startTimestamp: this.startDatetime.getTime(),
-      lastHourUserStatsObj
-    };
+    return {startTimestamp: this.startDatetime.getTime(), lastHourUserStatsObj};
   }
 
   private deserialize(serializedObject: {}) {
@@ -312,8 +309,8 @@ export function getHourlyServerMetricsReport(
   });
 }
 
-export function postHourlyServerMetricsReports(report: HourlyServerMetricsReport,
-    metricsUrl: string) {
+export function postHourlyServerMetricsReports(
+    report: HourlyServerMetricsReport, metricsUrl: string) {
   const options = {
     url: metricsUrl,
     headers: {'Content-Type': 'application/json'},
@@ -321,20 +318,21 @@ export function postHourlyServerMetricsReports(report: HourlyServerMetricsReport
     body: JSON.stringify(report)
   };
   logging.info('Posting metrics: ' + JSON.stringify(options));
-  return follow_redirects.requestFollowRedirectsWithSameMethodAndBody(options, (error, response, body) => {
-    if (error) {
-      logging.error(`Error posting metrics: ${error}`);
-      return;
-    }
-    logging.info('Metrics server responded with status ' + response.statusCode);
-  });
+  return follow_redirects.requestFollowRedirectsWithSameMethodAndBody(
+      options, (error, response, body) => {
+        if (error) {
+          logging.error(`Error posting metrics: ${error}`);
+          return;
+        }
+        logging.info('Metrics server responded with status ' + response.statusCode);
+      });
 }
 
 function setHourlyInterval(callback: Function) {
   const msUntilNextHour = MS_PER_HOUR - (Date.now() % MS_PER_HOUR);
   setTimeout(() => {
-      setInterval(callback, MS_PER_HOUR);
-      callback();
+    setInterval(callback, MS_PER_HOUR);
+    callback();
   }, msUntilNextHour);
 }
 
@@ -394,7 +392,8 @@ function getWithoutDuplicates<T>(a: T[]): T[] {
   return [...new Set(a)];
 }
 
-function getWithoutSanctionedReports(userReports: HourlyUserMetricsReport[]): HourlyUserMetricsReport[] {
+function getWithoutSanctionedReports(userReports: HourlyUserMetricsReport[]):
+    HourlyUserMetricsReport[] {
   const sanctionedCountries = ['CU', 'IR', 'KP', 'SY'];
   const filteredReports = [];
   for (const userReport of userReports) {

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createManagedAccessKeyRepository } from './managed_access_key';
-import { MockShadowsocksServer, MockStats, InMemoryFile } from './mocks/mocks';
-import { AccessKeyRepository } from '../model/access_key';
+import {AccessKeyRepository} from '../model/access_key';
 
-describe('ManagedAccessKeyRepository', () => {
+import {InMemoryFile, MockShadowsocksServer, MockStats} from './mocks/mocks';
+import {createServerAccessKeyRepository} from './server_access_key';
+
+describe('ServerAccessKeyRepository', () => {
   it('Repos with non-existent files are created with no access keys', (done) => {
     createRepo(new InMemoryFile(false)).then((repo) => {
       expect(countAccessKeys(repo)).toEqual(0);
@@ -140,9 +141,6 @@ function countAccessKeys(repo: AccessKeyRepository) {
 }
 
 function createRepo(inMemoryFile: InMemoryFile) {
-  return createManagedAccessKeyRepository(
-      'hostname',
-      inMemoryFile,
-      new MockShadowsocksServer(),
-      new MockStats());
+  return createServerAccessKeyRepository(
+      'hostname', inMemoryFile, new MockShadowsocksServer(), new MockStats());
 }

--- a/src/shadowbox/types/node.d.ts
+++ b/src/shadowbox/types/node.d.ts
@@ -21,9 +21,7 @@ declare module 'dns' {
 
 // https://nodejs.org/dist/latest-v8.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback
 declare module 'child_process' {
-  export interface ExecError {
-    code: number;
-  }
+  export interface ExecError { code: number; }
   export function exec(
       command: string,
       callback?: (error: ExecError|undefined, stdout: string, stderr: string) =>


### PR DESCRIPTION
We already have a "Manager" service and "Managed" here doesn't mean much. Now `ServerAccessKey` means the `AccessKey` implementation used by the Server. This should avoid some confusion on the code and make it more readable.