### PR TITLE
Fix reported metrics

### DIFF
--- a/src/shadowbox/server/manager_metrics.ts
+++ b/src/shadowbox/server/manager_metrics.ts
@@ -28,6 +28,9 @@ export class PrometheusManagerMetrics implements ManagerMetrics {
 
   async get30DayByteTransfer(): Promise<DataUsageByUser> {
     // TODO(fortuna): Consider pre-computing this to save server's CPU.
+    // We measure only traffic leaving the server, since that's what DigitalOcean charges
+    // TODO: Display all directions to admin
+    // TODO: Remove >p< once ss-libev support is gone.
     const result = await this.prometheusClient.query(
         'sum(increase(shadowsocks_data_bytes{dir=~"c<p|p>t|>p<"}[30d])) by (access_key)');
     const usage = {} as {[userId: string]: number};

--- a/src/shadowbox/server/manager_metrics.ts
+++ b/src/shadowbox/server/manager_metrics.ts
@@ -28,7 +28,7 @@ export class PrometheusManagerMetrics implements ManagerMetrics {
 
   async get30DayByteTransfer(): Promise<DataUsageByUser> {
     // TODO(fortuna): Consider pre-computing this to save server's CPU.
-    // We measure only traffic leaving the server, since that's what DigitalOcean charges
+    // We measure only traffic leaving the server, since that's what DigitalOcean charges.
     // TODO: Display all directions to admin
     // TODO: Remove >p< once ss-libev support is gone.
     const result = await this.prometheusClient.query(

--- a/src/shadowbox/server/shared_metrics.ts
+++ b/src/shadowbox/server/shared_metrics.ts
@@ -74,8 +74,10 @@ export class PrometheusUsageMetrics implements UsageMetrics {
 
   async getUsage(): Promise<KeyUsage[]> {
     const timeDeltaSecs = Math.round((Date.now() - this.resetTimeMs) / 1000);
+    // We mesure the traffic to and from the target, since that's what we are protecting.
+    // TODO: remove >p< once the ss-libev support is gone.
     const result =
-        await this.prometheusClient.query(`sum(increase(shadowsocks_data_bytes{dir=">p<"}[${
+        await this.prometheusClient.query(`sum(increase(shadowsocks_data_bytes{dir=~">p<|p>t|p<t"}[${
             timeDeltaSecs}s])) by (location, access_key)`);
     const usage = [] as KeyUsage[];
     for (const entry of result.result) {

--- a/src/shadowbox/server/shared_metrics.ts
+++ b/src/shadowbox/server/shared_metrics.ts
@@ -74,10 +74,10 @@ export class PrometheusUsageMetrics implements UsageMetrics {
 
   async getUsage(): Promise<KeyUsage[]> {
     const timeDeltaSecs = Math.round((Date.now() - this.resetTimeMs) / 1000);
-    // We mesure the traffic to and from the target, since that's what we are protecting.
+    // We measure the traffic to and from the target, since that's what we are protecting.
     // TODO: remove >p< once the ss-libev support is gone.
-    const result =
-        await this.prometheusClient.query(`sum(increase(shadowsocks_data_bytes{dir=~">p<|p>t|p<t"}[${
+    const result = await this.prometheusClient.query(
+        `sum(increase(shadowsocks_data_bytes{dir=~">p<|p>t|p<t"}[${
             timeDeltaSecs}s])) by (location, access_key)`);
     const usage = [] as KeyUsage[];
     for (const entry of result.result) {


### PR DESCRIPTION
This change will report all the traffic between the proxy and the target, since that's the actual protected traffic.

I added some extra comments on measured flows, since that's quite confusing.