### PR TITLE
Synthesize DigitalOcean API CORS preflight responses

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -150,13 +150,29 @@ function getWebAppUrl() {
 
 // Digital Ocean stopped sending 'Acces-Control-Allow-Origin' headers in some API responses
 // (i.e. v2/droplets). As a workaround, intercept DO API requests and preemptively inject the
-// header to allow our origin.
+// header to allow our origin.  Additionally, some OPTIONS requests return 403. Modify the response
+// status code and inject CORS response headers.
 function workaroundDigitalOceanApiCors() {
   const headersFilter = {urls: ['https://api.digitalocean.com/*']};
   electron.session.defaultSession.webRequest.onHeadersReceived(
       // tslint:disable-next-line:no-any
       headersFilter, (details: any, callback: Function) => {
-        details.responseHeaders['access-control-allow-origin'] = ['outline://web_app'];
+        if (details.method === 'OPTIONS') {
+          details.responseHeaders['access-control-allow-origin'] = ['outline://web_app'];
+          if (details.statusCode === 403) {
+            details.statusCode = 200;
+            details.statusLine = 'HTTP/1.1 200';
+            details.responseHeaders['status'] = ['200'];
+            details.responseHeaders['access-control-allow-headers'] =
+                [details.headers['Access-Control-Request-Headers']];
+            details.responseHeaders['access-control-allow-credentials'] = ['true'];
+            details.responseHeaders['access-control-allow-methods'] =
+                ['GET, POST, PUT, PATCH, DELETE, OPTIONS'];
+            details.responseHeaders['access-control-expose-headers'] =
+                ['RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Total, Link'];
+            details.responseHeaders['access-control-max-age'] = ['86400'];
+          }
+        }
         callback(details);
       });
 }


### PR DESCRIPTION
* DigitalOcean API OPTIONS requests are failing with status code 403. 
* As a workaround, synthesize successful preflight responses by injecting CORS headers and modifying the reponse status code to 200.
* Fixes #476.