### PR TITLE
Add API spec

### DIFF
--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -14,7 +14,7 @@ To install and run Shadowbox on your own server, run
 sudo bash -c "$(wget -qO- https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/server_manager/install_scripts/install_server.sh)"
 ```
 
-Use `bash -x` instead at the end of the command if you need to debug the installation.
+Use `sudo --preserve-env` if you need to pass environment variables. Use `bash -x` if you need to debug the installation.
 
 ## Running from source code
 
@@ -25,24 +25,15 @@ Besides [Node](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/e
 1. [Docker 1.13+](https://docs.docker.com/engine/installation/)
 1. [docker-compose 1.11+](https://docs.docker.com/compose/install/)
 
-Run `docker info` and make sure `Storage Driver` is `devicemapper`. If it is
-not, you can override it by editing `/etc/default/docker` or by passing
-another storage driver in the daemon commandline:
-```
-sudo dockerd --storage-driver=devicemapper
-```
-
 ### Running Shadowbox as a Node.js app
 
-Build the server as a Node.js app:
+> **NOTE:**: This is currently broken. Use the docker option instead.
+
+Build and run the server as a Node.js app:
 ```
-yarn do shadowbox/server/build
+yarn do shadowbox/server/run
 ```
 The output will be at `build/shadowbox/app`.
-
-
-You can see how to run the server at [`shadowbox/server/run_action.sh`](server/run_action.sh).
-
 
 ### Running Shadowbox as a Docker container
 
@@ -52,14 +43,19 @@ testing section below.
 
 ### With docker command
 
-Build the `outline/shadowbox` Docker image:
-```
-yarn do shadowbox/docker/build
-```
-
-Run server:
+Build the image and run server:
 ```
 yarn do shadowbox/docker/run
+```
+
+You should be able to successfully query the management API:
+```
+curl --insecure https://[::]:8081/TestApiPrefix/server
+```
+
+To build the image only:
+```
+yarn do shadowbox/docker/build
 ```
 
 Debug image:
@@ -72,7 +68,6 @@ Or a running container:
 docker exec -it shadowbox sh
 ```
 
-
 Delete dangling images:
 ```
 docker rmi $(docker images -f dangling=true -q)
@@ -81,7 +76,14 @@ docker rmi $(docker images -f dangling=true -q)
 
 ## Access Keys Management API
 
-In order to utilize the Management API, you'll need to know the apiUrl for your Outline server. You can obtain this information from the 'access.txt' file under the 'shadowbox' directory of your server. An example apiUrl is: https://1.2.3.4:1234/3pQ4jf6qSr5WVeMO0XOo4z. 
+In order to utilize the Management API, you'll need to know the apiUrl for your Outline server.
+You can obtain this information from the "Settings" tab of the server page in the Outline Manager.
+Alternatively, you can check the 'access.txt' file under the '/opt/outline' directory of an Outline server. An example apiUrl is: https://1.2.3.4:1234/3pQ4jf6qSr5WVeMO0XOo4z. 
+
+See [Full API Documentation](https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/shadowbox/server/api.yml).
+The OpenAPI specification can be found at [api.yml](./api.yml).
+
+### Examples
 
 Start by storing the apiURL you see see in that file, as a variable. For example:
 ```
@@ -90,70 +92,27 @@ API_URL=https://1.2.3.4:1234/3pQ4jf6qSr5WVeMO0XOo4z
 
 You can then perform the following operations on the server, remotely.
 
-List users
+List access keys
 ```
 curl --insecure $API_URL/access-keys/
 ```
 
-Create a user
+Create an access keys
 ```
 curl --insecure -X POST $API_URL/access-keys
 ```
 
-Rename a user
-(e.g. rename user ID 2 to 'albion')
+Rename an access keys
+(e.g. rename access key 2 to 'albion')
 ```
 curl --insecure -X PUT curl -F 'name=albion' $API_URL/access-keys/2/name
 ```
 
-Remove a user
-(e.g. remove user ID 2)
+Remove as access keys
+(e.g. remove access key 2)
 ```
 curl --insecure -X DELETE $API_URL/access-keys/2
 ```
