### PR TITLE
Update outline-ss-server to v1.0.4

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -16,7 +16,7 @@
 FROM node:8.14.0-alpine
 
 # Versions can be found at https://github.com/Jigsaw-Code/outline-ss-server/releases
-ARG SS_VERSION=1.0.3
+ARG SS_VERSION=1.0.4
 
 # Save metadata on the software versions we are using.
 LABEL shadowbox.node_version=8.14.0


### PR DESCRIPTION
* Updates outline-ss-server to [v1.0.4](https://github.com/Jigsaw-Code/outline-ss-server/releases/tag/v1.0.4).
* Modifies the integration test to fetch a public URL through shadowbox, since v1.0.4 restricts access to the the server's LAN. The integration test validates that the server's LAN is indeed not accessible.
