### PR TITLE
Add umask to Shadowbox

### DIFF
--- a/src/shadowbox/docker/cmd.sh
+++ b/src/shadowbox/docker/cmd.sh
@@ -17,8 +17,8 @@
 export SB_PUBLIC_IP=${SB_PUBLIC_IP:-$(curl https://ipinfo.io/ip)}
 export SB_METRICS_URL=${SB_METRICS_URL:-https://metrics-prod.uproxy.org}
 
-# Make sure we don't leave readable files behind.
-umask 0077
+# Make sure we don't leak readable files to other users.
+umask 0007
 
 # The maximum number of files that can be opened by ss-server greatly
 # influence on performance, as described here:

--- a/src/shadowbox/docker/cmd.sh
+++ b/src/shadowbox/docker/cmd.sh
@@ -17,6 +17,9 @@
 export SB_PUBLIC_IP=${SB_PUBLIC_IP:-$(curl https://ipinfo.io/ip)}
 export SB_METRICS_URL=${SB_METRICS_URL:-https://metrics-prod.uproxy.org}
 
+# Make sure we don't leave readable files behind.
+umask 0077
+
 # The maximum number of files that can be opened by ss-server greatly
 # influence on performance, as described here:
 #   https://shadowsocks.org/en/config/advanced.html


### PR DESCRIPTION
Files created by Node, outline-ss-server or prometheus will not be readable by other users

This partially addresses https://github.com/Jigsaw-Code/outline-cure53/issues/9, since there are still files created at installation (such as access.txt or the TLS key).