-
-<details>
-<summary>
-Example output
-</summary>
-
-```
-$ API_URL=https://1.2.3.4:1234/3pQ4jf6qSr5WVeMO0XOo4z
-$ curl --insecure $API_URL/access-keys
-{"users":[]}
-
-$ curl --insecure -X POST $API_URL/access-keys
-{"id":"0","password":"Nm9wtQkPeshs","port":34180}
-
-$ curl --insecure -X POST $API_URL/access-keys
-{"id":"1","password":"32mW3jhuhBGv","port":55625}
-
-$ curl --insecure -X POST $API_URL/access-keys
-{"id":"2","password":"jFOKrJcpbgIb","port":15884}
-
-$ curl --insecure $API_URL/access-keys
-{"users":[{"id":"0","password":"Nm9wtQkPeshs","port":34180},{"id":"1","password":"32mW3jhuhBGv","port":55625},{"id":"2","password":"jFOKrJcpbgIb","port":15884}]}
-
-$ curl --insecure -X DELETE $API_URL/access-keys/0 -v
-* Hostname was NOT found in DNS cache
-*   Trying ::1...
-* Connected to 1.2.3.4 (::1) port 1234 (#0)
-> DELETE /access-keys/0 HTTP/1.1
-> User-Agent: curl/7.35.0
-> Host: 1.2.3.4:1234
-> Accept: */*
->
-< HTTP/1.1 204 No Content
-< Date: Fri, 03 Feb 2017 22:46:39 GMT
-< Connection: keep-alive
-<
-* Connection #0 to host 1.2.3.4 left intact
-
-$ curl --insecure $API_URL/access-keys
-{"users":[{"id":"1","password":"32mW3jhuhBGv","port":55625},{"id":"2","password":"jFOKrJcpbgIb","port":15884}]}
-```
-</details>
-
 
 ## Testing
 

--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -97,18 +97,18 @@ List access keys
 curl --insecure $API_URL/access-keys/
 ```
 
-Create an access keys
+Create an access key
 ```
 curl --insecure -X POST $API_URL/access-keys
 ```
 
-Rename an access keys
+Rename an access key
 (e.g. rename access key 2 to 'albion')
 ```
 curl --insecure -X PUT curl -F 'name=albion' $API_URL/access-keys/2/name
 ```
 
-Remove as access keys
+Remove an access key
 (e.g. remove access key 2)
 ```
 curl --insecure -X DELETE $API_URL/access-keys/2

--- a/src/shadowbox/docker/run_action.sh
+++ b/src/shadowbox/docker/run_action.sh
@@ -16,7 +16,7 @@
 
 do_action shadowbox/docker/build
 
-OUTLINE_DIR=/tmp/outline
+readonly OUTLINE_DIR=/tmp/outline
 touch "$OUTLINE_DIR/config.json"
 source $ROOT_DIR/src/shadowbox/scripts/make_test_certificate.sh "${OUTLINE_DIR}"
 

--- a/src/shadowbox/docker/run_action.sh
+++ b/src/shadowbox/docker/run_action.sh
@@ -14,19 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-touch /tmp/config.json
-source $ROOT_DIR/src/shadowbox/scripts/make_certificate.sh
+do_action shadowbox/docker/build
+
+OUTLINE_DIR=/tmp/outline
+touch "$OUTLINE_DIR/config.json"
+source $ROOT_DIR/src/shadowbox/scripts/make_test_certificate.sh "${OUTLINE_DIR}"
 
 # TODO: mount a folder rather than individual files.
 declare -a docker_bindings=(
-  -v /tmp/config.json:/root/shadowbox/shadowbox_config.json
-  -v /tmp/stats.json:/root/shadowbox/shadowbox_stats.json
+  -v "$OUTLINE_DIR/config.json":/root/shadowbox/shadowbox_config.json
+  -v "$OUTLINE_DIR/stats.json":/root/shadowbox/shadowbox_stats.json
   -v ${SB_CERTIFICATE_FILE}:${SB_CERTIFICATE_FILE}
   -v ${SB_PRIVATE_KEY_FILE}:${SB_PRIVATE_KEY_FILE}
   -e "LOG_LEVEL=${LOG_LEVEL:-debug}"
   -e SB_API_PREFIX=TestApiPrefix
-  -e SB_CERTIFICATE_FILE
-  -e SB_PRIVATE_KEY_FILE
+  -e SB_CERTIFICATE_FILE=${SB_CERTIFICATE_FILE}
+  -e SB_PRIVATE_KEY_FILE=${SB_PRIVATE_KEY_FILE}
 )
 export DOCKER_CONTENT_TRUST=${DOCKER_CONTENT_TRUST:-1}
-docker run --rm -it --network=host --name shadowbox "${docker_bindings[@]}" outline/shadowbox
+sudo docker run --rm -it --network=host --name shadowbox "${docker_bindings[@]}" outline/shadowbox

--- a/src/shadowbox/docker/run_action.sh
+++ b/src/shadowbox/docker/run_action.sh
@@ -31,5 +31,5 @@ declare -a docker_bindings=(
   -e SB_CERTIFICATE_FILE=${SB_CERTIFICATE_FILE}
   -e SB_PRIVATE_KEY_FILE=${SB_PRIVATE_KEY_FILE}
 )
