### PR TITLE
Access key quotas

### DIFF
--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -122,7 +122,7 @@ curl --insecure -X DELETE $API_URL/access-keys/2
 Set an access key quota
 (e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding window)
 ```
-curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"quota": {"quotaBytes": 1000000, "windowHours": 24}}' $API_URL/access-keys/2/quota
+curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"quota": {"quota": {"bytes": 1000}, "window": {"hours": 1}}}' $API_URL/access-keys/2/quota
 ```
 
 Remove an access key quota

--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -83,7 +83,7 @@ docker rmi $(docker images -f dangling=true -q)
 
 In order to utilize the Management API, you'll need to know the apiUrl for your Outline server.
 You can obtain this information from the "Settings" tab of the server page in the Outline Manager.
-Alternatively, you can check the 'access.txt' file under the '/opt/outline' directory of an Outline server. An example apiUrl is: https://1.2.3.4:1234/3pQ4jf6qSr5WVeMO0XOo4z. 
+Alternatively, you can check the 'access.txt' file under the '/opt/outline' directory of an Outline server. An example apiUrl is: https://1.2.3.4:1234/3pQ4jf6qSr5WVeMO0XOo4z.
 
 See [Full API Documentation](https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/shadowbox/server/api.yml).
 The OpenAPI specification can be found at [api.yml](./api.yml).
@@ -117,6 +117,17 @@ Remove an access key
 (e.g. remove access key 2)
 ```
 curl --insecure -X DELETE $API_URL/access-keys/2
+```
+
+Set an access key quota
+(e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding window)
+```
+curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"quota": {"quotaBytes": 1000000, "windowHours": 24}}' $API_URL/access-keys/2/quota
+```
+
+Remove an access key quota
+```
+curl -v --insecure -X DELETE $API_URL/access-keys/2/quota
 ```
 
 ## Testing

--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -122,7 +122,7 @@ curl --insecure -X DELETE $API_URL/access-keys/2
 Set an access key quota
 (e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding window)
 ```
-curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"quota": {"quota": {"bytes": 1000}, "window": {"hours": 1}}}' $API_URL/access-keys/2/quota
+curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"quota": {"data": {"bytes": 1000}, "window": {"hours": 1}}}' $API_URL/access-keys/2/quota
 ```
 
 Remove an access key quota

--- a/src/shadowbox/docker/run_action.sh
+++ b/src/shadowbox/docker/run_action.sh
@@ -17,7 +17,7 @@
 do_action shadowbox/docker/build
 
 readonly OUTLINE_DIR=/tmp/outline
-touch "$OUTLINE_DIR/config.json"
+mkdir -p $OUTLINE_DIR && touch "$OUTLINE_DIR/config.json"
 source $ROOT_DIR/src/shadowbox/scripts/make_test_certificate.sh "${OUTLINE_DIR}"
 
 # TODO: mount a folder rather than individual files.

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -27,9 +27,9 @@ export interface ProxyParams {
   readonly password: string;
 }
 
