### PR TITLE
Upgrades and localhost fix

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 # See versions at https://hub.docker.com/_/node/
-FROM node:8.11.3-alpine
+FROM node:8.14.0-alpine
 
 # Versions can be found at https://github.com/Jigsaw-Code/outline-ss-server/releases
-ARG SS_VERSION=1.0.2
+ARG SS_VERSION=1.0.3
 
 # Save metadata on the software versions we are using.
 LABEL shadowbox.node_version=8.11.3

--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM node:8.14.0-alpine
 ARG SS_VERSION=1.0.3
 
 # Save metadata on the software versions we are using.
-LABEL shadowbox.node_version=8.11.3
+LABEL shadowbox.node_version=8.14.0
 LABEL shadowbox.outline-ss-server_version="${SS_VERSION}"
 
 ARG GITHUB_RELEASE

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -138,7 +138,9 @@ async function main() {
   logging.info('Starting...');
 
   const prometheusPort = await portProvider.reserveFirstFreePort(9090);
-  const prometheusLocation = `localhost:${prometheusPort}`;
+  // Use 127.0.0.1 instead of localhost for Prometheus because it's resolving incorrectly for some users.
+  // See https://github.com/Jigsaw-Code/outline-server/issues/341
+  const prometheusLocation = `127.0.0.1:${prometheusPort}`;
 
   const nodeMetricsPort = await portProvider.reserveFirstFreePort(prometheusPort + 1);
   exportPrometheusMetrics(prometheus.register, nodeMetricsPort);


### PR DESCRIPTION
I'm upgrading the node and outline-ss-server versions and also making a change that should fix https://github.com/Jigsaw-Code/outline-server/issues/341.

I expect to be able to release this today.