-export DOCKER_CONTENT_TRUST=${DOCKER_CONTENT_TRUST:-1}
+
 docker run --rm -it --network=host --name shadowbox "${docker_bindings[@]}" outline/shadowbox

--- a/src/shadowbox/docker/run_action.sh
+++ b/src/shadowbox/docker/run_action.sh
@@ -32,4 +32,4 @@ declare -a docker_bindings=(
   -e SB_PRIVATE_KEY_FILE=${SB_PRIVATE_KEY_FILE}
 )
 export DOCKER_CONTENT_TRUST=${DOCKER_CONTENT_TRUST:-1}
-sudo docker run --rm -it --network=host --name shadowbox "${docker_bindings[@]}" outline/shadowbox
+docker run --rm -it --network=host --name shadowbox "${docker_bindings[@]}" outline/shadowbox

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -77,7 +77,7 @@ function cleanup() {
   (($DEBUG != 0)) && set -x
 
   # Make the certificate
-  source ../scripts/make_certificate.sh
+  source ../scripts/make_test_certificate.sh /tmp
 
   # Ensure proper shut down on exit if not in debug mode
   trap "cleanup" EXIT

--- a/src/shadowbox/scripts/make_test_certificate.sh
+++ b/src/shadowbox/scripts/make_test_certificate.sh
@@ -17,7 +17,7 @@
 # Make a certificate for development purposes, and populate the
 # corresponding environment variables.
 
-CERTIFICATE_NAME="$1/shadowbox-selfsigned-dev"
+readonly CERTIFICATE_NAME="$1/shadowbox-selfsigned-dev"
 export SB_CERTIFICATE_FILE="${CERTIFICATE_NAME}.crt"
 export SB_PRIVATE_KEY_FILE="${CERTIFICATE_NAME}.key"
 declare -a openssl_req_flags=(

--- a/src/shadowbox/scripts/make_test_certificate.sh
+++ b/src/shadowbox/scripts/make_test_certificate.sh
@@ -16,7 +16,8 @@
 
 # Make a certificate for development purposes, and populate the
 # corresponding environment variables.
-CERTIFICATE_NAME='/tmp/shadowbox-selfsigned-dev'
+
+CERTIFICATE_NAME="$1/shadowbox-selfsigned-dev"
 export SB_CERTIFICATE_FILE="${CERTIFICATE_NAME}.crt"
 export SB_PRIVATE_KEY_FILE="${CERTIFICATE_NAME}.key"
 declare -a openssl_req_flags=(

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -3,10 +3,17 @@ info:
   title: Outline Server Management
   description: API to manage an Outline server.
   version: '1.0'
+tags:
+  - name: Server
+    description: Server-level functions
+  - name: Access Key
+    description: Access key functions
 paths:
   /name:
     put:
       description: Renames the server
+      tags:
+        - Server
       requestBody:
         required: true
         content: 
@@ -26,6 +33,8 @@ paths:
           description: Invalid name
   /server:
     get:
+      tags:
+        - Server
       description: Returns information about the server
       responses:
         '200':
@@ -41,6 +50,8 @@ paths:
   /access-keys:
     post:
       description: Creates a new access key
+      tags:
+        - Access Key
       responses:
         '201':
           description: The newly created access key
@@ -49,7 +60,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/AccessKey"
               examples:
-                # TODO: Sanitize
                 '0':
                   value: >-
                     {"id":"0","name":"First","password":"XxXxXx","port":9795,"method":"chacha20-ietf-poly1305","accessUrl":"ss://SADFJSKADFJAKSD@0.0.0.0:9795/?outline=1"}
@@ -58,6 +68,8 @@ paths:
                     {"id":"1","name":"Second","password":"xXxXxX","port":9795,"method":"chacha20-ietf-poly1305","accessUrl":"ss://ASDFHAKSDFSDAKFJ@0.0.0.0:9795/?outline=1"}
     get:
       description: Lists the access keys
+      tags:
+        - Access Key
       responses:
         '200':
           description: List of access keys
@@ -80,6 +92,8 @@ paths:
   /access-keys/{id}:
     delete:
       description: Deletes an access key
+      tags:
+        - Access Key
       parameters:
         - name: id
           in: path
@@ -109,6 +123,8 @@ paths:
   /access-keys/{id}/name:
     put:
       description: Renames an access key
+      tags:
+        - Access Key
       parameters:
         - name: id
           in: path
@@ -133,6 +149,8 @@ paths:
   /metrics/transfer:
     get:
       description: Returns the data transferred per user
+      tags:
+        - Access Key
       responses:
         '200':
           description: The data tranferred by user
@@ -151,6 +169,8 @@ paths:
   /metrics/enabled:
     get:
       description: Returns whether metrics is being shared
+      tags:
+        - Server
       responses:
         '200':
           description: The metrics enabled setting
@@ -166,6 +186,8 @@ paths:
                   value: '{"metricsEnabled":true}'
     put:
       description: Enables or disables sharing of metrics
+      tags:
+        - Server
       requestBody:
         required: true
         content: 
@@ -214,4 +236,3 @@ components:
           type: string
         accessUrl:
           type: string
-      

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -8,6 +8,9 @@ tags:
     description: Server-level functions
   - name: Access Key
     description: Access key functions
+servers: 
+  - url: https://example.com/SecretPath
+    description: Example URL. Change to your own server.  
 paths:
   /server:
     get:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -1,0 +1,217 @@
+openapi: 3.0.1
+info:
+  title: Outline Server Management
+  description: API to manage an Outline server.
+  version: '1.0'
+paths:
+  /name:
+    put:
+      description: Renames the server
+      requestBody:
+        required: true
+        content: 
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+            examples:
+              '0':
+                value: '{"name":"My Server"}'
+      responses:
+        '204':
+          description: Server renamed successfully
+        '400':
+          description: Invalid name
+  /server:
+    get:
+      description: Returns information about the server
+      responses:
+        '200':
+          description: Server information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Server"
+              examples:
+                '0':
+                  value: >-
+                    {"name":"My Server","serverId":"000-000-000-000","metricsEnabled":true,"createdTimestampMs":1536613192052,"portForNewAccessKeys":1234}
+  /access-keys:
+    post:
+      description: Creates a new access key
+      responses:
+        '201':
+          description: The newly created access key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessKey"
+              examples:
+                # TODO: Sanitize
+                '0':
+                  value: >-
+                    {"id":"0","name":"First","password":"XxXxXx","port":9795,"method":"chacha20-ietf-poly1305","accessUrl":"ss://SADFJSKADFJAKSD@0.0.0.0:9795/?outline=1"}
+                '1':
+                  value: >-
+                    {"id":"1","name":"Second","password":"xXxXxX","port":9795,"method":"chacha20-ietf-poly1305","accessUrl":"ss://ASDFHAKSDFSDAKFJ@0.0.0.0:9795/?outline=1"}
+    get:
+      description: Lists the access keys
+      responses:
+        '200':
+          description: List of access keys
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessKeys:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AccessKey"
+              examples:
+                '0':
+                  value: >-
+                    {"accessKeys":[
+                      {"id":"0","name":"Admin","password":"XxXxXx","port":18162,"method":"chacha20-ietf-poly1305","accessUrl":"ss://SADFJSKADFJAKSD@0.0.0.0:18162/?outline=1"},
+                      {"id":"1","name":"First","password":"xXxXxX","port":4410,"method":"chacha20-ietf-poly1305","accessUrl":"ss://ASDFSADJFKAS=@0.0.0.0:4410/?outline=1"},
+                      {"id":"2","name":"Second","password":"XxXxXx","port":25424,"method":"chacha20-ietf-poly1305","accessUrl":"ss://ASDFHAKSDFSDAKFJ@0.0.0.0:25424/?outline=1"}]}
+  /access-keys/{id}:
+    delete:
+      description: Deletes an access key
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the access key to delete
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Access key deleted successfully
+        '404':
+          description: Access key inexistent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
+              examples:
+                '0':
+                  value: >-
+                    {"code":"NotFoundError","message":"No access key found with
+                    id 9"}
+  /access-keys/{id}/name:
+    put:
+      description: Renames an access key
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the access key to rename
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content: 
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '204':
+          description: Access key renamed successfully
+        '404':
+          description: Access key inexistent
+  /metrics/transfer:
+    get:
+      description: Returns the data transferred per user
+      responses:
+        '200':
+          description: The data tranferred by user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bytesTransferredByUserId:
+                    type: object
+                    additionalProperties:
+                      type: integer
+              examples:
+                '0':
+                  value: '{"bytesTransferredByUserId":{"1":1008040941,"2":5958113497,"3":752221577}}'
+  /metrics/enabled:
+    get:
+      description: Returns whether metrics is being shared
+      responses:
+        '200':
+          description: The metrics enabled setting
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metricsEnabled:
+                    type: boolean
+              examples:
+                '0':
+                  value: '{"metricsEnabled":true}'
+    put:
+      description: Enables or disables sharing of metrics
+      requestBody:
+        required: true
+        content: 
+          application/json:
+            schema:
+              type: object
+              properties:
+                metricsEnabled:
+                  type: boolean
+            examples:
+              '0':
+                value: '{"metricsEnabled": true}'
+      responses:
+        '204':
+          description: Setting successful
+        '400':
+          description: Invalid request
+          
+components:
+  schemas:
+    Server:
+      properties:
+        name:
+          type: string
+        serverId:
+          type: string
+        metricsEnabled:
+          type: boolean
+        createdTimestampMs:
+          type: number
+        portForNewAccessKeys:
+          type: integer
+    AccessKey:
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        password:
+          type: string
+        port:
+          type: integer
+        method:
+          type: string
+        accessUrl:
+          type: string
+      

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Outline Server Management
-  description: API to manage an Outline server.
+  description: API to manage an Outline server. See [getoutline.org](https://getoutline.org).
   version: '1.0'
 tags:
   - name: Server

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -9,6 +9,22 @@ tags:
   - name: Access Key
     description: Access key functions
 paths:
+  /server:
+    get:
+      tags:
+        - Server
+      description: Returns information about the server
+      responses:
+        '200':
+          description: Server information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Server"
+              examples:
+                '0':
+                  value: >-
+                    {"name":"My Server","serverId":"000-000-000-000","metricsEnabled":true,"createdTimestampMs":1536613192052,"portForNewAccessKeys":1234}
   /name:
     put:
       description: Renames the server
@@ -31,22 +47,6 @@ paths:
           description: Server renamed successfully
         '400':
           description: Invalid name
-  /server:
-    get:
-      tags:
-        - Server
-      description: Returns information about the server
-      responses:
-        '200':
-          description: Server information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Server"
-              examples:
-                '0':
-                  value: >-
-                    {"name":"My Server","serverId":"000-000-000-000","metricsEnabled":true,"createdTimestampMs":1536613192052,"portForNewAccessKeys":1234}
   /access-keys:
     post:
       description: Creates a new access key
@@ -148,12 +148,12 @@ paths:
           description: Access key inexistent
   /metrics/transfer:
     get:
-      description: Returns the data transferred per user
+      description: Returns the data transferred per access key
       tags:
         - Access Key
       responses:
         '200':
-          description: The data tranferred by user
+          description: The data tranferred by each access key
           content:
             application/json:
               schema:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -9,7 +9,7 @@ tags:
   - name: Access Key
     description: Access key functions
 servers: 
-  - url: https://example.com/SecretPath
+  - url: https://myserver/SecretPath
     description: Example URL. Change to your own server.  
 paths:
   /server:

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -113,7 +113,7 @@ export class ShadowsocksManagerService {
   // Lists all access keys
   public listAccessKeys(req: RequestType, res: ResponseType, next: restify.Next): void {
     logging.debug(`listAccessKeys request ${JSON.stringify(req.params)}`);
-    const response = {accessKeys: [], users: []};
+    const response = {accessKeys: []};
     for (const accessKey of this.accessKeys.listAccessKeys()) {
       response.accessKeys.push(accessKeyToJson(accessKey));
     }

--- a/src/shadowbox/server/run_action.sh
+++ b/src/shadowbox/server/run_action.sh
@@ -21,8 +21,10 @@ export SB_PUBLIC_IP="${SB_PUBLIC_IP:-$(curl https://ipinfo.io/ip)}"
 # WARNING: The SB_API_PREFIX should be kept secret!
 export SB_API_PREFIX=TestApiPrefix
 export SB_METRICS_URL=https://metrics-test.uproxy.org
-export SB_STATE_DIR=/tmp
+export SB_STATE_DIR=/tmp/outline
 
-source $ROOT_DIR/src/shadowbox/scripts/make_certificate.sh
+source $ROOT_DIR/src/shadowbox/scripts/make_test_certificate.sh $SB_STATE_DIR
 
+# This will fail because it expects prometheus and outline-ss-server to be in /root/shadowbox/bin.
+# TODO: Fix it
 node $BUILD_DIR/shadowbox/app/server/main

--- a/src/shadowbox/server/run_action.sh
+++ b/src/shadowbox/server/run_action.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo "** Currently broken, use yarn do shadowbox/docker/run instead **" >&2
+exit 1
+
 do_action shadowbox/server/build
 
 export LOG_LEVEL="${LOG_LEVEL:-debug}"


### PR DESCRIPTION
This creates an OpenAPI 3.0 spec for our management API, which can be used to document our API and generate client code.

You can see the new API documentation from the spec here: https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/Jigsaw-Code/outline-server/fortuna-api/src/shadowbox/server/api.yml