### PR TITLE
strip whitespace from server configs, like we used to

### DIFF
--- a/src/server_manager/web_app/management_urls.spec.ts
+++ b/src/server_manager/web_app/management_urls.spec.ts
@@ -46,4 +46,18 @@ describe('parseManualServerConfig', () => {
     expect(result.apiUrl).toEqual('http://abc.com/xyz');
     expect(result.certSha256).toEqual('1234567');
   });
+
+  it('strips whitespace', () => {
+    const result =
+        parseManualServerConfig('{"apiUrl":http://abc.com/xyz, "certSha256":"123   4567"}');
+    expect(result.apiUrl).toEqual('http://abc.com/xyz');
+    expect(result.certSha256).toEqual('1234567');
+  });
+
+  it('strips newlines', () => {
+    const result =
+        parseManualServerConfig('{"apiUrl":http://abc.com/xyz, "certSha256":"123\n4567"}');
+    expect(result.apiUrl).toEqual('http://abc.com/xyz');
+    expect(result.certSha256).toEqual('1234567');
+  });
 });

--- a/src/server_manager/web_app/management_urls.ts
+++ b/src/server_manager/web_app/management_urls.ts
@@ -30,6 +30,9 @@ export function parseManualServerConfig(userInput: string): ManualServerConfig {
     userInput = userInput.substring(0, indexOfLastBrace + 1);
   }
 
+  // Strip whitespace.
+  userInput = userInput.replace(/\s+/g, '');
+
   const config = jsonic(userInput) as ManualServerConfig;
 
   if (!config.apiUrl) {


### PR DESCRIPTION
Prior to https://github.com/Jigsaw-Code/outline-server/pull/315 we stripped whitespace from manual server configs input into the text box; this restores that behaviour (my mistake).

Fixes:
https://github.com/Jigsaw-Code/outline-server/issues/322