### PR TITLE
migrate to ubuntu 18 for new droplets

### DIFF
--- a/src/server_manager/web_app/digitalocean_server.ts
+++ b/src/server_manager/web_app/digitalocean_server.ts
@@ -387,7 +387,7 @@ export class DigitaloceanServerRepository implements server.ManagedServerReposit
     const dropletSpec = {
       installCommand,
       size: MACHINE_SIZE,
-      image: 'docker',
+      image: 'docker-18-04',
       tags: [SHADOWBOX_TAG],
     };
     return onceKeyPair


### PR DESCRIPTION
This makes the installer use the new Ubuntu 18-based one-click Docker image:
https://www.digitalocean.com/docs/one-clicks/docker/

I logged into the droplet and verified that password-based login, auto-reboot for upgrades, and firewall are all configured correctly.

@sandrigo Downside is increased setup time: it's ~45-60s slower than the previous image. Looks like the image downloads several Docker images - ubuntu:xenial, etc. - before handing us control. Not sure why it does that.