### PR TITLE
just build appimage for linux

### DIFF
--- a/src/server_manager/electron_app/package_linux_action.sh
+++ b/src/server_manager/electron_app/package_linux_action.sh
@@ -16,29 +16,13 @@
 
 yarn do server_manager/electron_app/build
 
-# Auto-updates only work for AppImage:
-# https://github.com/electron-userland/electron-builder/issues/2498
 $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
   --projectDir=build/server_manager/electron_app/static \
   --config.asarUnpack=server_manager/web_app/images \
   --publish=never \
   --config.publish.provider=generic \
   --config.publish.url=https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/ \
-  --x64 \
   --linux AppImage \
   --config.linux.icon=icons/png \
   --config.linux.category=Network \
   --config.artifactName='Outline-Manager.${ext}'
-
-for arch in ia32 x64; do
-  $ROOT_DIR/src/server_manager/node_modules/.bin/electron-builder \
-    --projectDir=build/server_manager/electron_app/static \
-    --config.asarUnpack=server_manager/web_app/images \
-    --publish=never \
-    --$arch \
-    --linux deb rpm tar.gz \
-    --config.linux.icon=icons/png \
-    --config.linux.category=Network \
-    --config.artifactName='Outline-Manager-'${arch}'.${ext}'
-
-done


### PR DESCRIPTION
We're building Linux in several formats without any reason to believe anyone is using them - let's just build the AppImage since that's what we distribute, supports auto-update, and is mostly what we use ourselves.