### PR TITLE
Implement cloud function to post Sentry events to Salesforce

### DIFF
--- a/src/sentry_webhook/README.md
+++ b/src/sentry_webhook/README.md
@@ -1,0 +1,36 @@
+# Outline Sentry Webhook
+
+The Outline Sentry webhook is a [Google Cloud Function](https://cloud.google.com/functions/) that receives a Sentry event and posts it to Salesforce.
+
+## Requirements
+
+* [Google Cloud SDK](https://cloud.google.com/sdk/)
+* Access to Outline's Sentry account.
+
+
+## Build
+
+```sh
+yarn do sentry_webhook/build
+```
+
+## Deploy
+
+Authenticate with `gcloud`:
+  ```sh
+  gcloud auth login
+  ```
+To deploy:
+  ```sh
+  yarn do sentry_webhook/deploy
+  ```
+
+## Configure Sentry Webhooks
+
+* Log in to Outline's [Sentry account](https://sentry.io/outlinevpn/)
+* Select a project (outline-client, outline-client-dev, outline-server, outline-server-dev).
+  * Note that this process must be repeated for all Sentry projects.
+* Enable the WebHooks plugin at `https://sentry.io/settings/outlinevpn/<project>/plugins/`
+* Set the webhook endpoint at `https://sentry.io/settings/outlinevpn/<project>/plugins/webhooks/`
+* Configure alerts to invoke the webhook at `https://sentry.io/settings/outlinevpn/<project>/alerts/`
+* Create rules to trigger the webhook at `https://sentry.io/settings/outlinevpn/<project>/alerts/rules/`

--- a/src/sentry_webhook/README.md
+++ b/src/sentry_webhook/README.md
@@ -7,7 +7,6 @@ The Outline Sentry webhook is a [Google Cloud Function](https://cloud.google.com
 * [Google Cloud SDK](https://cloud.google.com/sdk/)
 * Access to Outline's Sentry account.
 
-
 ## Build
 
 ```sh

--- a/src/sentry_webhook/build_action.sh
+++ b/src/sentry_webhook/build_action.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tsc -p $(dirname $0)

--- a/src/sentry_webhook/deploy_action.sh
+++ b/src/sentry_webhook/deploy_action.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+yarn do sentry_webhook/build
+
+cp src/sentry_webhook/package.json build/sentry_webhook/
+gcloud --project=uproxysite functions deploy postSentryEventToSalesforce --trigger-http --source=build/sentry_webhook --entry-point=postSentryEventToSalesforce

--- a/src/sentry_webhook/index.ts
+++ b/src/sentry_webhook/index.ts
@@ -1,0 +1,47 @@
+// Copyright 2018 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as sentry from '@sentry/types';
+import * as express from 'express';
+
+import {postSentryEventToSalesforce} from './post_sentry_event_to_salesforce';
+
+exports.postSentryEventToSalesforce = (req: express.Request, res: express.Response) => {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method not allowed');
+    return;
+  }
+  if (!req.body) {
+    res.status(400).send('Missing request body');
+    return;
+  }
+
+  const sentryEvent: sentry.SentryEvent = req.body.event;
+  if (!sentryEvent) {
+    res.status(400).send('Missing Sentry event');
+    return;
+  }
+  // Use the request message if SentryEvent.message is unpopulated.
+  sentryEvent.message = sentryEvent.message || req.body.message;
+  postSentryEventToSalesforce(sentryEvent, req.body.project)
+      .then(() => {
+        res.status(200).send();
+      })
+      .catch((e) => {
+        console.error(e);
+        // Send an OK response to Sentry - they don't need to know about errors with posting to
+        // Salesforce.
+        res.status(200).send();
+      });
+};

--- a/src/sentry_webhook/index.ts
+++ b/src/sentry_webhook/index.ts
@@ -15,22 +15,22 @@
 import * as sentry from '@sentry/types';
 import * as express from 'express';
 
-import {postSentryEventToSalesforce} from './post_sentry_event_to_salesforce';
+import {postSentryEventToSalesforce, shouldPostEventToSalesforce} from './post_sentry_event_to_salesforce';
 
 exports.postSentryEventToSalesforce = (req: express.Request, res: express.Response) => {
   if (req.method !== 'POST') {
-    res.status(405).send('Method not allowed');
-    return;
+    return res.status(405).send('Method not allowed');
   }
   if (!req.body) {
-    res.status(400).send('Missing request body');
-    return;
+    return res.status(400).send('Missing request body');
   }
 
   const sentryEvent: sentry.SentryEvent = req.body.event;
   if (!sentryEvent) {
-    res.status(400).send('Missing Sentry event');
-    return;
+    return res.status(400).send('Missing Sentry event');
+  }
+  if (!shouldPostEventToSalesforce(sentryEvent)) {
+    return res.status(200).send();
   }
   // Use the request message if SentryEvent.message is unpopulated.
   sentryEvent.message = sentryEvent.message || req.body.message;

--- a/src/sentry_webhook/package.json
+++ b/src/sentry_webhook/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sentry_webhook",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Outline Sentry Webhook",
+  "author": "Outline",
+  "license": "Apache",
+  "dependencies": {},
+  "devDependencies": {
+    "@sentry/types": "^4.4.1",
+    "@types/express": "^4.0.36"
+  }
+}

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -124,29 +124,23 @@ function getSalesforceFormData(
   form.push(encodeFormData(formFields.orgId, formValues.orgId));
   form.push(encodeFormData(formFields.recordType, formValues.recordType));
   form.push(encodeFormData(formFields.email, email));
-  form.push(encodeFormData(formFields.sentryEventId, getStringValueOrEmtpy(event.event_id)));
-  form.push(encodeFormData(formFields.description, getStringValueOrEmtpy(event.message)));
+  form.push(encodeFormData(formFields.sentryEventId, event.event_id));
+  form.push(encodeFormData(formFields.description, event.message));
   form.push(encodeFormData(formFields.type, isClient ? 'Outline client' : 'Outline manager'));
   const tags = getTagsMap(event.tags);
   if (!!tags) {
-    form.push(encodeFormData(formFields.category, getStringValueOrEmtpy(tags.get('category'))));
-    form.push(encodeFormData(formFields.os, getStringValueOrEmtpy(tags.get('os.name'))));
-    form.push(
-        encodeFormData(formFields.version, getStringValueOrEmtpy(tags.get('sentry:release'))));
+    form.push(encodeFormData(formFields.category, tags.get('category')));
+    form.push(encodeFormData(formFields.os, tags.get('os.name')));
+    form.push(encodeFormData(formFields.version, tags.get('sentry:release')));
     if (!isClient) {
-      form.push(encodeFormData(
-          formFields.cloudProvider, getStringValueOrEmtpy(tags.get('cloudProvider'))));
+      form.push(encodeFormData(formFields.cloudProvider, tags.get('cloudProvider')));
     }
   }
   return form.join('&');
 }
 
-function encodeFormData(field: string, value: string) {
-  return `${encodeURIComponent(field)}=${encodeURIComponent(value)}`;
-}
-
-function getStringValueOrEmtpy(str?: string): string {
-  return str || '';
+function encodeFormData(field: string, value?: string) {
+  return `${encodeURIComponent(field)}=${encodeURIComponent(value || '')}`;
 }
 
 // Although SentryEvent.tags is declared as an index signature object, it is actually an array of

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -1,0 +1,168 @@
+// Copyright 2018 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as sentry from '@sentry/types';
+import * as https from 'https';
+
+// Defines the Salesforce form field names.
+interface SalesforceFormFields {
+  orgId: string;
+  recordType: string;
+  email: string;
+  description: string;
+  category: string;
+  cloudProvider: string;
+  sentryEventId: string;
+  os: string;
+  version: string;
+  type: string;
+}
+
+// Defines the Salesforce form values.
+interface SalesforceFormValues {
+  orgId: string;
+  recordType: string;
+}
+
+const SALESFORCE_DEV_HOST = 'google-jigsaw--uat.my.salesforce.com';
+const SALESFORCE_PROD_HOST = 'webto.salesforce.com';
+const SALESFORCE_PATH = '/servlet/servlet.WebToCase';
+const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
+  orgId: 'orgid',
+  recordType: 'recordType',
+  email: 'email',
+  description: 'description',
+  category: '00N3F000002Rqho',
+  cloudProvider: '00N3F000002Rqhs',
+  sentryEventId: '00N3F000002Rqhq',
+  os: '00N3F000002cLcN',
+  version: '00N3F000002cLcI',
+  type: 'type'
+};
+const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
+  orgId: 'orgid',
+  recordType: 'recordType',
+  email: 'email',
+  description: 'description',
+  category: '00N0b00000BqOA2',
+  cloudProvider: '00N0b00000BqOA7',
+  sentryEventId: '00N0b00000BqOA4',
+  os: '00N0b00000BqOfW',
+  version: '00N0b00000BqOfR',
+  type: 'type'
+};
+const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
+  orgId: '00D3F000000DDDH',
+  recordType: '0123F000000MWTS',
+};
+const SALESFORCE_FORM_VALUES_PROD: SalesforceFormValues = {
+  orgId: '00D0b000000BrsN',
+  recordType: '0120b0000006e8i',
+};
+
+// Posts a Sentry event to Salesforce using predefined form data. Only posts if the event contains
+// an email address.
+export function postSentryEventToSalesforce(
+    event: sentry.SentryEvent, project: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!event.user || !event.user.email) {
+      reject(new Error('Not posting event without email'));
+      return;
+    }
+    // Sentry development projects are marked with 'dev', i.e. outline-client-dev.
+    const isProd = project.indexOf('-dev') === -1;
+    const salesforceHost = isProd ? SALESFORCE_PROD_HOST : SALESFORCE_DEV_HOST;
+    const formFields = isProd ? SALESFORCE_FORM_FIELDS_PROD : SALESFORCE_FORM_FIELDS_DEV;
+    const formValues = isProd ? SALESFORCE_FORM_VALUES_PROD : SALESFORCE_FORM_VALUES_DEV;
+    const isClient = project.indexOf('client') !== -1;
+    const formData =
+        getSalesforceFormData(formFields, formValues, event, event.user.email, isClient);
+    const req = https.request(
+        {
+          host: salesforceHost,
+          path: SALESFORCE_PATH,
+          protocol: 'https:',
+          method: 'post',
+          headers: {
+            // The production server will reject requests that do not specify this content type.
+            'Content-Type': 'application/x-www-form-urlencoded'
+          }
+        },
+        (res) => {
+          if (res.statusCode === 200) {
+            resolve();
+          } else {
+            reject(new Error(`Failed to post form data, response status: ${res.statusCode}`));
+          }
+        });
+    req.on('error', (err) => {
+      reject(new Error(
+          `Failed to submit form: ${err}`,
+          ));
+    });
+    req.write(formData);
+    req.end();
+  });
+}
+
+// Returns a URL-encoded string with the Salesforce form data.
+function getSalesforceFormData(
+    formFields: SalesforceFormFields, formValues: SalesforceFormValues, event: sentry.SentryEvent,
+    email: string, isClient: boolean): string {
+  const form = [];
+  form.push(encodeFormData(formFields.orgId, formValues.orgId));
+  form.push(encodeFormData(formFields.recordType, formValues.recordType));
+  form.push(encodeFormData(formFields.email, email));
+  form.push(encodeFormData(formFields.sentryEventId, getStringValueOrEmtpy(event.event_id)));
+  form.push(encodeFormData(formFields.description, getStringValueOrEmtpy(event.message)));
+  form.push(encodeFormData(formFields.type, isClient ? 'Outline client' : 'Outline manager'));
+  const tags = getTagsMap(event.tags);
+  if (!!tags) {
+    form.push(encodeFormData(formFields.category, getStringValueOrEmtpy(tags.get('category'))));
+    form.push(encodeFormData(formFields.os, getStringValueOrEmtpy(tags.get('os.name'))));
+    form.push(
+        encodeFormData(formFields.version, getStringValueOrEmtpy(tags.get('sentry:release'))));
+    if (!isClient) {
+      form.push(encodeFormData(
+          formFields.cloudProvider, getStringValueOrEmtpy(tags.get('cloudProvider'))));
+    }
+  }
+  return form.join('&');
+}
+
+function encodeFormData(field: string, value: string) {
+  return `${encodeURIComponent(field)}=${encodeURIComponent(value)}`;
+}
+
+function getStringValueOrEmtpy(str?: string): string {
+  return str || '';
+}
+
+// Although SentryEvent.tags is declared as an index signature object, it is actually an array of
+// arrays i.e. [['key0': 'value0'], ['key1': 'value1']]. Converts the tags to a Map of strings.
+function getTagsMap(tags?: {[key: string]: string}) {
+  if (!tags) {
+    return null;
+  }
+  const tagsMap = new Map<string, string>();
+  for (const i of Object.keys(tags)) {
+    try {
+      const tagEntry = tags[i];
+      tagsMap.set(tagEntry[0], tagEntry[1]);
+    } catch (e) {
+      console.error('Failed to process tag entry');
+    }
+  }
+  return tagsMap;
+}

--- a/src/sentry_webhook/tsconfig.json
+++ b/src/sentry_webhook/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "removeComments": false,
+    "strict": true,
+    "module": "commonjs",
+    "outDir": "../../build/sentry_webhook"
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,6 @@
 "@google-cloud/bigquery@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@google-cloud/bigquery/-/bigquery-2.0.3.tgz#83d8c794e003186e19e53906356e39a9f503fa33"
-  integrity sha512-N9d3KJPWyucdZ+8XUL2bm840BiK7RQE8gE2REJlEgUt2fGaNpJNbWL2rwF/YSRM/LuPUhmFKKbI4m2LL1VQXWw==
   dependencies:
     "@google-cloud/common" "^0.26.0"
     "@google-cloud/paginator" "^0.1.2"
@@ -27,7 +26,6 @@
 "@google-cloud/common@^0.26.0":
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.26.2.tgz#9c54e2471a84aa031e95a24824976e080f255645"
-  integrity sha512-xJ2M/q3MrUbnYZuFlpF01caAlEhAUoRn0NXp93Hn3pkFpfSOG8YfbKbpBAHvcKVbBOAKVIwPsleNtuyuabUwLQ==
   dependencies:
     "@google-cloud/projectify" "^0.3.2"
     "@google-cloud/promisify" "^0.3.0"
@@ -45,7 +43,6 @@
 "@google-cloud/paginator@^0.1.0", "@google-cloud/paginator@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-0.1.2.tgz#a7e6579e43f153055b4c65035a6729490a611a60"
-  integrity sha512-XL09cuPSEPyyNifavxWJRYkUFr5zCJ9njcFjqc1AqSQ2QIKycwdTxOP/zHsAWj0xN3rw1ApevA8o+8VAD4R6hw==
   dependencies:
     arrify "^1.0.1"
     extend "^3.0.1"
@@ -56,17 +53,14 @@
 "@google-cloud/projectify@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@google-cloud/projectify/-/projectify-0.3.2.tgz#ed54c98cae646dc03a742eac288184a13d33a4c2"
-  integrity sha512-t1bs5gE105IpgikX7zPCJZzVyXM5xZ/1kJomUPim2E2pNp4OUUFNyvKm/T2aM6GBP2F30o8abCD+/wbOhHWYYA==
 
 "@google-cloud/promisify@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-0.3.1.tgz#f641e6d944a8e0a05ee0cb1091dfa60089becdba"
-  integrity sha512-QzB0/IMvB0eFxFK7Eqh+bfC8NLv3E9ScjWQrPOk6GgfNroxcVITdTlT8NRsRrcp5+QQJVPLkRqKG0PUdaWXmHw==
 
 "@google-cloud/storage@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-2.3.1.tgz#89db0e051a3d30cd2f0c627d0f13633f646ee392"
-  integrity sha512-AXfze/I1J6NNk9yuyuKgYL2E1qxS7nvDGFvwitUyAb0FgDEA5UpXiKbDWouu4mwqVMYWl7HXlQiLUSkYNXMB1w==
   dependencies:
     "@google-cloud/common" "^0.26.0"
     "@google-cloud/paginator" "^0.1.0"
@@ -155,6 +149,10 @@
   version "4.0.0-beta.12"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.0.0-beta.12.tgz#0abd303692e48c0fc11afbfea8cbad87e625357a"
 
+"@sentry/types@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.4.1.tgz#d19f9b0450a543aa11b136681ea19612e3cc1611"
+
 "@sentry/utils@4.0.0-beta.12":
   version "4.0.0-beta.12"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-4.0.0-beta.12.tgz#9d51e88634843232b6c6f0edb6df3d3fba83071e"
@@ -186,7 +184,6 @@
 "@types/duplexify@^3.5.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"
-  integrity sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==
   dependencies:
     "@types/node" "*"
 
@@ -246,7 +243,6 @@
 "@types/request@^2.47.0":
   version "2.48.1"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.1.tgz#e402d691aa6670fbbff1957b15f1270230ab42fa"
-  integrity sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==
   dependencies:
     "@types/caseless" "*"
     "@types/form-data" "*"
@@ -323,7 +319,6 @@ acorn@^5.2.1, acorn@^5.4.1:
 agent-base@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
-  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
   dependencies:
     es6-promisify "^5.0.0"
 
@@ -513,7 +508,6 @@ async@^1.5.2:
 async@^2.0.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
   dependencies:
     lodash "^4.17.10"
 
@@ -532,7 +526,6 @@ aws4@^1.6.0:
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
@@ -580,7 +573,6 @@ bcrypt-pbkdf@^1.0.0:
 big.js@^5.1.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 bignumber.js@^2.1.0:
   version "2.4.0"
@@ -1059,7 +1051,6 @@ compare-version@^0.1.2:
 compressible@^2.0.12:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.15.tgz#857a9ab0a7e5a07d8d837ed43fe2defff64fe212"
-  integrity sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==
   dependencies:
     mime-db ">= 1.36.0 < 2"
 
@@ -1106,7 +1097,6 @@ configstore@^3.0.0:
 configstore@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7"
-  integrity sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==
   dependencies:
     dot-prop "^4.1.0"
     graceful-fs "^4.1.2"
@@ -1427,7 +1417,6 @@ duplexify@^3.5.0:
 duplexify@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.1.tgz#b1a7a29c4abfd639585efaecce80d666b1e34125"
-  integrity sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==
   dependencies:
     end-of-stream "^1.0.0"
     inherits "^2.0.1"
@@ -1443,7 +1432,6 @@ ecc-jsbn@~0.1.1:
 ecdsa-sig-formatter@1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
-  integrity sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=
   dependencies:
     safe-buffer "^5.0.1"
 
@@ -1628,7 +1616,6 @@ es6-promise@^4.0.3, es6-promise@^4.0.5:
 es6-promisify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
 
@@ -1729,7 +1716,6 @@ express@^4.16.3:
 extend@^3.0.0, extend@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extend@~3.0.1:
   version "3.0.1"
@@ -1812,7 +1798,6 @@ find-up@^3.0.0:
 follow-redirects@^1.3.0:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
 
@@ -1894,7 +1879,6 @@ function-bind@^1.0.2, function-bind@^1.1.1:
 gcp-metadata@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-0.7.0.tgz#6c35dbb52bda32a427bb9c98f54237ddd1b5406f"
-  integrity sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==
   dependencies:
     axios "^0.18.0"
     extend "^3.0.1"
@@ -1903,7 +1887,6 @@ gcp-metadata@^0.7.0:
 gcs-resumable-upload@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/gcs-resumable-upload/-/gcs-resumable-upload-0.13.0.tgz#706e5c835e4c53cd5527b86013c9f4dda4bfcb14"
-  integrity sha512-hrSYPFJWyx8FDLJEK3XeqbNcCjkRqcuKSaUxL1RpwEAWAxtV+AdUH+NX3n7st/U6/JddQkdb1mmWAy3jgRDflw==
   dependencies:
     axios "^0.18.0"
     configstore "^4.0.0"
@@ -1978,7 +1961,6 @@ globby@^5.0.0:
 google-auth-library@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-2.0.1.tgz#32c6215e771538ef826cb65391a984a2c62ba57c"
-  integrity sha512-CWLKZxqYw4SE+fE3GWbVT9r/10h75w8lB3cdmmLpLtCfccFDcsI84qI5rx7npemlrHtKJh3C2HUz4s6SihCeIQ==
   dependencies:
     axios "^0.18.0"
     gcp-metadata "^0.7.0"
@@ -1992,7 +1974,6 @@ google-auth-library@^2.0.0:
 google-p12-pem@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-1.0.3.tgz#3d8acc140573339a5bca7b2f6a4b206bbea6d8d7"
-  integrity sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==
   dependencies:
     node-forge "^0.7.5"
     pify "^4.0.0"
@@ -2020,7 +2001,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
 gtoken@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-2.3.0.tgz#4e0ffc16432d7041a1b3dbc1d97aac17a5dc964a"
-  integrity sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==
   dependencies:
     axios "^0.18.0"
     google-p12-pem "^1.0.0"
@@ -2085,7 +2065,6 @@ hash-base@^3.0.0:
 hash-stream-validation@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz#ecc9b997b218be5bb31298628bb807869b73dcd1"
-  integrity sha1-7Mm5l7IYvluzEphii7gHhptz3NE=
   dependencies:
     through2 "^2.0.0"
 
@@ -2194,7 +2173,6 @@ https-browserify@^1.0.0:
 https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
-  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
@@ -2402,7 +2380,6 @@ is-retry-allowed@^1.0.0:
 is-stream-ended@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
-  integrity sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==
 
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2586,7 +2563,6 @@ jwa@^1.1.4:
 jwa@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
-  integrity sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==
   dependencies:
     buffer-equal-constant-time "1.0.1"
     ecdsa-sig-formatter "1.0.10"
@@ -2603,7 +2579,6 @@ jws@^3.1.4:
 jws@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
-  integrity sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==
   dependencies:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
@@ -2692,7 +2667,6 @@ lodash.isequal@^4.5.0:
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
-  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.memoize@~3.0.3:
   version "3.0.4"
@@ -2705,7 +2679,6 @@ lodash@^4.13.1:
 lodash@^4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -2728,7 +2701,6 @@ lru-cache@^4.0.1:
 lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -2805,7 +2777,6 @@ miller-rabin@^4.0.0:
 "mime-db@>= 1.36.0 < 2", mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
-  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
 
 mime-db@~1.33.0:
   version "1.33.0"
@@ -2814,7 +2785,6 @@ mime-db@~1.33.0:
 mime-types@^2.0.8:
   version "2.1.21"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
-  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
   dependencies:
     mime-db "~1.37.0"
 
@@ -2839,7 +2809,6 @@ mime@^1.2.11, mime@^1.3.4:
 mime@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
-  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
 
 mime@^2.3.1:
   version "2.3.1"
@@ -2940,7 +2909,6 @@ negotiator@0.6.1, negotiator@^0.6.1:
 node-fetch@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-forge@^0.7.1:
   version "0.7.5"
@@ -2949,7 +2917,6 @@ node-forge@^0.7.1:
 node-forge@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
-  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 node-uuid@~1.4.0:
   version "1.4.8"
@@ -3223,7 +3190,6 @@ pify@^3.0.0:
 pify@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
-  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -3341,7 +3307,6 @@ public-encrypt@^4.0.0:
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
-  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
@@ -3349,7 +3314,6 @@ pump@^2.0.0:
 pumpify@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
-  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
   dependencies:
     duplexify "^3.6.0"
     inherits "^2.0.3"
@@ -3479,7 +3443,6 @@ read-pkg@^1.0.0:
 "readable-stream@2 || 3":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
-  integrity sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -3671,12 +3634,10 @@ restify@^4.3.0:
 retry-axios@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-0.3.2.tgz#5757c80f585b4cc4c4986aa2ffd47a60c6d35e13"
-  integrity sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ==
 
 retry-request@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-4.0.0.tgz#5c366166279b3e10e9d7aa13274467a05cb69290"
-  integrity sha512-S4HNLaWcMP6r8E4TMH52Y7/pM8uNayOcTDDQNBwsCccL1uI+Ol2TljxRDPzaNfbhOB30+XWP5NnZkB3LiJxi1w==
   dependencies:
     through2 "^2.0.0"
 
@@ -3832,7 +3793,6 @@ single-line-log@^1.1.2:
 snakeize@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/snakeize/-/snakeize-0.1.0.tgz#10c088d8b58eb076b3229bb5a04e232ce126422d"
-  integrity sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0=
 
 sntp@2.x.x:
   version "2.1.0"
@@ -3907,7 +3867,6 @@ speedometer@~0.1.2:
 split-array-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/split-array-stream/-/split-array-stream-2.0.0.tgz#85a4f8bfe14421d7bca7f33a6d176d0c076a53b1"
-  integrity sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==
   dependencies:
     is-stream-ended "^0.1.4"
 
@@ -3968,7 +3927,6 @@ stream-events@^1.0.1:
 stream-events@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
-  integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
   dependencies:
     stubs "^3.0.0"
 
@@ -4035,7 +3993,6 @@ string-width@^2.0.0, string-width@^2.1.1:
 string_decoder@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
-  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -4152,7 +4109,6 @@ tdigest@^0.1.1:
 teeny-request@^3.11.0:
   version "3.11.3"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
-  integrity sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==
   dependencies:
     https-proxy-agent "^2.2.1"
     node-fetch "^2.2.0"
@@ -4191,7 +4147,6 @@ through2@^2.0.0:
 through2@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.0.tgz#468b461df9cd9fcc170f22ebf6852e467e578ff2"
-  integrity sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==
   dependencies:
     readable-stream "2 || 3"
     xtend "~4.0.1"
@@ -4304,7 +4259,6 @@ typedarray@^0.0.6, typedarray@~0.0.5:
 typescript@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 umd@^3.0.0:
   version "3.0.3"
@@ -4400,7 +4354,6 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
* The cloud function and enclosing package follow the example of `metrics_server`.
* It receives Sentry events via webhook integration, extracts the data and posts it as form data to Salesforce.
* Infers whether the event is from development or production and posts to the corresponding Salesforce endpoint.