-// Parameters needed to enforce an access key data quota, over a sliding window.
+// Parameters needed to enforce an access key data transfer quota, over a sliding window.
 export interface AccessKeyQuota {
-  // The allowed metered traffic measured in bytes.
+  // The allowed metered data transfer measured in bytes.
   readonly quota: {bytes: number};
   // The sliding window size in hours.
   readonly window: {hours: number};
@@ -47,7 +47,7 @@ export interface AccessKey {
   readonly proxyParams: ProxyParams;
   // Admin-controlled, data transfer quota for this access key. Unlimited if unset.
   readonly quota?: AccessKeyQuota;
-  // Whether the access key data usage exceeds the quota.
+  // Whether the access key data transfer exceeds the quota.
   readonly isOverQuota?: boolean;
 }
 

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -27,6 +27,14 @@ export interface ProxyParams {
   password: string;
 }
 
+// Parameters needed to enforce an access key data quota, over a sliding window.
+export interface AccessKeyQuota {
+  // The allowed metered traffic measured in bytes.
+  quotaBytes: number;
+  // The sliding window size in hours.
+  windowHours: number;
+}
+
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.
 export interface AccessKey {
   // The unique identifier for this access key.
@@ -37,6 +45,10 @@ export interface AccessKey {
   metricsId: AccessKeyMetricsId;
   // Parameters to access the proxy
   proxyParams: ProxyParams;
+  // Admin-controlled, data transfer quota for this access key. Unlimited if unset.
+  quota?: AccessKeyQuota;
+  // Whether the access key data usage exceeds the quota.
+  isOverQuota?: boolean;
 }
 
 export interface AccessKeyRepository {
@@ -45,11 +57,14 @@ export interface AccessKeyRepository {
   // Removes the access key given its id.  Returns true if successful.
   removeAccessKey(id: AccessKeyId): boolean;
   // Lists all existing access keys
-  listAccessKeys(): IterableIterator<AccessKey>;
+  listAccessKeys(): AccessKey[];
   // Apply the specified update to the specified access key.
   // Returns true if successful.
   renameAccessKey(id: AccessKeyId, name: string): boolean;
-
   // Gets the metrics id for a given Access Key.
   getMetricsId(id: AccessKeyId): AccessKeyMetricsId|undefined;
+  // Sets the transfer quota for the specified access key. Returns true if successful.
+  setAccessKeyQuota(id: AccessKeyId, quota: AccessKeyQuota): Promise<boolean>;
+  // Clears the transfer quota for the specified access key. Returns true if successful.
+  removeAccessKeyQuota(id: AccessKeyId): Promise<boolean>;
 }

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -55,6 +55,8 @@ export interface AccessKey {
   readonly proxyParams: ProxyParams;
   // Admin-controlled, data transfer quota for this access key. Unlimited if unset.
   readonly quotaUsage?: AccessKeyQuotaUsage;
+  // Returns whether the access key has exceeded its data transfer quota.
+  isOverQuota(): boolean;
 }
 
 export interface AccessKeyRepository {

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -30,9 +30,9 @@ export interface ProxyParams {
 // Parameters needed to enforce an access key data quota, over a sliding window.
 export interface AccessKeyQuota {
   // The allowed metered traffic measured in bytes.
-  readonly quotaBytes: number;
+  readonly quota: {bytes: number};
   // The sliding window size in hours.
-  readonly windowHours: number;
+  readonly window: {hours: number};
 }
 
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -27,12 +27,20 @@ export interface ProxyParams {
   readonly password: string;
 }
 
-// Parameters needed to enforce an access key data transfer quota, over a sliding window.
+// Parameters needed to limit access key data usage over a sliding window.
 export interface AccessKeyQuota {
   // The allowed metered data transfer measured in bytes.
-  readonly quota: {bytes: number};
+  readonly data: {bytes: number};
   // The sliding window size in hours.
   readonly window: {hours: number};
+}
+
+// Parameters needed to enforce an access key data transfer quota.
+export interface AccessKeyQuotaUsage {
+  // Data transfer quota on this access key.
+  readonly quota: AccessKeyQuota;
+  // Data transferred by this access key over the quota window.
+  readonly usage: {bytes: number};
 }
 
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.
@@ -46,9 +54,7 @@ export interface AccessKey {
   // Parameters to access the proxy
   readonly proxyParams: ProxyParams;
   // Admin-controlled, data transfer quota for this access key. Unlimited if unset.
-  readonly quota?: AccessKeyQuota;
-  // Whether the access key data transfer exceeds the quota.
-  readonly isOverQuota?: boolean;
+  readonly quotaUsage?: AccessKeyQuotaUsage;
 }
 
 export interface AccessKeyRepository {

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -18,37 +18,37 @@ export type AccessKeyMetricsId = string;
 // Parameters needed to access a Shadowsocks proxy.
 export interface ProxyParams {
   // Hostname of the proxy
-  hostname: string;
+  readonly hostname: string;
   // Number of the port where the Shadowsocks service is running.
-  portNumber: number;
+  readonly portNumber: number;
   // The Shadowsocks encryption method being used.
-  encryptionMethod: string;
+  readonly encryptionMethod: string;
   // The password for the encryption.
-  password: string;
+  readonly password: string;
 }
 
 // Parameters needed to enforce an access key data quota, over a sliding window.
 export interface AccessKeyQuota {
   // The allowed metered traffic measured in bytes.
-  quotaBytes: number;
+  readonly quotaBytes: number;
   // The sliding window size in hours.
-  windowHours: number;
+  readonly windowHours: number;
 }
 
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.
 export interface AccessKey {
   // The unique identifier for this access key.
-  id: AccessKeyId;
+  readonly id: AccessKeyId;
   // Admin-controlled, editable name for this access key.
-  name: string;
+  readonly name: string;
   // Used in metrics reporting to decouple from the real id. Can change.
-  metricsId: AccessKeyMetricsId;
+  readonly metricsId: AccessKeyMetricsId;
   // Parameters to access the proxy
-  proxyParams: ProxyParams;
+  readonly proxyParams: ProxyParams;
   // Admin-controlled, data transfer quota for this access key. Unlimited if unset.
-  quota?: AccessKeyQuota;
+  readonly quota?: AccessKeyQuota;
   // Whether the access key data usage exceeds the quota.
-  isOverQuota?: boolean;
+  readonly isOverQuota?: boolean;
 }
 
 export interface AccessKeyRepository {

--- a/src/shadowbox/model/shadowsocks_server.ts
+++ b/src/shadowbox/model/shadowsocks_server.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export interface AccessKey {
+export interface ShadowsocksAccessKey {
   id: string;
   port: number;
   cipher: string;
@@ -21,5 +21,5 @@ export interface AccessKey {
 
 export interface ShadowsocksServer {
   // Updates the server to accept only the given access keys.
-  update(keys: AccessKey[]): Promise<void>;
+  update(keys: ShadowsocksAccessKey[]): Promise<void>;
 }

--- a/src/shadowbox/model/shadowsocks_server.ts
+++ b/src/shadowbox/model/shadowsocks_server.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Parameters required to identify and authenticate connections to a Shadowsocks server.
 export interface ShadowsocksAccessKey {
   id: string;
   port: number;

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -8,9 +8,9 @@ tags:
     description: Server-level functions
   - name: Access Key
     description: Access key functions
-servers: 
+servers:
   - url: https://myserver/SecretPath
-    description: Example URL. Change to your own server.  
+    description: Example URL. Change to your own server.
 paths:
   /server:
     get:
@@ -35,7 +35,7 @@ paths:
         - Server
       requestBody:
         required: true
-        content: 
+        content:
           application/json:
             schema:
               type: object
@@ -137,7 +137,7 @@ paths:
             type: string
       requestBody:
         required: true
-        content: 
+        content:
           application/json:
             schema:
               type: object
@@ -147,6 +147,50 @@ paths:
       responses:
         '204':
           description: Access key renamed successfully
+        '404':
+          description: Access key inexistent
+  /access-keys/{id}/quota:
+    put:
+      description: Sets an access key data transfer quota
+      tags:
+        - Access Key
+        - Quota
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the access key to set a quota
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessKeyQuota"
+              examples:
+                '0':
+                  value: "{quotaBytes: 1000000, windowHours: 24}"
+      responses:
+        '204':
+          description: Access key quota set successfully
+        '404':
+          description: Access key inexistent
+    delete:
+      description: Removes an acess key data transfer quota
+      tags:
+        - Access Key
+        - Quota
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the access key to delete a quota
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Access key quota set successfully
         '404':
           description: Access key inexistent
   /metrics/transfer:
@@ -193,7 +237,7 @@ paths:
         - Server
       requestBody:
         required: true
-        content: 
+        content:
           application/json:
             schema:
               type: object
@@ -208,7 +252,7 @@ paths:
           description: Setting successful
         '400':
           description: Invalid request
-          
+
 components:
   schemas:
     Server:
@@ -222,6 +266,12 @@ components:
         createdTimestampMs:
           type: number
         portForNewAccessKeys:
+          type: integer
+    AccessKeyQuota:
+      properties:
+        quotaBytes:
+          type: integer
+        windowHours:
           type: integer
     AccessKey:
       required:
@@ -239,3 +289,5 @@ components:
           type: string
         accessUrl:
           type: string
+        quota:
+          $ref: "#/components/schemas/AccessKeyQuota"

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -269,10 +269,16 @@ components:
           type: integer
     AccessKeyQuota:
       properties:
-        quotaBytes:
-          type: integer
-        windowHours:
-          type: integer
+        quota:
+          type: object
+          properties:
+            bytes:
+              type: integer
+        window:
+          type: object
+          properties:
+            hours:
+              type: integer
     AccessKey:
       required:
         - id

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -269,7 +269,7 @@ components:
           type: integer
     AccessKeyQuota:
       properties:
-        quota:
+        data:
           type: object
           properties:
             bytes:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -177,7 +177,7 @@ paths:
         '404':
           description: Access key inexistent
     delete:
-      description: Removes an acess key data transfer quota
+      description: Removes an access key data transfer quota, lifting data transfer restrictions on the key.
       tags:
         - Access Key
         - Quota
@@ -190,7 +190,7 @@ paths:
             type: string
       responses:
         '204':
-          description: Access key quota set successfully
+          description: Access key quota deleted successfully.
         '404':
           description: Access key inexistent
   /metrics/transfer:

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -29,7 +29,7 @@ import {AccessKeyId} from '../model/access_key';
 import {PrometheusManagerMetrics} from './manager_metrics';
 import {bindService, ShadowsocksManagerService} from './manager_service';
 import {OutlineShadowsocksServer} from './outline_shadowsocks_server';
-import {AccessKeyConfigJson, AccessKeyUsageMetrics, ServerAccessKeyRepository} from './server_access_key';
+import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import * as server_config from './server_config';
 import {OutlineSharedMetricsPublisher, PrometheusUsageMetrics, RestMetricsCollectorClient, SharedMetricsPublisher} from './shared_metrics';
 
@@ -161,8 +161,7 @@ async function main() {
 
   const prometheusClient = new PrometheusClient(`http://${prometheusLocation}`);
   const accessKeyRepository = new ServerAccessKeyRepository(
-      portProvider, proxyHostname, accessKeyConfig, shadowsocksServer,
-      new AccessKeyUsageMetrics(prometheusClient));
+      portProvider, proxyHostname, accessKeyConfig, shadowsocksServer, prometheusClient);
 
   const portForNewAccessKeys = getPortForNewAccessKeys(serverConfig, accessKeyConfig) ||
       await reservePortForNewAccessKeys(portProvider, serverConfig);

--- a/src/shadowbox/server/manager_metrics.spec.ts
+++ b/src/shadowbox/server/manager_metrics.spec.ts
@@ -1,0 +1,70 @@
+// Copyright 2019 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import {PrometheusClient, QueryResultData} from '../infrastructure/prometheus_scraper';
+import {DataUsageByUser} from '../model/metrics';
+
+import {PrometheusManagerMetrics} from './manager_metrics';
+
+describe('PrometheusManagerMetrics', () => {
+  it('get30DayByteTransfer', async (done) => {
+    const managerMetrics = getManagerMetrics({'access-key-1': 1000, 'access-key-2': 10000});
+    const dataUsage = await managerMetrics.get30DayByteTransfer();
+    const bytesTransferredByUserId = dataUsage.bytesTransferredByUserId;
+    expect(Object.keys(bytesTransferredByUserId).length).toEqual(2);
+    expect(bytesTransferredByUserId['access-key-1']).toEqual(1000);
+    expect(bytesTransferredByUserId['access-key-2']).toEqual(10000);
+    done();
+  });
+
+  it('getOutboundByteTransfer', async (done) => {
+    const managerMetrics = getManagerMetrics({'access-key': 1024});
+    const dataUsage = await managerMetrics.getOutboundByteTransfer('access-key', 10);
+    const bytesTransferredByUserId = dataUsage.bytesTransferredByUserId;
+    expect(Object.keys(bytesTransferredByUserId).length).toEqual(1);
+    expect(bytesTransferredByUserId['access-key']).toEqual(1024);
+    done();
+  });
+
+  it('getOutboundByteTransfer returns zero when ID is missing', async (done) => {
+    const managerMetrics = getManagerMetrics({'access-key': 1024});
+    const dataUsage = await managerMetrics.getOutboundByteTransfer('doesnotexist', 10);
+    const bytesTransferredByUserId = dataUsage.bytesTransferredByUserId;
+    expect(Object.keys(bytesTransferredByUserId).length).toEqual(1);
+    expect(bytesTransferredByUserId['doesnotexist']).toEqual(0);
+    done();
+  });
+});
+
+class FakePrometheusClient extends PrometheusClient {
+  constructor(private transferredBytesById: {[accessKeyId: string]: number}) {
+    super('');
+  }
+
+  async query(query: string): Promise<QueryResultData> {
+    const queryResultData = {} as QueryResultData;
+    queryResultData.result = [];
+    for (const accessKeyId of Object.keys(this.transferredBytesById)) {
+      const transferredBytes = this.transferredBytesById[accessKeyId];
+      queryResultData.result.push(
+          {metric: {'access_key': accessKeyId}, value: [transferredBytes, `${transferredBytes}`]});
+    }
+    return queryResultData;
+  }
+}
+
+function getManagerMetrics(transferredBytesById: {[accessKeyId: string]: number}) {
+  return new PrometheusManagerMetrics(new FakePrometheusClient(transferredBytesById));
+}

--- a/src/shadowbox/server/manager_metrics.spec.ts
+++ b/src/shadowbox/server/manager_metrics.spec.ts
@@ -31,19 +31,15 @@ describe('PrometheusManagerMetrics', () => {
 
   it('getOutboundByteTransfer', async (done) => {
     const managerMetrics = getManagerMetrics({'access-key': 1024});
-    const dataUsage = await managerMetrics.getOutboundByteTransfer('access-key', 10);
-    const bytesTransferredByUserId = dataUsage.bytesTransferredByUserId;
-    expect(Object.keys(bytesTransferredByUserId).length).toEqual(1);
-    expect(bytesTransferredByUserId['access-key']).toEqual(1024);
+    const bytesTransferred = await managerMetrics.getOutboundByteTransfer('access-key', 10);
+    expect(bytesTransferred).toEqual(1024);
     done();
   });
 
   it('getOutboundByteTransfer returns zero when ID is missing', async (done) => {
     const managerMetrics = getManagerMetrics({'access-key': 1024});
-    const dataUsage = await managerMetrics.getOutboundByteTransfer('doesnotexist', 10);
-    const bytesTransferredByUserId = dataUsage.bytesTransferredByUserId;
-    expect(Object.keys(bytesTransferredByUserId).length).toEqual(1);
-    expect(bytesTransferredByUserId['doesnotexist']).toEqual(0);
+    const bytesTransferred = await managerMetrics.getOutboundByteTransfer('doesnotexist', 10);
+    expect(bytesTransferred).toEqual(0);
     done();
   });
 });

--- a/src/shadowbox/server/manager_metrics.ts
+++ b/src/shadowbox/server/manager_metrics.ts
@@ -17,7 +17,6 @@ import {DataUsageByUser} from '../model/metrics';
 
 export interface ManagerMetrics {
   get30DayByteTransfer(): Promise<DataUsageByUser>;
-  getOutboundByteTransfer(accessKeyId: string, windowHours: number): Promise<number>;
 }
 
 // Reads manager metrics from a Prometheus instance.
@@ -40,16 +39,5 @@ export class PrometheusManagerMetrics implements ManagerMetrics {
       usage[entry.metric['access_key'] || ''] = bytes;
     }
     return {bytesTransferredByUserId: usage};
-  }
-
-  async getOutboundByteTransfer(accessKeyId: string, windowHours: number): Promise<number> {
-    let bytesTransferred = 0;
-    const result = await this.prometheusClient.query(
-        `sum(increase(shadowsocks_data_bytes{dir=~"c<p|p>t",access_key="${accessKeyId}"}[${
-            windowHours}h])) by (access_key)`);
-    if (result && result.result[0] && result.result[0].metric['access_key'] === accessKeyId) {
-      bytesTransferred = Math.round(parseFloat(result.result[0].value[1]));
-    }
-    return bytesTransferred;
   }
 }

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -19,7 +19,7 @@ import {AccessKey, AccessKeyQuota, AccessKeyRepository} from '../model/access_ke
 
 import {ManagerMetrics} from './manager_metrics';
 import {ShadowsocksManagerService} from './manager_service';
-import {ManagerMetricsStub, MockShadowsocksServer} from './mocks/mocks';
+import {FakeManagerMetrics, FakeShadowsocksServer} from './mocks/mocks';
 import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import {ServerConfigJson} from './server_config';
 import {SharedMetricsPublisher} from './shared_metrics';
@@ -430,5 +430,5 @@ function getAccessKeyRepository(): AccessKeyRepository {
   return new ServerAccessKeyRepository(
       new PortProvider(), 'hostname',
       new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
-      new MockShadowsocksServer(), new ManagerMetricsStub({}));
+      new FakeShadowsocksServer(), new FakeManagerMetrics({}));
 }

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -231,7 +231,7 @@ describe('ShadowsocksManagerService', () => {
       const accessKey = await repo.createNewAccessKey();
       expect(accessKey.quota).toBeUndefined();
       expect(accessKey.isOverQuota).toBeFalsy();
-      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const quota: AccessKeyQuota = {quota: {bytes: 10000}, window: {hours: 48}};
       const res = {
         send: (httpCode, data) => {
           expect(httpCode).toEqual(204);
@@ -247,12 +247,16 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
-      let quota = {quotaBytes: 1} as AccessKeyQuota;
+      let quota = {quota: {bytes: 1}} as AccessKeyQuota;
       const res = {send: (httpCode, data) => {}};
       await service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
         expect(error.statusCode).toEqual(409);
       });
-      quota = {windowHours: 1} as AccessKeyQuota;
+      quota = {window: {}} as AccessKeyQuota;
+      await service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(409);
+      });
+      quota = {window: {hours: 1}} as AccessKeyQuota;
       service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
         expect(error.statusCode).toEqual(409);
         responseProcessed = true;  // required for afterEach to pass.
@@ -263,7 +267,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
-      const quota: AccessKeyQuota = {quotaBytes: -1, windowHours: 24};
+      const quota: AccessKeyQuota = {quota: {bytes: -1}, window: {hours: 24}};
       const res = {send: (httpCode, data) => {}};
       service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
         expect(error.statusCode).toEqual(409);
@@ -275,7 +279,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
-      const quota: AccessKeyQuota = {quotaBytes: 1000, windowHours: -24};
+      const quota: AccessKeyQuota = {quota: {bytes: 1000}, window: {hours: -24}};
       const res = {send: (httpCode, data) => {}};
       service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
         expect(error.statusCode).toEqual(409);
@@ -286,7 +290,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 404 when the access key is not found', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
-      const quota: AccessKeyQuota = {quotaBytes: 1000, windowHours: 24};
+      const quota: AccessKeyQuota = {quota: {bytes: 1000}, window: {hours: 24}};
       const res = {send: (httpCode, data) => {}};
       service.setAccessKeyQuota({params: {id: 'doesnotexist', quota}}, res, (error) => {
         expect(error.statusCode).toEqual(404);
@@ -299,7 +303,7 @@ describe('ShadowsocksManagerService', () => {
       spyOn(repo, 'setAccessKeyQuota').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
-      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const quota: AccessKeyQuota = {quota: {bytes: 10000}, window: {hours: 48}};
       const res = {send: (httpCode, data) => {}};
       service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
         expect(error.statusCode).toEqual(500);
@@ -313,7 +317,7 @@ describe('ShadowsocksManagerService', () => {
     it('clears access key quota', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
-      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const quota: AccessKeyQuota = {quota: {bytes: 10000}, window: {hours: 48}};
       const accessKey = await repo.createNewAccessKey();
       repo.setAccessKeyQuota(accessKey.id, quota);
       expect(accessKey.quota).toEqual(quota);
@@ -331,7 +335,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 404 when the access key is not found', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
-      const quota: AccessKeyQuota = {quotaBytes: 1000, windowHours: 24};
+      const quota: AccessKeyQuota = {quota: {bytes: 1000}, window: {hours: 24}};
       const res = {send: (httpCode, data) => {}};
       service.removeAccessKeyQuota({params: {id: 'doesnotexist', quota}}, res, (error) => {
         expect(error.statusCode).toEqual(404);
@@ -344,7 +348,7 @@ describe('ShadowsocksManagerService', () => {
       spyOn(repo, 'removeAccessKeyQuota').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
-      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const quota: AccessKeyQuota = {quota: {bytes: 10000}, window: {hours: 48}};
       const res = {send: (httpCode, data) => {}};
       service.removeAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
         expect(error.statusCode).toEqual(500);

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -20,7 +20,7 @@ import {AccessKey, AccessKeyQuota, AccessKeyRepository} from '../model/access_ke
 import {ManagerMetrics} from './manager_metrics';
 import {ShadowsocksManagerService} from './manager_service';
 import {FakePrometheusClient, FakeShadowsocksServer} from './mocks/mocks';
-import {AccessKeyConfigJson, IsAccessKeyOverQuota, ServerAccessKeyRepository} from './server_access_key';
+import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import {ServerConfigJson} from './server_config';
 import {SharedMetricsPublisher} from './shared_metrics';
 
@@ -230,14 +230,14 @@ describe('ShadowsocksManagerService', () => {
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
       expect(accessKey.quotaUsage).toBeUndefined();
-      expect(IsAccessKeyOverQuota(accessKey)).toBeFalsy();
+      expect(accessKey.isOverQuota()).toBeFalsy();
       const quota = {data: {bytes: 10000}, window: {hours: 48}};
       const res = {
         send: (httpCode, data) => {
           expect(httpCode).toEqual(204);
           const accessKey = getFirstAccessKey(repo);
           expect(accessKey.quotaUsage.quota).toEqual(quota);
-          expect(IsAccessKeyOverQuota(accessKey)).toBeFalsy();
+          expect(accessKey.isOverQuota()).toBeFalsy();
           responseProcessed = true;  // required for afterEach to pass.
         }
       };
@@ -327,7 +327,7 @@ describe('ShadowsocksManagerService', () => {
           expect(httpCode).toEqual(204);
           const accessKey = getFirstAccessKey(repo);
           expect(accessKey.quotaUsage).toBeUndefined();
-          expect(IsAccessKeyOverQuota(accessKey)).toBeFalsy();
+          expect(accessKey.isOverQuota()).toBeFalsy();
           responseProcessed = true;  // required for afterEach to pass.
         }
       };

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -19,7 +19,7 @@ import {AccessKey, AccessKeyQuota, AccessKeyRepository} from '../model/access_ke
 
 import {ManagerMetrics} from './manager_metrics';
 import {ShadowsocksManagerService} from './manager_service';
-import {FakeShadowsocksServer, FakeUsageMetrics} from './mocks/mocks';
+import {FakePrometheusClient, FakeShadowsocksServer} from './mocks/mocks';
 import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import {ServerConfigJson} from './server_config';
 import {SharedMetricsPublisher} from './shared_metrics';
@@ -428,5 +428,5 @@ function getAccessKeyRepository(): AccessKeyRepository {
   return new ServerAccessKeyRepository(
       new PortProvider(), 'hostname',
       new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
-      new FakeShadowsocksServer(), new FakeUsageMetrics({}));
+      new FakeShadowsocksServer(), new FakePrometheusClient({}));
 }

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ManualClock} from '../infrastructure/clock';
+import {PortProvider} from '../infrastructure/get_port';
 import {InMemoryConfig} from '../infrastructure/json_config';
-import {AccessKey, AccessKeyRepository} from '../model/access_key';
+import {AccessKey, AccessKeyQuota, AccessKeyRepository} from '../model/access_key';
 
+import {ManagerMetrics} from './manager_metrics';
 import {ShadowsocksManagerService} from './manager_service';
-import {MockAccessKeyRepository} from './mocks/mocks';
+import {ManagerMetricsStub, MockShadowsocksServer} from './mocks/mocks';
+import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import {ServerConfigJson} from './server_config';
 import {SharedMetricsPublisher} from './shared_metrics';
 
@@ -38,7 +42,7 @@ describe('ShadowsocksManagerService', () => {
 
   describe('getServer', () => {
     it('Return default name if name is absent', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const serverConfig = new InMemoryConfig({} as ServerConfigJson);
       const service = new ShadowsocksManagerService('default name', serverConfig, repo, null, null);
       service.getServer(
@@ -52,7 +56,7 @@ describe('ShadowsocksManagerService', () => {
           done);
     });
     it('Return saved name', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const serverConfig = new InMemoryConfig({name: 'Server'} as ServerConfigJson);
       const service = new ShadowsocksManagerService('default name', serverConfig, repo, null, null);
       service.getServer(
@@ -69,7 +73,7 @@ describe('ShadowsocksManagerService', () => {
 
   describe('renameServer', () => {
     it('Rename changes the server name', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const serverConfig = new InMemoryConfig({} as ServerConfigJson);
       const service = new ShadowsocksManagerService('default name', serverConfig, repo, null, null);
       service.renameServer(
@@ -86,7 +90,7 @@ describe('ShadowsocksManagerService', () => {
 
   describe('listAccessKeys', () => {
     it('lists access keys in order', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
 
       // Create 2 access keys with names.
@@ -115,14 +119,15 @@ describe('ShadowsocksManagerService', () => {
 
   describe('createNewAccessKey', () => {
     it('creates keys', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
 
       // Verify that response returns a key with the expected properties.
       const res = {
         send: (httpCode, data) => {
           expect(httpCode).toEqual(201);
-          const expectedProperties = ['id', 'name', 'password', 'port', 'method', 'accessUrl'];
+          const expectedProperties =
+              ['id', 'name', 'password', 'port', 'method', 'accessUrl', 'quota', 'isOverQuota'];
           expect(Object.keys(data).sort()).toEqual(expectedProperties.sort());
           responseProcessed = true;  // required for afterEach to pass.
         }
@@ -130,7 +135,7 @@ describe('ShadowsocksManagerService', () => {
       service.createNewAccessKey({params: {}}, res, done);
     });
     it('Create returns a 500 when the repository throws an exception', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       spyOn(repo, 'createNewAccessKey').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
 
@@ -145,7 +150,7 @@ describe('ShadowsocksManagerService', () => {
 
   describe('removeAccessKey', () => {
     it('removes keys', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
 
       // Create 2 access keys with names.
@@ -168,7 +173,7 @@ describe('ShadowsocksManagerService', () => {
           });
     });
     it('Remove returns a 500 when the repository throws an exception', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       spyOn(repo, 'removeAccessKey').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
 
@@ -186,7 +191,7 @@ describe('ShadowsocksManagerService', () => {
 
   describe('renameAccessKey', () => {
     it('renames keys', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const OLD_NAME = 'oldName';
       const NEW_NAME = 'newName';
@@ -204,7 +209,7 @@ describe('ShadowsocksManagerService', () => {
       });
     });
     it('Rename returns a 500 when the repository throws an exception', (done) => {
-      const repo = new MockAccessKeyRepository();
+      const repo = getAccessKeyRepository();
       spyOn(repo, 'renameAccessKey').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
 
@@ -215,6 +220,138 @@ describe('ShadowsocksManagerService', () => {
           responseProcessed = true;  // required for afterEach to pass.
           done();
         });
+      });
+    });
+  });
+
+  describe('setAccessKeyQuota', () => {
+    it('sets access key quota', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const accessKey = await repo.createNewAccessKey();
+      expect(accessKey.quota).toBeUndefined();
+      expect(accessKey.isOverQuota).toBeFalsy();
+      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const res = {
+        send: (httpCode, data) => {
+          expect(httpCode).toEqual(204);
+          const accessKey = getFirstAccessKey(repo);
+          expect(accessKey.quota).toEqual(quota);
+          expect(accessKey.isOverQuota).toBeFalsy();
+          responseProcessed = true;  // required for afterEach to pass.
+        }
+      };
+      service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, done);
+    });
+    it('returns 409 when quota is missing values', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const accessKey = await repo.createNewAccessKey();
+      let quota: AccessKeyQuota = {quotaBytes: 1, windowHours: 24};
+      delete quota.windowHours;  // Trick the compiler to pass a malformed quota.
+      const res = {send: (httpCode, data) => {}};
+      await service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(409);
+      });
+      quota = {quotaBytes: 1, windowHours: 24};
+      delete quota.quotaBytes;
+      service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(409);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
+      });
+    });
+    it('returns 409 when quota bytes is negative', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const accessKey = await repo.createNewAccessKey();
+      const quota: AccessKeyQuota = {quotaBytes: -1, windowHours: 24};
+      const res = {send: (httpCode, data) => {}};
+      service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(409);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
+      });
+    });
+    it('returns 409 when quota window is negative', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const accessKey = await repo.createNewAccessKey();
+      const quota: AccessKeyQuota = {quotaBytes: 1000, windowHours: -24};
+      const res = {send: (httpCode, data) => {}};
+      service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(409);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
+      });
+    });
+    it('returns 404 when the access key is not found', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const quota: AccessKeyQuota = {quotaBytes: 1000, windowHours: 24};
+      const res = {send: (httpCode, data) => {}};
+      service.setAccessKeyQuota({params: {id: 'doesnotexist', quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(404);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
+      });
+    });
+    it('returns 500 when the repository throws an exception', async (done) => {
+      const repo = getAccessKeyRepository();
+      spyOn(repo, 'setAccessKeyQuota').and.throwError('cannot write to disk');
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const accessKey = await repo.createNewAccessKey();
+      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const res = {send: (httpCode, data) => {}};
+      service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(500);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
+      });
+    });
+  });
+
+  describe('removeAccessKeyQuota', () => {
+    it('clears access key quota', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const accessKey = await repo.createNewAccessKey();
+      accessKey.quota = quota;
+      expect(accessKey.quota).toEqual(quota);
+      const res = {
+        send: (httpCode, data) => {
+          expect(httpCode).toEqual(204);
+          const accessKey = getFirstAccessKey(repo);
+          expect(accessKey.quota).toBeUndefined();
+          expect(accessKey.isOverQuota).toBeFalsy();
+          responseProcessed = true;  // required for afterEach to pass.
+        }
+      };
+      service.removeAccessKeyQuota({params: {id: accessKey.id}}, res, done);
+    });
+    it('returns 404 when the access key is not found', async (done) => {
+      const repo = getAccessKeyRepository();
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const quota: AccessKeyQuota = {quotaBytes: 1000, windowHours: 24};
+      const res = {send: (httpCode, data) => {}};
+      service.removeAccessKeyQuota({params: {id: 'doesnotexist', quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(404);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
+      });
+    });
+    it('returns 500 when the repository throws an exception', async (done) => {
+      const repo = getAccessKeyRepository();
+      spyOn(repo, 'removeAccessKeyQuota').and.throwError('cannot write to disk');
+      const service = new ShadowsocksManagerService('default name', null, repo, null, null);
+      const accessKey = await repo.createNewAccessKey();
+      const quota: AccessKeyQuota = {quotaBytes: 10000, windowHours: 48};
+      const res = {send: (httpCode, data) => {}};
+      service.removeAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
+        expect(error.statusCode).toEqual(500);
+        responseProcessed = true;  // required for afterEach to pass.
+        done();
       });
     });
   });
@@ -256,12 +393,20 @@ describe('ShadowsocksManagerService', () => {
 });
 
 function getFirstAccessKey(repo: AccessKeyRepository) {
-  return repo.listAccessKeys().next().value;
+  return repo.listAccessKeys()[0];
 }
 
 function createNewAccessKeyWithName(repo: AccessKeyRepository, name: string): Promise<AccessKey> {
   return repo.createNewAccessKey().then((key) => {
     key.name = name;
+    return key;
+  });
+}
+
+function createNewAccessKeyWithQuota(
+    repo: AccessKeyRepository, quota: AccessKeyQuota): Promise<AccessKey> {
+  return repo.createNewAccessKey().then((key) => {
+    key.quota = quota;
     return key;
   });
 }
@@ -279,4 +424,11 @@ function fakeSharedMetricsReporter(): SharedMetricsPublisher {
       return sharing;
     }
   };
+}
+
+function getAccessKeyRepository(): AccessKeyRepository {
+  return new ServerAccessKeyRepository(
+      new PortProvider(), 'hostname',
+      new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
+      new MockShadowsocksServer(), new ManagerMetricsStub({}));
 }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -183,7 +183,7 @@ export class ShadowsocksManagerService {
         return next(new restify.InvalidArgumentError(
             'Must provide a quota value with "quotaBytes" and "windowHours"'));
       }
-      if (quota.quotaBytes <= 0 || quota.windowHours <= 0) {
+      if (quota.quotaBytes < 0 || quota.windowHours < 0) {
         return next(new restify.InvalidArgumentError('Must provide positive quota values'));
       }
       const success = await this.accessKeys.setAccessKeyQuota(accessKeyId, quota);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -179,11 +179,11 @@ export class ShadowsocksManagerService {
       const accessKeyId = req.params.id;
       const quota = req.params.quota;
       // TODO(alalama): remove these checks once the repository supports typed errors.
-      if (!quota || !quota.quotaBytes || !quota.windowHours) {
+      if (!quota || !quota.quota || !quota.window) {
         return next(new restify.InvalidArgumentError(
-            'Must provide a quota value with "quotaBytes" and "windowHours"'));
+            'Must provide a quota value with "quota.bytes" and "window.hours"'));
       }
-      if (quota.quotaBytes < 0 || quota.windowHours < 0) {
+      if (quota.quota.bytes < 0 || quota.window.hours < 0) {
         return next(new restify.InvalidArgumentError('Must provide positive quota values'));
       }
       const success = await this.accessKeys.setAccessKeyQuota(accessKeyId, quota);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -41,8 +41,7 @@ function accessKeyToJson(accessKey: AccessKey) {
       password: accessKey.proxyParams.password,
       outline: 1,
     })),
-    quota: accessKey.quota,
-    isOverQuota: accessKey.isOverQuota || false
+    quota: accessKey.quotaUsage ? accessKey.quotaUsage.quota : undefined
   };
 }
 
@@ -179,11 +178,11 @@ export class ShadowsocksManagerService {
       const accessKeyId = req.params.id;
       const quota = req.params.quota;
       // TODO(alalama): remove these checks once the repository supports typed errors.
-      if (!quota || !quota.quota || !quota.window) {
+      if (!quota || !quota.data || !quota.window) {
         return next(new restify.InvalidArgumentError(
-            'Must provide a quota value with "quota.bytes" and "window.hours"'));
+            'Must provide a quota value with "data.bytes" and "window.hours"'));
       }
-      if (quota.quota.bytes < 0 || quota.window.hours < 0) {
+      if (quota.data.bytes < 0 || quota.window.hours < 0) {
         return next(new restify.InvalidArgumentError('Must provide positive quota values'));
       }
       const success = await this.accessKeys.setAccessKeyQuota(accessKeyId, quota);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -178,11 +178,12 @@ export class ShadowsocksManagerService {
       logging.debug(`setAccessKeyQuota request ${JSON.stringify(req.params)}`);
       const accessKeyId = req.params.id;
       const quota = req.params.quota;
+      // TODO(alalama): remove these checks once the repository supports typed errors.
       if (!quota || !quota.quotaBytes || !quota.windowHours) {
         return next(new restify.InvalidArgumentError(
             'Must provide a quota value with "quotaBytes" and "windowHours"'));
       }
-      if (quota.quotaBytes < 0 || quota.windowHours < 0) {
+      if (quota.quotaBytes <= 0 || quota.windowHours <= 0) {
         return next(new restify.InvalidArgumentError('Must provide positive quota values'));
       }
       const success = await this.accessKeys.setAccessKeyQuota(accessKeyId, quota);

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -55,15 +55,12 @@ export class ManagerMetricsStub implements ManagerMetrics {
   get30DayByteTransfer(): Promise<DataUsageByUser> {
     throw new Error('Not implemented');
   }
-  async getOutboundByteTransfer(accessKeyId: string, windowHours: number):
-      Promise<DataUsageByUser> {
+  async getOutboundByteTransfer(accessKeyId: string, windowHours: number): Promise<number> {
     const accessKeyUsage = this.usage[accessKeyId];
     let usageBytes = 0;
     if (!!accessKeyUsage) {
       usageBytes = accessKeyUsage[windowHours] || 0;
     }
-    const bytesTransferredByUserId = {};
-    bytesTransferredByUserId[accessKeyId] = usageBytes;
-    return {bytesTransferredByUserId};
+    return usageBytes;
   }
 }

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -36,7 +36,7 @@ export class InMemoryFile implements TextFile {
   }
 }
 
-export class MockShadowsocksServer implements ShadowsocksServer {
+export class FakeShadowsocksServer implements ShadowsocksServer {
   private accessKeys: ShadowsocksAccessKey[] = [];
 
   update(keys: ShadowsocksAccessKey[]) {
@@ -49,7 +49,7 @@ export class MockShadowsocksServer implements ShadowsocksServer {
   }
 }
 
-export class ManagerMetricsStub implements ManagerMetrics {
+export class FakeManagerMetrics implements ManagerMetrics {
   constructor(public usage: {[accessKeyId: string]: {[windowHours: number]: number}}) {}
 
   get30DayByteTransfer(): Promise<DataUsageByUser> {

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -19,7 +19,7 @@ import * as mkdirp from 'mkdirp';
 import * as path from 'path';
 
 import * as logging from '../infrastructure/logging';
-import {AccessKey, ShadowsocksServer} from '../model/shadowsocks_server';
+import {ShadowsocksAccessKey, ShadowsocksServer} from '../model/shadowsocks_server';
 
 // Runs outline-ss-server.
 export class OutlineShadowsocksServer implements ShadowsocksServer {
@@ -41,7 +41,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
   // Promise is resolved after the outline-ss-config config is updated and the SIGHUP sent.
   // Keys may not be active yet.
   // TODO(fortuna): Make promise resolve when keys are ready.
-  update(keys: AccessKey[]): Promise<void> {
+  update(keys: ShadowsocksAccessKey[]): Promise<void> {
     return this.writeConfigFile(keys).then(() => {
       if (!this.ssProcess) {
         this.start();
@@ -52,9 +52,9 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     });
   }
 
-  private writeConfigFile(keys: AccessKey[]): Promise<void> {
+  private writeConfigFile(keys: ShadowsocksAccessKey[]): Promise<void> {
     return new Promise((resolve, reject) => {
-      const keysJson = {keys: [] as AccessKey[]};
+      const keysJson = {keys: [] as ShadowsocksAccessKey[]};
       for (const key of keys) {
         if (!isAeadCipher(key.cipher)) {
           logging.error(`Cipher ${key.cipher} for access key ${

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -96,7 +96,7 @@ describe('ServerAccessKeyRepository', () => {
   it('Can set access key quota', async (done) => {
     const repo = createRepo();
     const accessKey = await repo.createNewAccessKey();
-    const quota = {quotaBytes: 5000, windowHours: 24};
+    const quota = {quota: {bytes: 5000}, window: {hours: 24}};
     expect(await repo.setAccessKeyQuota(accessKey.id, quota)).toBeTruthy();
     const accessKeys = repo.listAccessKeys();
     expect(accessKeys[0].quota).toEqual(quota);
@@ -106,7 +106,7 @@ describe('ServerAccessKeyRepository', () => {
   it('setAccessKeyQuota returns false for missing keys', async (done) => {
     const repo = createRepo();
     await repo.createNewAccessKey();
-    const quota = {quotaBytes: 1000, windowHours: 24};
+    const quota = {quota: {bytes: 1000}, window: {hours: 24}};
     expect(await repo.setAccessKeyQuota('doesnotexist', quota)).toBeFalsy();
     done();
   });
@@ -115,9 +115,9 @@ describe('ServerAccessKeyRepository', () => {
     const repo = createRepo();
     const accessKey = await repo.createNewAccessKey();
     // Negative values
-    const negativeBytesQuota = {quotaBytes: -1000, windowHours: 24};
+    const negativeBytesQuota = {quota: {bytes: -1000}, window: {hours: 24}};
     expect(await repo.setAccessKeyQuota(accessKey.id, negativeBytesQuota)).toBeFalsy();
-    const negativeWindowQuota = {quotaBytes: 1000, windowHours: -24};
+    const negativeWindowQuota = {quota: {bytes: 1000}, window: {hours: -24}};
     expect(await repo.setAccessKeyQuota(accessKey.id, negativeWindowQuota)).toBeFalsy();
     // Undefined quota
     expect(await repo.setAccessKeyQuota(accessKey.id, undefined)).toBeFalsy();
@@ -133,7 +133,7 @@ describe('ServerAccessKeyRepository', () => {
     const accessKey1 = await repo.createNewAccessKey();
     const accessKey2 = await repo.createNewAccessKey();
 
-    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 200, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey1.id, {quota: {bytes: 200}, window: {hours: 1}});
     let accessKeys = await repo.listAccessKeys();
     expect(accessKeys[0].isOverQuota).toBeTruthy();
     expect(accessKeys[1].isOverQuota).toBeFalsy();
@@ -142,8 +142,8 @@ describe('ServerAccessKeyRepository', () => {
     expect(serverAccessKeys[0].id).toEqual(accessKey2.id);
     // The over-quota access key should be re-enabled after increasing its quota, while the
     // under-quota key should be disabled after setting its quota.
-    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 1000, windowHours: 2});
-    await repo.setAccessKeyQuota(accessKey2.id, {quotaBytes: 100, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey1.id, {quota: {bytes: 1000}, window: {hours: 2}});
+    await repo.setAccessKeyQuota(accessKey2.id, {quota: {bytes: 100}, window: {hours: 1}});
     accessKeys = await repo.listAccessKeys();
     expect(accessKeys[0].isOverQuota).toBeFalsy();
     expect(accessKeys[1].isOverQuota).toBeTruthy();
@@ -156,7 +156,7 @@ describe('ServerAccessKeyRepository', () => {
   it('can remove access key quotas', async (done) => {
     const repo = createRepo();
     const accessKey = await repo.createNewAccessKey();
-    await expect(repo.setAccessKeyQuota(accessKey.id, {quotaBytes: 100, windowHours: 24}))
+    await expect(repo.setAccessKeyQuota(accessKey.id, {quota: {bytes: 100}, window: {hours: 24}}))
         .toBeTruthy();
     expect(repo.listAccessKeys()[0].quota).toBeDefined();
     expect(repo.removeAccessKeyQuota(accessKey.id)).toBeTruthy();
@@ -179,7 +179,7 @@ describe('ServerAccessKeyRepository', () => {
         new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}), server, metrics);
     const accessKey = await repo.createNewAccessKey();
     await repo.createNewAccessKey();
-    await repo.setAccessKeyQuota(accessKey.id, {quotaBytes: 100, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey.id, {quota: {bytes: 100}, window: {hours: 1}});
     expect(server.getAccessKeys().length).toEqual(1);
 
     // Remove the quota; expect the key to be under quota and enabled.
@@ -199,7 +199,7 @@ describe('ServerAccessKeyRepository', () => {
         new FakeShadowsocksServer(), metrics);
     const accessKey1 = await repo.createNewAccessKey();
     await repo.createNewAccessKey();
-    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 200, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey1.id, {quota: {bytes: 200}, window: {hours: 1}});
 
     await repo.enforceAccessKeyQuotas();
     let accessKeys = await repo.listAccessKeys();
@@ -222,7 +222,7 @@ describe('ServerAccessKeyRepository', () => {
         new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}), server, metrics);
     const accessKey1 = await repo.createNewAccessKey();
     const accessKey2 = await repo.createNewAccessKey();
-    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 200, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey1.id, {quota: {bytes: 200}, window: {hours: 1}});
 
     await repo.enforceAccessKeyQuotas();
     const accessKeys = await repo.listAccessKeys();
@@ -245,7 +245,7 @@ describe('ServerAccessKeyRepository', () => {
     // Create 2 new access keys
     await Promise.all([repo1.createNewAccessKey(), repo1.createNewAccessKey()]);
     // Modify properties
-    await repo1.setAccessKeyQuota('0', {quotaBytes: 100, windowHours: 12});
+    await repo1.setAccessKeyQuota('0', {quota: {bytes: 100}, window: {hours: 12}});
     repo1.renameAccessKey('1', 'name');
 
     // Create a 2nd repo from the same config file. This simulates what
@@ -306,8 +306,8 @@ describe('ServerAccessKeyRepository', () => {
     const accessKey1 = await repo.createNewAccessKey();
     const accessKey2 = await repo.createNewAccessKey();
     const accessKey3 = await repo.createNewAccessKey();
-    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 300, windowHours: 1});
-    await repo.setAccessKeyQuota(accessKey2.id, {quotaBytes: 100, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey1.id, {quota: {bytes: 300}, window: {hours: 1}});
+    await repo.setAccessKeyQuota(accessKey2.id, {quota: {bytes: 100}, window: {hours: 1}});
     const clock = new ManualClock();
 
     await repo.start(clock);

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -143,6 +143,8 @@ describe('ServerAccessKeyRepository', () => {
     let accessKeys = await repo.listAccessKeys();
     expect(accessKeys[0].isOverQuota()).toBeTruthy();
     expect(accessKeys[1].isOverQuota()).toBeFalsy();
+    // We determine which access keys have been enabled/disabled by accessing them from
+    // the server's perspective, ensuring `server.update` has been called.
     let serverAccessKeys = server.getAccessKeys();
     expect(serverAccessKeys.length).toEqual(1);
     expect(serverAccessKeys[0].id).toEqual(accessKey2.id);

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ManualClock} from '../infrastructure/clock';
 import {PortProvider} from '../infrastructure/get_port';
 import {InMemoryConfig} from '../infrastructure/json_config';
 import {AccessKeyRepository} from '../model/access_key';
-import {AccessKey, ShadowsocksServer} from '../model/shadowsocks_server';
+import {ManagerMetricsStub, MockShadowsocksServer} from './mocks/mocks';
 
 import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
 import {ServerConfigJson} from './server_config';
@@ -33,6 +34,13 @@ describe('ServerAccessKeyRepository', () => {
       expect(accessKey).toBeDefined();
       done();
     });
+  });
+
+  it('Creates access keys under quota', async (done) => {
+    const repo = createRepo();
+    const accessKey = await repo.createNewAccessKey();
+    expect(accessKey.isOverQuota).toBeFalsy();
+    done();
   });
 
   it('Can remove access keys', (done) => {
@@ -63,8 +71,8 @@ describe('ServerAccessKeyRepository', () => {
       const NEW_NAME = 'newName';
       const renameResult = repo.renameAccessKey(accessKey.id, NEW_NAME);
       expect(renameResult).toEqual(true);
-      // List keys again and expect to see the NEW_NAME;
-      const accessKeys = iterToArray(repo.listAccessKeys());
+      // List keys again and expect to see the NEW_NAME.
+      const accessKeys = repo.listAccessKeys();
       expect(accessKeys[0].name).toEqual(NEW_NAME);
       done();
     });
@@ -76,51 +84,269 @@ describe('ServerAccessKeyRepository', () => {
       const NEW_NAME = 'newName';
       const renameResult = repo.renameAccessKey('badId', NEW_NAME);
       expect(renameResult).toEqual(false);
-      // List keys again and expect to NOT see the NEW_NAME;
-      const accessKeys = iterToArray(repo.listAccessKeys());
+      // List keys again and expect to NOT see the NEW_NAME.
+      const accessKeys = repo.listAccessKeys();
       expect(accessKeys[0].name).not.toEqual(NEW_NAME);
       done();
     });
   });
 
-  it('Repos created with an existing file restore access keys', (done) => {
+  it('Creates access keys with no quota', async (done) => {
+    const repo = createRepo();
+    const accessKey = await repo.createNewAccessKey();
+    expect(accessKey.quota).toBeUndefined();
+    expect(accessKey.isOverQuota).toBeFalsy();
+    done();
+  });
+
+  it('Can set access key quota', async (done) => {
+    const repo = createRepo();
+    const accessKey = await repo.createNewAccessKey();
+    const quota = {quotaBytes: 5000, windowHours: 24};
+    expect(await repo.setAccessKeyQuota(accessKey.id, quota)).toBeTruthy();
+    const accessKeys = repo.listAccessKeys();
+    expect(accessKeys[0].quota).toEqual(quota);
+    done();
+  });
+
+  it('setAccessKeyQuota returns false for missing keys', async (done) => {
+    const repo = createRepo();
+    await repo.createNewAccessKey();
+    const quota = {quotaBytes: 1000, windowHours: 24};
+    expect(await repo.setAccessKeyQuota('doesnotexist', quota)).toBeFalsy();
+    done();
+  });
+
+  it('setAccessKeyQuota fails with disallowed quota values', async (done) => {
+    const repo = createRepo();
+    const accessKey = await repo.createNewAccessKey();
+    // Negative values
+    let quota = {quotaBytes: -1000, windowHours: 24};
+    expect(await repo.setAccessKeyQuota(accessKey.id, quota)).toBeFalsy();
+    quota = {quotaBytes: 1000, windowHours: -24};
+    expect(await repo.setAccessKeyQuota(accessKey.id, quota)).toBeFalsy();
+    // Decimal values
+    quota = {quotaBytes: 0.1, windowHours: 24};
+    expect(await repo.setAccessKeyQuota(accessKey.id, quota)).toBeFalsy();
+    quota = {quotaBytes: 1000, windowHours: 0.1};
+    expect(await repo.setAccessKeyQuota(accessKey.id, quota)).toBeFalsy();
+    // Undefined quota
+    expect(await repo.setAccessKeyQuota(accessKey.id, undefined)).toBeFalsy();
+    done();
+  });
+
+  it('setAccessKeyQuota updates keys quota status', async (done) => {
+    const server = new MockShadowsocksServer();
+    const metrics = new ManagerMetricsStub({'0': {1: 500, 2: 800}, '1': {1: 200}});
+    const repo = new ServerAccessKeyRepository(
+        new PortProvider(), '',
+        new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}), server, metrics);
+    const accessKey1 = await repo.createNewAccessKey();
+    const accessKey2 = await repo.createNewAccessKey();
+
+    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 200, windowHours: 1});
+    let accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeTruthy();
+    expect(accessKeys[1].isOverQuota).toBeFalsy();
+    let serverAccessKeys = server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(1);
+    expect(serverAccessKeys[0].id).toEqual(accessKey2.id);
+    // The over-quota access key should be re-enabled after increasing its quota, while the
+    // under-quota key should be disabled after setting its quota.
+    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 1000, windowHours: 2});
+    await repo.setAccessKeyQuota(accessKey2.id, {quotaBytes: 100, windowHours: 1});
+    accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeFalsy();
+    expect(accessKeys[1].isOverQuota).toBeTruthy();
+    serverAccessKeys = server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(1);
+    expect(serverAccessKeys[0].id).toEqual(accessKey1.id);
+    done();
+  });
+
+  it('can remove access key quotas', async (done) => {
+    const repo = createRepo();
+    const accessKey = await repo.createNewAccessKey();
+    await expect(repo.setAccessKeyQuota(accessKey.id, {quotaBytes: 100, windowHours: 24}))
+        .toBeTruthy();
+    expect(repo.listAccessKeys()[0].quota).toBeDefined();
+    expect(repo.removeAccessKeyQuota(accessKey.id)).toBeTruthy();
+    expect(repo.listAccessKeys()[0].quota).toBeUndefined();
+    done();
+  });
+
+  it('removeAccessKeyQuota returns false for missing keys', async (done) => {
+    const repo = createRepo();
+    await repo.createNewAccessKey();
+    expect(await repo.removeAccessKeyQuota('doesnotexist')).toBeFalsy();
+    done();
+  });
+
+  it('removeAccessKeyQuota restores over-quota access keys when removing quota ', async (done) => {
+    const server = new MockShadowsocksServer();
+    const metrics = new ManagerMetricsStub({'0': {1: 500}, '1': {1: 100}});
+    const repo = new ServerAccessKeyRepository(
+        new PortProvider(), '',
+        new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}), server, metrics);
+    const accessKey = await repo.createNewAccessKey();
+    await repo.createNewAccessKey();
+    await repo.setAccessKeyQuota(accessKey.id, {quotaBytes: 100, windowHours: 1});
+    expect(server.getAccessKeys().length).toEqual(1);
+
+    // Remove the quota; expect the key to be under quota and enabled.
+    expect(repo.removeAccessKeyQuota(accessKey.id)).toBeTruthy();
+    expect(server.getAccessKeys().length).toEqual(2);
+    const accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeFalsy();
+    expect(accessKeys[1].isOverQuota).toBeFalsy();
+    done();
+  });
+
+  it('enforceAccessKeyQuotas updates keys quota status ', async (done) => {
+    const metrics = new ManagerMetricsStub({'0': {1: 500}, '1': {1: 100}});
+    const repo = new ServerAccessKeyRepository(
+        new PortProvider(), '',
+        new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
+        new MockShadowsocksServer(), metrics);
+    const accessKey1 = await repo.createNewAccessKey();
+    await repo.createNewAccessKey();
+    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 200, windowHours: 1});
+
+    await repo.enforceAccessKeyQuotas();
+    let accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeTruthy();
+    expect(accessKeys[1].isOverQuota).toBeFalsy();
+
+    metrics.usage = {'0': {1: 100}, '1': {1: 100}};
+    await repo.enforceAccessKeyQuotas();
+    accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeFalsy();
+    expect(accessKeys[1].isOverQuota).toBeFalsy();
+    done();
+  });
+
+  it('enforceAccessKeyQuotas enables and disables keys', async (done) => {
+    const server = new MockShadowsocksServer();
+    const metrics = new ManagerMetricsStub({'0': {1: 500}, '1': {1: 100}});
+    const repo = new ServerAccessKeyRepository(
+        new PortProvider(), '',
+        new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}), server, metrics);
+    const accessKey1 = await repo.createNewAccessKey();
+    const accessKey2 = await repo.createNewAccessKey();
+    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 200, windowHours: 1});
+
+    await repo.enforceAccessKeyQuotas();
+    const accessKeys = await repo.listAccessKeys();
+    let serverAccessKeys = server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(1);
+    expect(serverAccessKeys[0].id).toEqual(accessKey2.id);
+
+    metrics.usage = {'0': {1: 100}, '1': {1: 100}};
+    await repo.enforceAccessKeyQuotas();
+    serverAccessKeys = server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(2);
+    done();
+  });
+
+  it('Repos created with an existing file restore access keys', async (done) => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo1 = new ServerAccessKeyRepository(
-        new PortProvider(), 'hostname', config, createMockShadowsocksServer());
+        new PortProvider(), 'hostname', config, new MockShadowsocksServer(),
+        new ManagerMetricsStub({}));
     // Create 2 new access keys
-    Promise.all([repo1.createNewAccessKey(), repo1.createNewAccessKey()]).then(() => {
-      // Create a 2nd repo from the same config file.  This simulates what
-      // might happen after the shadowbox server is restarted.
-      const repo2 = new ServerAccessKeyRepository(
-          new PortProvider(), 'hostname', config, createMockShadowsocksServer());
-      // Check that repo1 and repo2 have the same access keys
-      const repo1Keys = iterToArray(repo1.listAccessKeys());
-      const repo2Keys = iterToArray(repo2.listAccessKeys());
-      expect(repo1Keys.length).toEqual(2);
-      expect(repo2Keys.length).toEqual(2);
-      expect(repo1Keys[0]).toEqual(repo2Keys[0]);
-      expect(repo1Keys[1]).toEqual(repo2Keys[1]);
-      done();
-    });
+    await Promise.all([repo1.createNewAccessKey(), repo1.createNewAccessKey()]);
+    // Modify properties
+    await repo1.setAccessKeyQuota('0', {quotaBytes: 100, windowHours: 12});
+    repo1.renameAccessKey('1', 'name');
+
+    // Create a 2nd repo from the same config file. This simulates what
+    // might happen after the shadowbox server is restarted.
+    const repo2 = new ServerAccessKeyRepository(
+        new PortProvider(), 'hostname', config, new MockShadowsocksServer(),
+        new ManagerMetricsStub({}));
+    // Check that repo1 and repo2 have the same access keys
+    const repo1Keys = repo1.listAccessKeys();
+    const repo2Keys = repo2.listAccessKeys();
+    expect(repo1Keys.length).toEqual(2);
+    expect(repo2Keys.length).toEqual(2);
+    expect(repo1Keys[0]).toEqual(repo2Keys[0]);
+    expect(repo1Keys[1]).toEqual(repo2Keys[1]);
+    done();
   });
 
   it('Does not re-use ids when using the same config file', (done) => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     // Create a repo with 1 access key, then delete that access key.
     const repo1 = new ServerAccessKeyRepository(
-        new PortProvider(), 'hostname', config, createMockShadowsocksServer());
+        new PortProvider(), '', config, new MockShadowsocksServer(), new ManagerMetricsStub({}));
     repo1.createNewAccessKey().then((accessKey1) => {
       repo1.removeAccessKey(accessKey1.id);
 
       // Create a 2nd repo with one access key, and verify that
       // it hasn't reused the first access key's ID.
       const repo2 = new ServerAccessKeyRepository(
-          new PortProvider(), 'hostname', config, createMockShadowsocksServer());
+          new PortProvider(), '', config, new MockShadowsocksServer(), new ManagerMetricsStub({}));
       repo2.createNewAccessKey().then((accessKey2) => {
         expect(accessKey1.id).not.toEqual(accessKey2.id);
         done();
       });
     });
+  });
+
+  it('start exposes the access keys to the server', async (done) => {
+    const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
+    const repo = new ServerAccessKeyRepository(
+        new PortProvider(), '', config, new MockShadowsocksServer(), new ManagerMetricsStub({}));
+    const accessKey1 = await repo.createNewAccessKey();
+    const accessKey2 = await repo.createNewAccessKey();
+    // Create a new repository with the same configuration. The keys should not be exposed to the
+    // server until `start` is called.
+    const server = new MockShadowsocksServer();
+    const repo2 = new ServerAccessKeyRepository(
+        new PortProvider(), '', config, server, new ManagerMetricsStub({}));
+    expect(server.getAccessKeys().length).toEqual(0);
+    await repo2.start(new ManualClock());
+    const serverAccessKeys = server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(2);
+    expect(serverAccessKeys[0].id).toEqual(accessKey1.id);
+    expect(serverAccessKeys[1].id).toEqual(accessKey2.id);
+    done();
+  });
+
+  it('start periodically enforces access key quotas', async (done) => {
+    const server = new MockShadowsocksServer();
+    const metrics = new ManagerMetricsStub({'0': {1: 500}, '1': {1: 300}, '2': {5: 1000}});
+    const repo = new ServerAccessKeyRepository(
+        new PortProvider(), '',
+        new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}), server, metrics);
+    const accessKey1 = await repo.createNewAccessKey();
+    const accessKey2 = await repo.createNewAccessKey();
+    const accessKey3 = await repo.createNewAccessKey();
+    await repo.setAccessKeyQuota(accessKey1.id, {quotaBytes: 300, windowHours: 1});
+    await repo.setAccessKeyQuota(accessKey2.id, {quotaBytes: 100, windowHours: 1});
+    const clock = new ManualClock();
+
+    await repo.start(clock);
+    await clock.runCallbacks();
+    let accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeTruthy();
+    expect(accessKeys[1].isOverQuota).toBeTruthy();
+    expect(accessKeys[2].isOverQuota).toBeFalsy();
+    let serverAccessKeys = await server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(1);
+    expect(serverAccessKeys[0].id).toEqual(accessKey3.id);
+
+    metrics.usage = {'0': {1: 100}, '1': {1: 300}, '2': {5: 1000}};  // Simulate a change in usage.
+    await clock.runCallbacks();
+    accessKeys = await repo.listAccessKeys();
+    expect(accessKeys[0].isOverQuota).toBeFalsy();
+    expect(accessKeys[1].isOverQuota).toBeTruthy();
+    expect(accessKeys[2].isOverQuota).toBeFalsy();
+    serverAccessKeys = await server.getAccessKeys();
+    expect(serverAccessKeys.length).toEqual(2);
+    expect(serverAccessKeys[0].id).toEqual(accessKey1.id);
+    expect(serverAccessKeys[1].id).toEqual(accessKey3.id);
+    done();
   });
 });
 
@@ -134,19 +360,12 @@ function iterToArray<T>(iter: IterableIterator<T>): T[] {
 }
 
 function countAccessKeys(repo: AccessKeyRepository) {
-  return iterToArray(repo.listAccessKeys()).length;
-}
-
-function createMockShadowsocksServer(): ShadowsocksServer {
-  return {
-    update(keys: AccessKey[]) {
-      return Promise.resolve();
-    }
-  };
+  return repo.listAccessKeys().length;
 }
 
 function createRepo(): ServerAccessKeyRepository {
   const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
-  const server = createMockShadowsocksServer();
-  return new ServerAccessKeyRepository(new PortProvider(), 'hostname', config, server);
+  return new ServerAccessKeyRepository(
+      new PortProvider(), 'hostname', config, new MockShadowsocksServer(),
+      new ManagerMetricsStub({}));
 }

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -350,15 +350,6 @@ describe('ServerAccessKeyRepository', () => {
   });
 });
 
-// Convert from an IterableIterator to an Array
-function iterToArray<T>(iter: IterableIterator<T>): T[] {
-  const returnArray = [];
-  for (const el of iter) {
-    returnArray.push(el);
-  }
-  return returnArray;
-}
-
 function countAccessKeys(repo: AccessKeyRepository) {
   return repo.listAccessKeys().length;
 }

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -164,7 +164,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
   }
 
   listAccessKeys(): AccessKey[] {
-    return [...this.accessKeys];  // Return a copy to the access key array.
+    return [...this.accessKeys];  // Return a copy of the access key array.
   }
 
   renameAccessKey(id: AccessKeyId, name: string): boolean {

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -266,13 +266,14 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
   // Retrieves access key outbound data transfer in bytes for `accessKeyId` over `windowHours`
   // from a Prometheus instance.
   async getOutboundByteTransfer(accessKeyId: string, windowHours: number): Promise<number> {
+    const escapedAccessKeyId = JSON.stringify(accessKeyId);
     let bytesTransferred = 0;
     const result = await this.prometheusClient.query(
-        `sum(increase(shadowsocks_data_bytes{dir=~"c<p|p>t",access_key="${accessKeyId}"}[${
+        `sum(increase(shadowsocks_data_bytes{dir=~"c<p|p>t",access_key=${escapedAccessKeyId}}[${
             windowHours}h])) by (access_key)`);
     if (result && result.result[0] && result.result[0].metric['access_key'] === accessKeyId &&
         result.result[0].value && result.result[0].value.length > 1) {
-      bytesTransferred = Math.round(parseFloat(result.result[0].value[1]));
+      bytesTransferred = Math.round(parseFloat(result.result[0].value[1])) || 0;
     }
     return bytesTransferred;
   }

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -191,7 +191,8 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
   }
 
   async setAccessKeyQuota(id: AccessKeyId, quota: AccessKeyQuota): Promise<boolean> {
-    if (!quota || quota.quotaBytes < 0 || quota.windowHours < 0) {
+    if (!quota || !quota.quota || !quota.window || quota.quota.bytes < 0 ||
+        quota.window.hours < 0) {
       return false;
     }
     const accessKey = this.getAccessKey(id);
@@ -254,8 +255,8 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
       return false;  // Don't query the usage of access keys without quota.
     }
     const usageBytes =
-        await this.metrics.getOutboundByteTransfer(accessKey.id, accessKey.quota.windowHours);
-    const isOverQuota = usageBytes > accessKey.quota.quotaBytes;
+        await this.metrics.getOutboundByteTransfer(accessKey.id, accessKey.quota.window.hours);
+    const isOverQuota = usageBytes > accessKey.quota.quota.bytes;
     logging.debug(`Enforcing quota for access key ${accessKey.id}. Quota: ${
         JSON.stringify(accessKey.quota)}, usage: ${usageBytes}B, isOverQuota: ${isOverQuota}`);
     const quotaStatusChanged = isOverQuota !== accessKey.isOverQuota;


### PR DESCRIPTION
* Implements support for access key (outbound) data transfer quotas over a sliding time window, expressed in hours.
  * Enforces access keys quotas hourly by comparing their usage over the set time window to the set quota. Disables over-quota access keys at the Shadowsocks server and enables them once they are under-quota.
* Exposes APIs to set and remove access key quotas through the management service.
  * `PUT /access-key/{id}/quota`
  * `DELETE /access-key/{id}/quota`
* Adds functionality to query per-access-key hourly data transfer usage through Prometheus metrics.
* Refactors `ServerAccessKeyRepository` to keep access keys in memory and improves asynchronous interface.
* Implements unit tests for every new method.