### PR TITLE
Don't change to connections tab after changing server name

### DIFF
--- a/src/server_manager/ui_components/outline-server-view.html
+++ b/src/server_manager/ui_components/outline-server-view.html
@@ -559,7 +559,7 @@
         monthlyCost: {type: Number, value: 0},
         selectedTab: {
           type: String,
-          value: '',
+          value: 'connections',
         },
         managedServerUtilzationPercentage: {
           type: Number,

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -773,7 +773,6 @@ export class App {
     }
 
     view.metricsEnabled = selectedServer.getMetricsEnabled();
-    view.selectedTab = 'connections';
     this.appRoot.showServerView();
     this.showMetricsOptInWhenNeeded(selectedServer, view);
 


### PR DESCRIPTION
* Doesn't change selected tab to Connections 
* Makes Connections the default tab of the server view