### PR TITLE
do not build and test for cron builds (take two)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ stages:
   - name: tag
     if: type = cron
   - build and unit test
+    if: type != cron
   - integration test
+    if: type != cron
   - name: deploy
     if: tag =~ ^daily
   - name: release
@@ -30,15 +32,10 @@ stages:
 # doing, we add a descriptive environment variable.
 jobs:
   include:
-    # Because this stage's only function is to trigger a subsequent, full-blown release build, we
-    # make it terminate the entire build after tagging. Without exiting, it would (wastefully)
-    # build and run tests - using travis_terminate here avoids significantly complicating the
-    # stages: section, above.
     - stage: tag
       script:
         - RELEASE_NAME=daily-$(date -I)
         - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
-        - travis_terminate 0
 
     # Ideally, we would split this stage in some way, e.g. by component or by
     # build/test commands, to make it clearer in the Travis UI exactly which


### PR DESCRIPTION
Looks like https://github.com/Jigsaw-Code/outline-server/pull/342 is not doing exactly what I'd like:
https://travis-ci.org/Jigsaw-Code/outline-server/jobs/465463017

Looks like `travis_terminate` is only good for terminating stages, not entire builds. Let's do it the old-fashioned way (no comment required now, I think).