### PR TITLE
Avoid declare -g for old bash installs

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -448,9 +448,6 @@ function parse_flags() {
   params=$(getopt --longoptions hostname:,api-port:,keys-port: -n $0 -- $0 "$@")
   [[ $? == 0 ]] || exit 1
   eval set -- $params
-  declare -g FLAGS_HOSTNAME=""
-  declare -gi FLAGS_API_PORT=0
-  declare -gi FLAGS_KEYS_PORT=0
 
   while [[ "$#" > 0 ]]; do
     local flag=$1
@@ -495,6 +492,9 @@ function parse_flags() {
 
 function main() {
   trap finish EXIT
+  declare FLAGS_HOSTNAME=""
+  declare -i FLAGS_API_PORT=0
+  declare -i FLAGS_KEYS_PORT=0
   parse_flags "$@"
   install_shadowbox
 }


### PR DESCRIPTION
Fixes https://github.com/Jigsaw-Code/outline-server/issues/459

`declare -g` only works in bash 4.2 and above, which some old versions of CentOS don't have.  Our use of it is pretty unnecessary, there's no reason to be messing around with scope like that in a bash script anyways.

Tested by running the following script on bash 4.1 (built from source from ftp.gnu.org/gnu/bash/bash-4.1.tar.gz) and ensuring the output is "abc" then "def".

```
function f1 () {
  echo "${MY_VAR}"
}

function f2() {
  MYVAR="def"
}

function main () {
  declare MYVAR="abc"
  f1
  f2
  f1
}

main
```