### PR TITLE
Sort access keys by name

### DIFF
--- a/src/server_manager/ui_components/outline-server-view.html
+++ b/src/server_manager/ui_components/outline-server-view.html
@@ -320,7 +320,7 @@
               </span>
             </div>
             <!-- rows for each access key -->
-            <template is="dom-repeat" items="{{accessKeyRows}}" filter="isRegularConnection">
+            <template is="dom-repeat" items="{{accessKeyRows}}" filter="isRegularConnection" sort='sort'>
               <div class="access-key-row">
                 <span class="access-key-container">
                   <img class="access-key-icon" src="images/key-avatar.svg">
@@ -591,6 +591,20 @@
       },
       isRegularConnection: function(item) {
         return item.id !== MY_CONNECTION_USER_ID;
+      },
+      // https://stackoverflow.com/a/46119203/1298144
+      sort: function(a, b) {
+        var nameA = a.name.toUpperCase(); 
+        var nameB = b.name.toUpperCase(); 
+        if (nameA < nameB) {
+          return -1;
+        }
+        if (nameA > nameB) {
+          return 1;
+        }
+
+        // names must be equal
+        return 0;
       },
       deleteServer: function() {
         this.fire('DeleteServerRequested');


### PR DESCRIPTION
Added sort access keys by name to make it easy to find them when managing many users.

---

Currently keys are sorted by creation dates.

When we have many users, it makes it easy manage keys if it's sorted by name. E.g when you have multiple orgs/departments on one server, you can have:

```
cfa-david
...
alpha-larry
...
jigsaw-george
```

Above by sorting by name would know where to scroll to to find it without introducing any new "features" e.g search nor trying to remember when you created the key:

```
alpha-larry
...
cfa-david
...
jigsaw-george
```

Related: #293 