### PR TITLE
Add outline-ss-server with rollout

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM golang:1-alpine as outline-ss-server
+RUN apk add --no-cache git
+RUN go get github.com/Jigsaw-Code/outline-ss-server
+
 # See versions at https://hub.docker.com/_/node/
 FROM node:8.11.3-alpine
 
@@ -38,6 +42,7 @@ RUN /etc/periodic/weekly/update_mmdb
 
 WORKDIR /root/shadowbox
 
+COPY --from=outline-ss-server /go/bin/outline-ss-server ./bin/
 COPY third_party/prometheus/prometheus ./bin/
 COPY src/shadowbox/package.json .
 COPY yarn.lock .

--- a/src/shadowbox/integration_test/client/Dockerfile
+++ b/src/shadowbox/integration_test/client/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This ensures that the client is up to date with the server.
-FROM outline/shadowbox
+FROM golang:1-alpine
+
+# curl for fetching pages using the local proxy
+RUN apk add --no-cache curl git
+RUN go get github.com/shadowsocks/go-shadowsocks2
 
 ENTRYPOINT [ "sh" ]

--- a/src/shadowbox/model/shadowsocks_server.ts
+++ b/src/shadowbox/model/shadowsocks_server.ts
@@ -19,4 +19,7 @@ export interface AccessKey {
   secret: string;
 }
 
-export interface ShadowsocksServer { update(keys: AccessKey[]): Promise<void>; }
+export interface ShadowsocksServer {
+  // Updates the server to accept only the given access keys.
+  update(keys: AccessKey[]): Promise<void>;
+}

