### PR TITLE
Access key limits

### DIFF
--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -119,15 +119,15 @@ Remove an access key
 curl --insecure -X DELETE $API_URL/access-keys/2
 ```
 
-Set an access key quota
-(e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding window)
+Set an access key limit
+(e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding timeframe)
 ```
-curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"quota": {"data": {"bytes": 1000}, "window": {"hours": 1}}}' $API_URL/access-keys/2/quota
+curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"limit": {"data": {"bytes": 1000}, "timeframe": {"hours": 1}}}' $API_URL/access-keys/2/limit
 ```
 
-Remove an access key quota
+Remove an access key limit
 ```
-curl -v --insecure -X DELETE $API_URL/access-keys/2/quota
+curl -v --insecure -X DELETE $API_URL/access-keys/2/limit
 ```
 
 ## Testing

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -27,19 +27,19 @@ export interface ProxyParams {
   readonly password: string;
 }
 
-// Parameters needed to limit access key data usage over a sliding window.
-export interface AccessKeyQuota {
+// Parameters needed to limit access key data usage over a sliding timeframe.
+export interface AccessKeyLimit {
   // The allowed metered data transfer measured in bytes.
   readonly data: {bytes: number};
-  // The sliding window size in hours.
-  readonly window: {hours: number};
+  // The sliding timeframe size in hours.
+  readonly timeframe: {hours: number};
 }
 
-// Parameters needed to enforce an access key data transfer quota.
-export interface AccessKeyQuotaUsage {
-  // Data transfer quota on this access key.
-  readonly quota: AccessKeyQuota;
-  // Data transferred by this access key over the quota window.
+// Parameters needed to enforce an access key data transfer limit.
+export interface AccessKeyLimitUsage {
+  // Data transfer limit on this access key.
+  readonly limit: AccessKeyLimit;
+  // Data transferred by this access key over the limit timeframe.
   readonly usage: {bytes: number};
 }
 
@@ -53,10 +53,10 @@ export interface AccessKey {
   readonly metricsId: AccessKeyMetricsId;
   // Parameters to access the proxy
   readonly proxyParams: ProxyParams;
-  // Admin-controlled, data transfer quota for this access key. Unlimited if unset.
-  readonly quotaUsage?: AccessKeyQuotaUsage;
-  // Returns whether the access key has exceeded its data transfer quota.
-  isOverQuota(): boolean;
+  // Admin-controlled, data transfer limit for this access key. Unlimited if unset.
+  readonly limitUsage?: AccessKeyLimitUsage;
+  // Returns whether the access key has exceeded its data transfer limit.
+  isOverLimit(): boolean;
 }
 
 export interface AccessKeyRepository {
@@ -72,8 +72,8 @@ export interface AccessKeyRepository {
   renameAccessKey(id: AccessKeyId, name: string): void;
   // Gets the metrics id for a given Access Key.
   getMetricsId(id: AccessKeyId): AccessKeyMetricsId|undefined;
-  // Sets the transfer quota for the specified access key. Throws on failure.
-  setAccessKeyQuota(id: AccessKeyId, quota: AccessKeyQuota): Promise<void>;
-  // Clears the transfer quota for the specified access key. Throws on failure.
-  removeAccessKeyQuota(id: AccessKeyId): Promise<void>;
+  // Sets the transfer limit for the specified access key. Throws on failure.
+  setAccessKeyLimit(id: AccessKeyId, limit: AccessKeyLimit): Promise<void>;
+  // Clears the transfer limit for the specified access key. Throws on failure.
+  removeAccessKeyLimit(id: AccessKeyId): Promise<void>;
 }

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -62,19 +62,18 @@ export interface AccessKey {
 export interface AccessKeyRepository {
   // Creates a new access key. Parameters are chosen automatically.
   createNewAccessKey(): Promise<AccessKey>;
-  // Removes the access key given its id.  Returns true if successful.
-  removeAccessKey(id: AccessKeyId): boolean;
+  // Removes the access key given its id. Throws on failure.
+  removeAccessKey(id: AccessKeyId);
   // Lists all existing access keys
   listAccessKeys(): AccessKey[];
   // Changes the port for new access keys.
   setPortForNewAccessKeys(port: number): Promise<void>;
-  // Apply the specified update to the specified access key.
-  // Returns true if successful.
-  renameAccessKey(id: AccessKeyId, name: string): boolean;
+  // Apply the specified update to the specified access key. Throws on failure.
+  renameAccessKey(id: AccessKeyId, name: string): void;
   // Gets the metrics id for a given Access Key.
   getMetricsId(id: AccessKeyId): AccessKeyMetricsId|undefined;
-  // Sets the transfer quota for the specified access key. Returns true if successful.
-  setAccessKeyQuota(id: AccessKeyId, quota: AccessKeyQuota): Promise<boolean>;
-  // Clears the transfer quota for the specified access key. Returns true if successful.
-  removeAccessKeyQuota(id: AccessKeyId): Promise<boolean>;
+  // Sets the transfer quota for the specified access key. Throws on failure.
+  setAccessKeyQuota(id: AccessKeyId, quota: AccessKeyQuota): Promise<void>;
+  // Clears the transfer quota for the specified access key. Throws on failure.
+  removeAccessKeyQuota(id: AccessKeyId): Promise<void>;
 }

--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -39,9 +39,9 @@ export class AccessKeyNotFound extends ShadowboxError {
   }
 }
 
-export class InvalidAccessKeyQuota extends ShadowboxError {
+export class InvalidAccessKeyLimit extends ShadowboxError {
   constructor() {
     super(
-        'Must provide a quota value with positive integer values for "data.bytes" and "window.hours"');
+        'Must provide a limit value with positive integer values for "data.bytes" and "timeframe.hours"');
   }
 }

--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -32,3 +32,16 @@ export class PortUnavailable extends ShadowboxError {
     super(port.toString());
   }
 }
+
+export class AccessKeyNotFound extends ShadowboxError {
+  constructor(accessKeyId?: string) {
+    super(`Access key "${accessKeyId}" not found`);
+  }
+}
+
+export class InvalidAccessKeyQuota extends ShadowboxError {
+  constructor() {
+    super(
+        'Must provide a quota value with positive integer values for "data.bytes" and "window.hours"');
+  }
+}

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -52,7 +52,7 @@ paths:
           description: The requested port wasn't an integer from 1 through 65535, or the request had no port parameter.
         '409':
           description: The requested port was already in use by another service.
-  
+
   /name:
     put:
       description: Renames the server
@@ -174,17 +174,17 @@ paths:
           description: Access key renamed successfully
         '404':
           description: Access key inexistent
-  /access-keys/{id}/quota:
+  /access-keys/{id}/limit:
     put:
-      description: Sets an access key data transfer quota
+      description: Sets an access key data transfer limit
       tags:
         - Access Key
-        - Quota
+        - Limit
       parameters:
         - name: id
           in: path
           required: true
-          description: The id of the access key to set a quota
+          description: The id of the access key to set a limit
           schema:
             type: string
       requestBody:
@@ -192,30 +192,30 @@ paths:
         content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AccessKeyQuota"
+                $ref: "#/components/schemas/AccessKeyLimit"
               examples:
                 '0':
-                  value: "{quotaBytes: 1000000, windowHours: 24}"
+                  value: "{limitBytes: 1000000, timeframeHours: 24}"
       responses:
         '204':
-          description: Access key quota set successfully
+          description: Access key limit set successfully
         '404':
           description: Access key inexistent
     delete:
-      description: Removes an access key data transfer quota, lifting data transfer restrictions on the key.
+      description: Removes an access key data transfer limit, lifting data transfer restrictions on the key.
       tags:
         - Access Key
-        - Quota
+        - Limit
       parameters:
         - name: id
           in: path
           required: true
-          description: The id of the access key to delete a quota
+          description: The id of the access key to delete a limit
           schema:
             type: string
       responses:
         '204':
-          description: Access key quota deleted successfully.
+          description: Access key limit deleted successfully.
         '404':
           description: Access key inexistent
   /metrics/transfer:
@@ -292,14 +292,14 @@ components:
           type: number
         portForNewAccessKeys:
           type: integer
-    AccessKeyQuota:
+    AccessKeyLimit:
       properties:
         data:
           type: object
           properties:
             bytes:
               type: integer
-        window:
+        timeframe:
           type: object
           properties:
             hours:
@@ -320,5 +320,5 @@ components:
           type: string
         accessUrl:
           type: string
-        quota:
-          $ref: "#/components/schemas/AccessKeyQuota"
+        limit:
+          $ref: "#/components/schemas/AccessKeyLimit"

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -411,31 +411,31 @@ describe('ShadowsocksManagerService', () => {
       let quota = {data: {bytes: 1}} as AccessKeyQuota;
       const res = {send: (httpCode, data) => {}};
       await service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
-        expect(error.statusCode).toEqual(409);
+        expect(error.statusCode).toEqual(400);
       });
       quota = {window: {}} as AccessKeyQuota;
       await service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
-        expect(error.statusCode).toEqual(409);
+        expect(error.statusCode).toEqual(400);
       });
       quota = {window: {hours: 1}} as AccessKeyQuota;
       service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
-        expect(error.statusCode).toEqual(409);
+        expect(error.statusCode).toEqual(400);
         responseProcessed = true;  // required for afterEach to pass.
         done();
       });
     });
-    it('returns 409 when quota has negative values', async (done) => {
+    it('returns 400 when quota has negative values', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const accessKey = await repo.createNewAccessKey();
       let quota = {data: {bytes: -1}, window: {hours: 24}};
       const res = {send: (httpCode, data) => {}};
       await service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
-        expect(error.statusCode).toEqual(409);
+        expect(error.statusCode).toEqual(400);
       });
       quota = {data: {bytes: 1000}, window: {hours: -24}};
       service.setAccessKeyQuota({params: {id: accessKey.id, quota}}, res, (error) => {
-        expect(error.statusCode).toEqual(409);
+        expect(error.statusCode).toEqual(400);
         responseProcessed = true;  // required for afterEach to pass.
         done();
       });

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -228,7 +228,7 @@ export class ShadowsocksManagerService {
     } catch (error) {
       logging.error(error);
       if (error instanceof errors.InvalidAccessKeyQuota) {
-        return next(new restify.InvalidArgumentError(error.message));
+        return next(new restify.InvalidArgumentError({statusCode: 400}, error.message));
       } else if (error instanceof errors.AccessKeyNotFound) {
         return next(new restify.NotFoundError(error.message));
       }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -17,7 +17,7 @@ import {makeConfig, SIP002_URI} from 'ShadowsocksConfig/shadowsocks_config';
 
 import {JsonConfig} from '../infrastructure/json_config';
 import * as logging from '../infrastructure/logging';
-import {AccessKey, AccessKeyQuota, AccessKeyRepository} from '../model/access_key';
+import {AccessKey, AccessKeyLimit, AccessKeyRepository} from '../model/access_key';
 import * as errors from '../model/errors';
 
 import {ManagerMetrics} from './manager_metrics';
@@ -42,7 +42,7 @@ function accessKeyToJson(accessKey: AccessKey) {
       password: accessKey.proxyParams.password,
       outline: 1,
     })),
-    quota: accessKey.quotaUsage ? accessKey.quotaUsage.quota : undefined
+    limit: accessKey.limitUsage ? accessKey.limitUsage.limit : undefined
   };
 }
 
@@ -52,7 +52,7 @@ interface RequestParams {
   id?: string;
   name?: string;
   metricsEnabled?: boolean;
-  quota?: AccessKeyQuota;
+  limit?: AccessKeyLimit;
   port?: number;
 }
 interface RequestType {
@@ -80,8 +80,8 @@ export function bindService(
 
   apiServer.del(`${apiPrefix}/access-keys/:id`, service.removeAccessKey.bind(service));
   apiServer.put(`${apiPrefix}/access-keys/:id/name`, service.renameAccessKey.bind(service));
-  apiServer.put(`${apiPrefix}/access-keys/:id/quota`, service.setAccessKeyQuota.bind(service));
-  apiServer.del(`${apiPrefix}/access-keys/:id/quota`, service.removeAccessKeyQuota.bind(service));
+  apiServer.put(`${apiPrefix}/access-keys/:id/limit`, service.setAccessKeyLimit.bind(service));
+  apiServer.del(`${apiPrefix}/access-keys/:id/limit`, service.removeAccessKeyLimit.bind(service));
 
   apiServer.get(`${apiPrefix}/metrics/transfer`, service.getDataUsage.bind(service));
   apiServer.get(`${apiPrefix}/metrics/enabled`, service.getShareMetrics.bind(service));
@@ -217,17 +217,17 @@ export class ShadowsocksManagerService {
     }
   }
 
-  public async setAccessKeyQuota(req: RequestType, res: ResponseType, next: restify.Next) {
+  public async setAccessKeyLimit(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
-      logging.debug(`setAccessKeyQuota request ${JSON.stringify(req.params)}`);
+      logging.debug(`setAccessKeyLimit request ${JSON.stringify(req.params)}`);
       const accessKeyId = req.params.id;
-      const quota = req.params.quota;
-      await this.accessKeys.setAccessKeyQuota(accessKeyId, quota);
+      const limit = req.params.limit;
+      await this.accessKeys.setAccessKeyLimit(accessKeyId, limit);
       res.send(HttpSuccess.NO_CONTENT);
       return next();
     } catch (error) {
       logging.error(error);
-      if (error instanceof errors.InvalidAccessKeyQuota) {
+      if (error instanceof errors.InvalidAccessKeyLimit) {
         return next(new restify.InvalidArgumentError({statusCode: 400}, error.message));
       } else if (error instanceof errors.AccessKeyNotFound) {
         return next(new restify.NotFoundError(error.message));
@@ -236,11 +236,11 @@ export class ShadowsocksManagerService {
     }
   }
 
-  public async removeAccessKeyQuota(req: RequestType, res: ResponseType, next: restify.Next) {
+  public async removeAccessKeyLimit(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
-      logging.debug(`removeAccessKeyQuota request ${JSON.stringify(req.params)}`);
+      logging.debug(`removeAccessKeyLimit request ${JSON.stringify(req.params)}`);
       const accessKeyId = req.params.id;
-      await this.accessKeys.removeAccessKeyQuota(accessKeyId);
+      await this.accessKeys.removeAccessKeyLimit(accessKeyId);
       res.send(HttpSuccess.NO_CONTENT);
       return next();
     } catch (error) {


### PR DESCRIPTION
* 72a1510 uses typed errors instead of booleans in the `AccessKeyRepository` interface, fixes a bug in access key limit enforcement, and improves access key limit tests.
* 52beadb sends a 400 (instead of a 409) error code on access key limits APIs that receive invalid limit parameters.
* fcb11ee updates access key quotas terminology, replacing "quota" with "limit" and "window" with "timeframe".