### PR TITLE
when invoked by cron, only run the tag stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 stages:
-  - build and unit test
-  - integration test
   - name: tag
     if: type = cron
+  - build and unit test
+  - integration test
   - name: deploy
     if: tag =~ ^daily
   - name: release
@@ -30,6 +30,16 @@ stages:
 # doing, we add a descriptive environment variable.
 jobs:
   include:
+    # Because this stage's only function is to trigger a subsequent, full-blown release build, we
+    # make it terminate the entire build after tagging. Without exiting, it would (wastefully)
+    # build and run tests - using travis_terminate here avoids significantly complicating the
+    # stages: section, above.
+    - stage: tag
+      script:
+        - RELEASE_NAME=daily-$(date -I)
+        - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
+        - travis_terminate 0
+
     # Ideally, we would split this stage in some way, e.g. by component or by
     # build/test commands, to make it clearer in the Travis UI exactly which
     # command failed. However, since each stage incurs a significantly start-up
@@ -55,11 +65,6 @@ jobs:
           chmod +x docker-compose
           sudo mv docker-compose /usr/local/bin
         - yarn do shadowbox/integration_test/run
-
-    - stage: tag
-      script:
-        - RELEASE_NAME=daily-$(date -I)
-        - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
 
     - stage: deploy
       env:


### PR DESCRIPTION
Just a little thing I noticed while tests were flaky recently:
- if the build or tests are flaky then the tag stage won't get run and we lose out on that day's snapshot
- it's wasteful building and testing when the only function of the cronjob is to tag - this will get our daily builds out a little faster