--- a/src/shadowbox/model/shadowsocks_server.ts
+++ b/src/shadowbox/model/shadowsocks_server.ts
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export interface ShadowsocksServer {
-  startInstance(id: string, portNumber: number, password: string, encryptionMethod?: string):
-      Promise<ShadowsocksInstance>;
+export interface AccessKey {
+  id: string;
+  port: number;
+  cipher: string;
+  secret: string;
 }
 
-export interface ShadowsocksInstance {
-  portNumber: number;
-  password: string;
-  encryptionMethod: string;
-  accessUrl: string;
-  stop();
-}
+export interface ShadowsocksServer { update(keys: AccessKey[]): Promise<void>; }

--- a/src/shadowbox/scripts/install_shadowsocks.sh
+++ b/src/shadowbox/scripts/install_shadowsocks.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(fortuna): Delete once outline-ss-server rolls out
+
 VERSION=$1
 DOWNLOAD_URL=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v${VERSION}/shadowsocks-libev-${VERSION}.tar.gz
 BUILD_DIR=/src/shadowsocks-libev

--- a/src/shadowbox/server/libev_shadowsocks_server.ts
+++ b/src/shadowbox/server/libev_shadowsocks_server.ts
@@ -97,23 +97,25 @@ export class LibevShadowsocksServer implements ShadowsocksServer {
   }
 
   update(newKeys: AccessKey[]): Promise<void> {
-    const oldKeys = this.keys;
-    this.keys = new Map<string, AccessKey>();
-    for (const key of newKeys) {
-      this.keys[key.id] = key;
-      const oldKey = oldKeys.get(key.id);
-      if (oldKey) {
-        continue;
+    return new Promise((resolve, reject) => {
+      const oldKeys = this.keys;
+      this.keys = new Map<string, AccessKey>();
+      for (const key of newKeys) {
+        this.keys[key.id] = key;
+        const oldKey = oldKeys.get(key.id);
+        if (oldKey) {
+          continue;
+        }
+        this.startInstance(key);
       }
-      this.startInstance(key);
-    }
 
-    for (const oldKey of oldKeys.values()) {
-      if (!this.keys.has(oldKey.id)) {
-        this.stopInstance(oldKey.id);
+      for (const oldKey of oldKeys.values()) {
+        if (!this.keys.has(oldKey.id)) {
+          this.stopInstance(oldKey.id);
+        }
       }
-    }
-    return Promise.resolve();
+      resolve();
+    });
   }
 
   private startInstance(key: AccessKey): child_process.ChildProcess {

--- a/src/shadowbox/server/libev_shadowsocks_server.ts
+++ b/src/shadowbox/server/libev_shadowsocks_server.ts
@@ -97,6 +97,8 @@ export class LibevShadowsocksServer implements ShadowsocksServer {
     });
   }
 
+  // Update spawns the ss-libev subprocess and returns, likely before the instances
+  // are ready and serving.
   update(newKeys: AccessKey[]): Promise<void> {
     return new Promise((resolve, reject) => {
       const oldKeys = this.keys;

--- a/src/shadowbox/server/libev_shadowsocks_server.ts
+++ b/src/shadowbox/server/libev_shadowsocks_server.ts
@@ -100,6 +100,7 @@ export class LibevShadowsocksServer implements ShadowsocksServer {
     return new Promise((resolve, reject) => {
       const oldKeys = this.keys;
       this.keys = new Map<string, AccessKey>();
+      // Start keys that were added
       for (const key of newKeys) {
         this.keys[key.id] = key;
         const oldKey = oldKeys.get(key.id);
@@ -108,7 +109,7 @@ export class LibevShadowsocksServer implements ShadowsocksServer {
         }
         this.startInstance(key);
       }
-
+      // Stop keys that were removed.
       for (const oldKey of oldKeys.values()) {
         if (!this.keys.has(oldKey.id)) {
           this.stopInstance(oldKey.id);

--- a/src/shadowbox/server/libev_shadowsocks_server.ts
+++ b/src/shadowbox/server/libev_shadowsocks_server.ts
@@ -42,8 +42,9 @@ export class LibevShadowsocksServer implements ShadowsocksServer {
   private keys = new Map<string, AccessKey>();
 
   constructor(
-      private publicAddress: string, private metricsSocket: dgram.Socket,
-      ipLocation: IpLocationService, usageWriter: UsageMetricsWriter, private verbose: boolean) {
+      private readonly publicAddress: string, private readonly metricsSocket: dgram.Socket,
+      ipLocation: IpLocationService, usageWriter: UsageMetricsWriter,
+      private readonly verbose: boolean) {
     metricsSocket.on('message', (buf: Buffer) => {
       let metricsMessage;
       try {

--- a/src/shadowbox/server/libev_shadowsocks_server.ts
+++ b/src/shadowbox/server/libev_shadowsocks_server.ts
@@ -155,7 +155,7 @@ export class LibevShadowsocksServer implements ShadowsocksServer {
     childProcess.on('exit', (code, signal) => {
       logging.info(`Server on port ${key.port} has exited. Code: ${code}, Signal: ${signal}`);
     });
-    // TODO(fortuna): Disable this for production.
+    // This exposes the ss-server output on the docker logs.
     // TODO(fortuna): Consider saving the output and expose it through the manager service.
     childProcess.stdout.pipe(process.stdout);
     childProcess.stderr.pipe(process.stderr);

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -20,7 +20,6 @@ import * as prometheus from 'prom-client';
 import * as restify from 'restify';
 
 import {RealClock} from '../infrastructure/clock';
-import * as get_port from '../infrastructure/get_port';
 import {PortProvider} from '../infrastructure/get_port';
 import * as ip_location from '../infrastructure/ip_location';
 import * as json_config from '../infrastructure/json_config';
@@ -28,17 +27,19 @@ import * as logging from '../infrastructure/logging';
 import {PrometheusClient, runPrometheusScraper} from '../infrastructure/prometheus_scraper';
 import {RolloutTracker} from '../infrastructure/rollout';
 import {AccessKeyId} from '../model/access_key';
+import {ShadowsocksServer} from '../model/shadowsocks_server';
 
 import {createLibevShadowsocksServer} from './libev_shadowsocks_server';
-import {LegacyManagerMetrics, LegacyManagerMetricsJson, ManagerMetrics, PrometheusManagerMetrics} from './manager_metrics';
+import {LegacyManagerMetrics, LegacyManagerMetricsJson, PrometheusManagerMetrics} from './manager_metrics';
 import {bindService, ShadowsocksManagerService} from './manager_service';
+import {OutlineShadowsocksServer} from './outline_shadowsocks_server';
 import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import * as server_config from './server_config';
-import {ServerConfigJson} from './server_config';
-import {createPrometheusUsageMetricsWriter, InMemoryUsageMetrics, OutlineSharedMetricsPublisher, PrometheusUsageMetrics, RestMetricsCollectorClient, SharedMetricsPublisher, UsageMetrics, UsageMetricsWriter} from './shared_metrics';
+import {createPrometheusUsageMetricsWriter, OutlineSharedMetricsPublisher, PrometheusUsageMetrics, RestMetricsCollectorClient, SharedMetricsPublisher} from './shared_metrics';
 
 const DEFAULT_STATE_DIR = '/root/shadowbox/persisted-state';
 const MAX_STATS_FILE_AGE_MS = 5000;
+const MMDB_LOCATION = '/var/lib/libmaxminddb/GeoLite2-Country.mmdb';
 
 // Serialized format for the metrics file.
 // WARNING: Renaming fields will break backwards-compatibility.
@@ -57,16 +58,6 @@ function readMetricsConfig(filename: string): json_config.JsonConfig<MetricsConf
     return new json_config.DelayedConfig(metricsConfig, MAX_STATS_FILE_AGE_MS);
   } catch (error) {
     throw new Error(`Failed to read metrics config at ${filename}: ${error}`);
-  }
-}
-
-class MultiMetricsWriter implements UsageMetricsWriter {
-  constructor(
-      private managerMetrics: LegacyManagerMetrics, private sharedMetrics: UsageMetricsWriter) {}
-
-  writeBytesTransferred(accessKeyId: AccessKeyId, numBytes: number, countries: string[]) {
-    this.managerMetrics.writeBytesTransferred(accessKeyId, numBytes);
-    this.sharedMetrics.writeBytesTransferred(accessKeyId, numBytes, countries);
   }
 }
 
@@ -97,7 +88,7 @@ function createLegacyManagerMetrics(configFilename: string): LegacyManagerMetric
       new json_config.ChildConfig(metricsConfig, metricsConfig.data().transferStats));
 }
 
-function createRolloutTracker(serverConfig: json_config.JsonConfig<ServerConfigJson>):
+function createRolloutTracker(serverConfig: json_config.JsonConfig<server_config.ServerConfigJson>):
     RolloutTracker {
   const rollouts = new RolloutTracker(serverConfig.data().serverId);
   if (serverConfig.data().rollouts) {
@@ -147,54 +138,51 @@ async function main() {
       server_config.readServerConfig(getPersistentFilename('shadowbox_server_config.json'));
 
   logging.info('Starting...');
-  const ipLocation =
-      new ip_location.MmdbLocationService('/var/lib/libmaxminddb/GeoLite2-Country.mmdb');
 
   const legacyManagerMetrics =
       createLegacyManagerMetrics(getPersistentFilename('shadowbox_stats.json'));
-  let managerMetrics: ManagerMetrics;
-  let metricsWriter: UsageMetricsWriter;
-  let metricsReader: UsageMetrics;
+  const prometheusPort = await portProvider.reserveFirstFreePort(9090);
+  const prometheusLocation = `localhost:${prometheusPort}`;
+
+  const nodeMetricsPort = await portProvider.reserveFirstFreePort(prometheusPort + 1);
+  exportPrometheusMetrics(prometheus.register, nodeMetricsPort);
+  const nodeMetricsLocation = `localhost:${nodeMetricsPort}`;
+
+  const ssMetricsPort = await portProvider.reserveFirstFreePort(nodeMetricsPort + 1);
+  const ssMetricsLocation = `localhost:${ssMetricsPort}`;
+  runPrometheusScraper(
+      [
+        '--storage.tsdb.retention', '31d', '--storage.tsdb.path',
+        getPersistentFilename('prometheus/data'), '--web.listen-address', prometheusLocation,
+        '--log.level', verbose ? 'debug' : 'info'
+      ],
+      getPersistentFilename('prometheus/config.yml'), {
+        global: {
+          scrape_interval: '15s',
+        },
+        scrape_configs: [
+          {job_name: 'prometheus', static_configs: [{targets: [prometheusLocation]}]},
+          {job_name: 'outline-server-main', static_configs: [{targets: [nodeMetricsLocation]}]},
+          {job_name: 'outline-server-ss', static_configs: [{targets: [ssMetricsLocation]}]}
+        ]
+      });
+  const prometheusClient = new PrometheusClient(`http://${prometheusLocation}`);
+  const managerMetrics = new PrometheusManagerMetrics(prometheusClient, legacyManagerMetrics);
+  const metricsReader = new PrometheusUsageMetrics(prometheusClient);
+
   const rollouts = createRolloutTracker(serverConfig);
-  if (rollouts.isRolloutEnabled('prometheus', 0)) {
-    const prometheusPort = await portProvider.reserveFirstFreePort(9090);
-    const prometheusLocation = `localhost:${prometheusPort}`;
-
-    const nodeMetricsPort = await portProvider.reserveFirstFreePort(prometheusPort + 1);
-    exportPrometheusMetrics(prometheus.register, nodeMetricsPort);
-    const nodeMetricsLocation = `localhost:${nodeMetricsPort}`;
-
-    logging.info(`Prometheus is at ${prometheusLocation}`);
-    logging.info(`Node metrics is at ${nodeMetricsLocation}`);
-
-    runPrometheusScraper(
-        [
-          '--storage.tsdb.retention', '31d', '--storage.tsdb.path',
-          getPersistentFilename('prometheus/data'), '--web.listen-address', prometheusLocation,
-          '--log.level', verbose ? 'debug' : 'info'
-        ],
-        getPersistentFilename('prometheus/config.yml'), {
-          global: {
-            scrape_interval: '15s',
-          },
-          scrape_configs: [
-            {job_name: 'prometheus', static_configs: [{targets: [prometheusLocation]}]},
-            {job_name: 'outline-server-main', static_configs: [{targets: [nodeMetricsLocation]}]},
-          ]
-        });
-    const prometheusClient = new PrometheusClient(`http://${prometheusLocation}`);
-    managerMetrics = new PrometheusManagerMetrics(prometheusClient, legacyManagerMetrics);
-    metricsWriter = createPrometheusUsageMetricsWriter(prometheus.register);
-    metricsReader = new PrometheusUsageMetrics(prometheusClient);
+  let shadowsocksServer: ShadowsocksServer;
+  if (rollouts.isRolloutEnabled('outline-ss-server', 0)) {
+    shadowsocksServer = new OutlineShadowsocksServer(
+        getPersistentFilename('outline-ss-server/config.yml'), verbose, ssMetricsLocation,
+        MMDB_LOCATION);
   } else {
-    managerMetrics = legacyManagerMetrics;
-    const usageMetrics = new InMemoryUsageMetrics();
-    metricsWriter = new MultiMetricsWriter(legacyManagerMetrics, usageMetrics);
-    metricsReader = usageMetrics;
+    const ipLocation = new ip_location.MmdbLocationService(MMDB_LOCATION);
+    const metricsWriter = createPrometheusUsageMetricsWriter(prometheus.register);
+    shadowsocksServer = await createLibevShadowsocksServer(
+        proxyHostname, await portProvider.reserveNewPort(), ipLocation, metricsWriter, verbose);
   }
 
-  const shadowsocksServer = await createLibevShadowsocksServer(
-      proxyHostname, await portProvider.reserveNewPort(), ipLocation, metricsWriter, verbose);
   const accessKeyRepository = new ServerAccessKeyRepository(
       portProvider, proxyHostname, accessKeyConfig, shadowsocksServer);
 

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -173,9 +173,10 @@ async function main() {
   const rollouts = createRolloutTracker(serverConfig);
   let shadowsocksServer: ShadowsocksServer;
   if (rollouts.isRolloutEnabled('outline-ss-server', 0)) {
-    shadowsocksServer = new OutlineShadowsocksServer(
-        getPersistentFilename('outline-ss-server/config.yml'), verbose, ssMetricsLocation,
-        MMDB_LOCATION);
+    shadowsocksServer =
+        new OutlineShadowsocksServer(
+            getPersistentFilename('outline-ss-server/config.yml'), verbose, ssMetricsLocation)
+            .enableCountryMetrics(MMDB_LOCATION);
   } else {
     const ipLocation = new ip_location.MmdbLocationService(MMDB_LOCATION);
     const metricsWriter = createPrometheusUsageMetricsWriter(prometheus.register);

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as dgram from 'dgram';
 
 import {AccessKey, AccessKeyId, AccessKeyRepository} from '../../model/access_key';
-import {ShadowsocksInstance, ShadowsocksServer} from '../../model/shadowsocks_server';
 import {TextFile} from '../../model/text_file';
 
 export class MockAccessKeyRepository implements AccessKeyRepository {
@@ -59,24 +57,6 @@ export class MockAccessKeyRepository implements AccessKeyRepository {
   }
   getMetricsId(accessKeyId: AccessKeyId) {
     return `metrics:${accessKeyId}`;
-  }
-}
-
-class MockShadowsocksInstance implements ShadowsocksInstance {
-  constructor(
-      public portNumber = 12345,
-      public password = 'password',
-      public encryptionMethod = 'encryption',
-      public accessUrl = 'ss://somethingsomething') {}
-  onInboundBytes(callback: (bytes: number, ipAddresses: string[]) => void) {}
-  stop() {}
-}
-
-export class MockShadowsocksServer implements ShadowsocksServer {
-  startInstance(id: string, portNumber: number, password: string, encryptionMethod?: string):
-      Promise<ShadowsocksInstance> {
-    const mock = new MockShadowsocksInstance(portNumber, password, encryptionMethod);
-    return Promise.resolve(mock);
   }
 }
 

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -24,6 +24,7 @@ import {AccessKey, ShadowsocksServer} from '../model/shadowsocks_server';
 // Runs outline-ss-server.
 export class OutlineShadowsocksServer implements ShadowsocksServer {
   private ssProcess: child_process.ChildProcess;
+
   // configFilename is the location for the outline-ss-server config.
   constructor(
       private configFilename: string, private verbose: boolean, private metricsLocation: string,
@@ -44,6 +45,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
       });
     });
   }
+
   update(keys: AccessKey[]): Promise<void> {
     return this.writeConfigFile(keys).then(() => {
       if (!this.ssProcess) {
@@ -54,6 +56,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
       }
     });
   }
+
   private start() {
     const commandArguments = ['-config', this.configFilename, '-metrics', this.metricsLocation];
     if (this.ipCountryLocation) {

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -29,6 +29,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
   constructor(
       private configFilename: string, private verbose: boolean, private metricsLocation: string,
       private ipCountryLocation: string) {}
+
   private writeConfigFile(keys: AccessKey[]): Promise<void> {
     const keysJson = {keys: [] as AccessKey[]};
     for (const key of keys) {

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -1,0 +1,79 @@
+// Copyright 2018 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import * as jsyaml from 'js-yaml';
+import * as mkdirp from 'mkdirp';
+import * as path from 'path';
+
+import * as logging from '../infrastructure/logging';
+import {AccessKey, ShadowsocksServer} from '../model/shadowsocks_server';
+
+// Runs outline-ss-server.
+export class OutlineShadowsocksServer implements ShadowsocksServer {
+  private ssProcess: child_process.ChildProcess;
+  // configFilename is the location for the outline-ss-server config.
+  constructor(
+      private configFilename: string, private verbose: boolean, private metricsLocation: string,
+      private ipCountryLocation: string) {}
+  private writeConfigFile(keys: AccessKey[]): Promise<void> {
+    const keysJson = {keys: [] as AccessKey[]};
+    for (const key of keys) {
+      keysJson.keys.push(key);
+    }
+    const ymlTxt = jsyaml.safeDump(keysJson, {'sortKeys': true});
+    return new Promise((resolve, reject) => {
+      mkdirp.sync(path.dirname(this.configFilename));
+      fs.writeFile(this.configFilename, ymlTxt, 'utf-8', (err) => {
+        if (err) {
+          reject(err);
+        }
+        resolve();
+      });
+    });
+  }
+  update(keys: AccessKey[]): Promise<void> {
+    return this.writeConfigFile(keys).then(() => {
+      if (!this.ssProcess) {
+        this.start();
+        return Promise.resolve();
+      } else {
+        this.ssProcess.kill('SIGHUP');
+      }
+    });
+  }
+  private start() {
+    const commandArguments = ['-config', this.configFilename, '-metrics', this.metricsLocation];
+    if (this.ipCountryLocation) {
+      commandArguments.push('-ip_country_db', this.ipCountryLocation);
+    }
+    if (this.verbose) {
+      commandArguments.push('-verbose');
+    }
+    this.ssProcess = child_process.spawn('/root/shadowbox/bin/outline-ss-server', commandArguments);
+    this.ssProcess.on('error', (error) => {
+      logging.error(`Error spawning outline-ss-server: ${error}`);
+    });
+    this.ssProcess.on('exit', (code, signal) => {
+      logging.info(`outline-ss-server has exited with error. Code: ${code}, Signal: ${signal}`);
+      logging.info(`Restarting`);
+      this.start();
+    });
+    // TODO(fortuna): Disable this for production.
+    // TODO(fortuna): Consider saving the output and expose it through the manager service.
+    this.ssProcess.stdout.pipe(process.stdout);
+    this.ssProcess.stderr.pipe(process.stderr);
+  }
+}

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -28,7 +28,8 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
 
   // configFilename is the location for the outline-ss-server config.
   constructor(
-      private configFilename: string, private verbose: boolean, private metricsLocation: string) {}
+      private readonly configFilename: string, private readonly verbose: boolean,
+      private readonly metricsLocation: string) {}
 
   // Annotates the Prometheus data metrics with countries.
   // ipCountryFilename is the location of the GeoLite2-Country.mmdb file.

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -85,7 +85,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
       logging.info(`Restarting`);
       this.start();
     });
-    // TODO(fortuna): Disable this for production.
+    // This exposes the outline-ss-server output on the docker logs.
     // TODO(fortuna): Consider saving the output and expose it through the manager service.
     this.ssProcess.stdout.pipe(process.stdout);
     this.ssProcess.stderr.pipe(process.stderr);

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -40,6 +40,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
 
   // Promise is resolved after the outline-ss-config config is updated and the SIGHUP sent.
   // Keys may not be active yet.
+  // TODO(fortuna): Make promise resolve when keys are ready.
   update(keys: AccessKey[]): Promise<void> {
     return this.writeConfigFile(keys).then(() => {
       if (!this.ssProcess) {

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -38,6 +38,8 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     return this;
   }
 
+  // Promise is resolved after the outline-ss-config config is updated and the SIGHUP sent.
+  // Keys may not be active yet.
   update(keys: AccessKey[]): Promise<void> {
     return this.writeConfigFile(keys).then(() => {
       if (!this.ssProcess) {

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -49,12 +49,12 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
   }
 
   private writeConfigFile(keys: AccessKey[]): Promise<void> {
-    const keysJson = {keys: [] as AccessKey[]};
-    for (const key of keys) {
-      keysJson.keys.push(key);
-    }
-    const ymlTxt = jsyaml.safeDump(keysJson, {'sortKeys': true});
     return new Promise((resolve, reject) => {
+      const keysJson = {keys: [] as AccessKey[]};
+      for (const key of keys) {
+        keysJson.keys.push(key);
+      }
+      const ymlTxt = jsyaml.safeDump(keysJson, {'sortKeys': true});
       mkdirp.sync(path.dirname(this.configFilename));
       fs.writeFile(this.configFilename, ymlTxt, 'utf-8', (err) => {
         if (err) {


### PR DESCRIPTION
This is the last PR for adding the Go server.

Once we fully rollout the Prometheus change, we can merge this PR and start the new rollout.

Then the only thing left will be to tweak ServerAccessKeyRepository to always use the same port to launch single port.