### PR TITLE
Add flags for hostname and ports

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -445,7 +445,7 @@ function is_valid_port() {
 }
 
 function parse_flags() {
-  local params=$(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@")
+  local params=$(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@" || exit 1)
   eval set -- $params
   declare -g FLAGS_HOSTNAME=""
   declare -gi FLAGS_API_PORT=0

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -30,7 +30,7 @@
 #
 # Deprecated:
 # SB_PUBLIC_IP: Use the --hostname flag instead
-# SB_API_PORT: Use the --port-for-api flag instead
+# SB_API_PORT: Use the --apit-port flag instead
 
 # Requires curl and docker to be installed
 
@@ -38,11 +38,11 @@ set -euo pipefail
 
 function display_usage() {
   cat <<EOF
-Usage: install_server.sh [--hostname <hostname>] [--port-for-api <port>] [--port-for-keys <port>]
+Usage: install_server.sh [--hostname <hostname>] [--apit-port <port>] [--keys-port <port>]
 
-  --hostname        The hostname to be used to access the management API and access keys
-  --port-for-api    The port number for the management API
-  --port-for-keys   The port number for the access keys
+  --hostname   The hostname to be used to access the management API and access keys
+  --api-port   The port number for the management API
+  --keys-port  The port number for the access keys
 EOF
 }
 

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Script to install a shadowbox docker container, a watchtower docker container
-# (to automatically update shadowbox), and to create a new shadowbox user.
+# Script to install the Outline Server docker container, a watchtower docker container
+# (to automatically update the server), and to create a new Outline user.
 
 # You may set the following environment variables, overriding their defaults:
-# SB_IMAGE: Shadowbox Docker image to install, e.g. quay.io/outline/shadowbox:nightly
+# SB_IMAGE: The Outline Server Docker image to install, e.g. quay.io/outline/shadowbox:nightly
 # SB_API_PORT: The port number of the management API.
-# SHADOWBOX_DIR: Directory for persistent Shadowbox state.
-# SB_PUBLIC_IP: The public hostname for Shadowbox.
+# SHADOWBOX_DIR: Directory for persistent Outline Server state.
+# SB_PUBLIC_IP: The public hostname for the Outline Server.
 # ACCESS_CONFIG: The location of the access config text file.
 # SB_DEFAULT_SERVER_NAME: Default name for this server, e.g. "Outline server New York".
 #     This name will be used for the server until the admins updates the name
@@ -33,6 +33,14 @@
 # Requires curl and docker to be installed
 
 set -euo pipefail
+
+function display_usage() {
+  echo Usage: install_server.sh [--hostname <hostname>] [--port-for-api <port>] [--port-for-keys <port>]
+  echo
+  echo  --hostname        The hostname to be used to access the management API and access keys
+  echo  --port-for-api    The port number for the management API
+  echo  --port-for-keys   The port number for the access keys
+}
 
 readonly SENTRY_LOG_FILE=${SENTRY_LOG_FILE:-}
 
@@ -189,7 +197,7 @@ function create_persisted_state_dir() {
   chmod g+s "${STATE_DIR}"
 }
 
-# Generate a secret key for access to the shadowbox API and store it in a tag.
+# Generate a secret key for access to the Management API and store it in a tag.
 # 16 bytes = 128 bits of entropy should be plenty for this use.
 function safe_base64() {
   # Implements URL-safe base64 of stdin, stripping trailing = chars.
@@ -296,7 +304,7 @@ function start_watchtower() {
   fi
 }
 
-# Waits for Shadowbox to be up and healthy
+# Waits for the service to be up and healthy
 function wait_shadowbox() {
   # We use insecure connection because our threat model doesn't include localhost port
   # interception and our certificate doesn't have localhost as a subject alternative name
@@ -422,12 +430,6 @@ $(echo -e "\033[1;32m{\"apiUrl\":\"$(get_field_value apiUrl)\",\"certSha256\":\"
 ${FIREWALL_STATUS}
 END_OF_SERVER_OUTPUT
 } # end of install_shadowbox
-
-function display_usage() {
-  echo Usage: install_server.sh [--hostname <hostname>] [--port-for-api <port>] [--port-for-keys <port>]
-  echo
-  echo  --hostname   The hostname to be used to access the management API and access keys.
-}
 
 function read_param() {
   if (( "$#" < 2 )); then

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -445,7 +445,8 @@ function is_valid_port() {
 }
 
 function parse_flags() {
-  eval set -- $(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@")
+  local params=$(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@")
+  eval set -- $params
   declare -g FLAGS_HOSTNAME=""
   declare -gi FLAGS_API_PORT=0
   declare -gi FLAGS_KEYS_PORT=0

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -445,7 +445,8 @@ function is_valid_port() {
 }
 
 function parse_flags() {
-  local params=$(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@" || exit 1)
+  params=$(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@")
+  [[ $? == 0 ]] || exit 1
   eval set -- $params
   declare -g FLAGS_HOSTNAME=""
   declare -gi FLAGS_API_PORT=0

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -30,7 +30,7 @@
 #
 # Deprecated:
 # SB_PUBLIC_IP: Use the --hostname flag instead
-# SB_API_PORT: Use the --apit-port flag instead
+# SB_API_PORT: Use the --api-port flag instead
 
 # Requires curl and docker to be installed
 
@@ -38,7 +38,7 @@ set -euo pipefail
 
 function display_usage() {
   cat <<EOF
-Usage: install_server.sh [--hostname <hostname>] [--apit-port <port>] [--keys-port <port>]
+Usage: install_server.sh [--hostname <hostname>] [--api-port <port>] [--keys-port <port>]
 
   --hostname   The hostname to be used to access the management API and access keys
   --api-port   The port number for the management API

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -371,7 +371,7 @@ install_shadowbox() {
   log_for_sentry "Setting API port"
   API_PORT="${FLAGS_API_PORT}"
   if [[ $API_PORT == 0 ]]; then
-    API_PORT = ${SB_API_PORT:-$(get_random_port)}
+    API_PORT=${SB_API_PORT:-$(get_random_port)}
   fi
   readonly ACCESS_CONFIG=${ACCESS_CONFIG:-$SHADOWBOX_DIR/access.txt}
   readonly SB_IMAGE=${SB_IMAGE:-quay.io/outline/shadowbox:stable}

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -17,9 +17,7 @@
 
 # You may set the following environment variables, overriding their defaults:
 # SB_IMAGE: The Outline Server Docker image to install, e.g. quay.io/outline/shadowbox:nightly
-# SB_API_PORT: The port number of the management API.
 # SHADOWBOX_DIR: Directory for persistent Outline Server state.
-# SB_PUBLIC_IP: The public hostname for the Outline Server.
 # ACCESS_CONFIG: The location of the access config text file.
 # SB_DEFAULT_SERVER_NAME: Default name for this server, e.g. "Outline server New York".
 #     This name will be used for the server until the admins updates the name
@@ -29,6 +27,10 @@
 #     only by do_install_server.sh.
 # WATCHTOWER_REFRESH_SECONDS: refresh interval in seconds to check for updates,
 #     defaults to 3600.
+#
+# Deprecated:
+# SB_PUBLIC_IP: Use the --hostname flag instead
+# SB_API_PORT: Use the --port-for-api flag instead
 
 # Requires curl and docker to be installed
 

--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -14,6 +14,11 @@ To install and run Shadowbox on your own server, run
 sudo bash -c "$(wget -qO- https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/server_manager/install_scripts/install_server.sh)"
 ```
 
+You can specify flags to customize the installation. For example, to use hostname `myserver.com` and the port 443 for access keys, you can run:
+```
+sudo bash -c "$(wget -qO- https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/server_manager/install_scripts/install_server.sh)" install_server.sh --hostname=myserver.com --keys-port=443
+```
+
 Use `sudo --preserve-env` if you need to pass environment variables. Use `bash -x` if you need to debug the installation.
 
 ## Running from source code


### PR DESCRIPTION
This will allow advanced users to easily specify a domain name for their server, and what ports to use.

Example use:
```
sudo bash -c "$(wget -qO- https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/server_manager/install_scripts/install_server.sh)" \
    install_server.sh --hostname=outline.mydomain.com --keys-port=443 --api-port=8443
```
