### PR TITLE
Clarify whether or not a server is sharing metrics data

### DIFF
--- a/src/server_manager/bower.json
+++ b/src/server_manager/bower.json
@@ -34,7 +34,6 @@
     "paper-progress": "PolymerElements/paper-progress#^2.0.1",
     "paper-tabs": "PolymerElements/paper-tabs#^2.1.1",
     "paper-toast": "PolymerElements/paper-toast#^2.0.0",
-    "paper-toggle-button": "PolymerElements/paper-toggle-button#^2.0.0",
     "web-animations-js": "web-animations/web-animations-js",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^v1.1.0"
   }

--- a/src/server_manager/bower.json
+++ b/src/server_manager/bower.json
@@ -23,6 +23,7 @@
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^2.1.0",
     "iron-pages": "PolymerElements/iron-pages#^2.0.1",
     "paper-button": "PolymerElements/paper-button#^2.0.0",
+    "paper-checkbox": "PolymerElements/paper-checkbox#^2.0.4",
     "paper-dialog": "PolymerElements/paper-dialog#^2.0.1",
     "paper-dialog-scrollable": "PolymerElements/paper-dialog-scrollable#^2.1.0",
     "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^2.0.2",

--- a/src/server_manager/ui_components/licenses/licenses.txt
+++ b/src/server_manager/ui_components/licenses/licenses.txt
@@ -1973,7 +1973,7 @@ The following software may be included in this product: paper-toast. A copy of t
 
 -----
 
-The following software may be included in this product: paper-toggle-button. A copy of the source code may be downloaded from https://github.com/PolymerElements/paper-toggle-button. This software contains the following license and notice below:
+The following software may be included in this product: paper-checkbox. A copy of the source code may be downloaded from https://github.com/PolymerElements/paper-checkbox. This software contains the following license and notice below:
 
 // Copyright (c) 2014 The Polymer Authors. All rights reserved.
 //

--- a/src/server_manager/ui_components/outline-server-settings.html
+++ b/src/server_manager/ui_components/outline-server-settings.html
@@ -195,7 +195,7 @@
           this.fire('ServerRenameRequested', {newName});
         }
       },
-       _metricsEnabledChanged: function (newMetricsEnabled, oldMetricsEnabled) {
+       _metricsEnabledChanged: function(newMetricsEnabled, oldMetricsEnabled) {
         if (oldMetricsEnabled === undefined || newMetricsEnabled === undefined) {
           return;
         }

--- a/src/server_manager/ui_components/outline-server-settings.html
+++ b/src/server_manager/ui_components/outline-server-settings.html
@@ -172,7 +172,6 @@
       update: function(name, metricsEnabled) {
         this.initialName = name;
         this.name = name;
-        this.initialMetricsEnabled = metricsEnabled;
         this.metricsEnabled = metricsEnabled;
       },
       _handleNameInputKeyDown: function(event) {
@@ -195,15 +194,14 @@
           this.fire('ServerRenameRequested', {newName});
         }
       },
-      _metricsEnabledChanged: function() {
-        if (this.metricsEnabled === undefined || this.initialMetricsEnabled === undefined) {
+       _metricsEnabledChanged: function (newMetricsEnabled, oldMetricsEnabled) {
+        if (oldMetricsEnabled === undefined || newMetricsEnabled === undefined) {
           return;
         }
         // Fire signal if metrics changed.
-        if (this.metricsEnabled !== this.initialMetricsEnabled) {
-          const metricsSignal = this.metricsEnabled ?
-              'EnableMetricsRequested' : 'DisableMetricsRequested';
-          this.initialMetricsEnabled = this.metricsEnabled;
+        if (newMetricsEnabled !== oldMetricsEnabled) {
+          const metricsSignal = newMetricsEnabled ?
+            'EnableMetricsRequested' : 'DisableMetricsRequested';
           this.fire(metricsSignal);
         }
       },

--- a/src/server_manager/ui_components/outline-server-settings.html
+++ b/src/server_manager/ui_components/outline-server-settings.html
@@ -70,7 +70,7 @@
         /* We want the ink to be the color we're going to, not coming from */
         --paper-checkbox-checked-color: var(--primary-green);
         --paper-checkbox-checked-ink-color: var(--dark-gray);
-        --paper-checkbox-unchecked-color: var(--dark-gray);
+        --paper-checkbox-unchecked-color: var(--light-gray);
         --paper-checkbox-unchecked-ink-color: var(--primary-green);
       }
       paper-input {

--- a/src/server_manager/ui_components/outline-server-settings.html
+++ b/src/server_manager/ui_components/outline-server-settings.html
@@ -16,7 +16,7 @@
 <link rel='import' href='../bower_components/polymer/polymer.html'>
 <link rel='import' href='../bower_components/paper-button/paper-button.html'>
 <link rel='import' href='../bower_components/paper-input/paper-input.html'>
-<link rel='import' href='../bower_components/paper-toggle-button/paper-toggle-button.html'>
+<link rel='import' href='../bower_components/paper-checkbox/paper-checkbox.html'>
 
 <link rel='import' href='./cloud-install-styles.html'>
 <link rel='import' href='./outline-iconset.html'>
@@ -66,11 +66,12 @@
       .clickable {
         cursor: pointer;
       }
-      paper-toggle-button {
-        --paper-toggle-button-checked-bar-color: var(--primary-green);
-        --paper-toggle-button-checked-button-color: var(--primary-green);
-        --paper-toggle-button-checked-ink-color: var(--primary-green);
-        --paper-toggle-button-unchecked-bar-color: var(--dark-gray);
+      paper-checkbox {
+        /* We want the ink to be the color we're going to, not coming from */
+        --paper-checkbox-checked-color: var(--primary-green);
+        --paper-checkbox-checked-ink-color: var(--dark-gray);
+        --paper-checkbox-unchecked-color: var(--dark-gray);
+        --paper-checkbox-unchecked-ink-color: var(--primary-green);
       }
       paper-input {
         /* Removes extra padding added by children of paper-input */
@@ -144,7 +145,7 @@
           <div>
             <div id="metricsHeader">
               <h3>Share anonymous metrics</h3>
-              <paper-toggle-button id="metricsToggle" checked="{{metricsEnabled}}"></paper-toggle-button>
+              <paper-checkbox id="metricsCheckbox" checked="{{metricsEnabled}}"></paper-checkbox>
             </div>
             <p>Share anonymized metrics to help improve the reliability and performance of Outline, for you and for those you share your server with. <a class="link" href="https://s3.amazonaws.com/outline-vpn/index.html#/en/support/dataCollection">Learn more</a>.</p>
           </div>


### PR DESCRIPTION
This changes the toggle button to be a checkbox, which is hopefully more clear of an indicator of whether or not metrics sharing is enabled.