### PR TITLE
Server data usage timeframe

### DIFF
--- a/src/server_manager/model/server.ts
+++ b/src/server_manager/model/server.ts
@@ -151,7 +151,7 @@ export interface AccessKey {
   accessUrl: string;
 }
 
-// Byte transfer stats for the past 30 days, including both inbound and outbound.
+// Byte transfer stats for a sliding timeframe, including both inbound and outbound.
 // TODO: this is copied at src/shadowbox/model/metrics.ts.  Both copies should
 // be kept in sync, until we can find a way to share code between the web_app
 // and shadowbox.

--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -122,7 +122,7 @@ curl --insecure -X DELETE $API_URL/access-keys/2
 Set an access key data limit
 (e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding timeframe)
 ```
-curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"limit": {"data": {"bytes": 1000}, "timeframe": {"hours": 1}}}' $API_URL/access-keys/2/data-limit
+curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"limit": {"bytes": 1000}}' $API_URL/access-keys/2/data-limit
 ```
 
 Remove an access key data limit

--- a/src/shadowbox/infrastructure/prometheus_scraper.ts
+++ b/src/shadowbox/infrastructure/prometheus_scraper.ts
@@ -99,9 +99,7 @@ export function runPrometheusScraper(
 async function waitForPrometheusReady(prometheusEndpoint: string) {
   logging.debug('Waiting for Prometheus to be ready...');
   while (!(await isHttpEndpointHealthy(prometheusEndpoint))) {
-    await new Promise((resolve) => setTimeout(() => {
-                        resolve();
-                      }, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
   logging.debug('Prometheus is ready');
 }

--- a/src/shadowbox/infrastructure/prometheus_scraper.ts
+++ b/src/shadowbox/infrastructure/prometheus_scraper.ts
@@ -74,44 +74,41 @@ export function runPrometheusScraper(
     prometheusEndpoint: string): Promise<child_process.ChildProcess> {
   mkdirp.sync(path.dirname(configFilename));
   const ymlTxt = jsyaml.safeDump(configJson, {'sortKeys': true});
-  return new Promise((resolve, reject) => {
-    fs.writeFile(configFilename, ymlTxt, 'utf-8', async (err) => {
-      if (err) {
-        reject(err);
-      }
-      const commandArguments = ['--config.file', configFilename];
-      commandArguments.push(...args);
-      const runProcess = child_process.spawn('/root/shadowbox/bin/prometheus', commandArguments);
-      runProcess.on('error', (error) => {
-        logging.error(`Error spawning prometheus: ${error}`);
-      });
-      // TODO(fortuna): Add restart logic.
-      runProcess.on('exit', (code, signal) => {
-        logging.info(`prometheus has exited with error. Code: ${code}, Signal: ${signal}`);
-      });
-      // TODO(fortuna): Disable this for production.
-      // TODO(fortuna): Consider saving the output and expose it through the manager service.
-      runProcess.stdout.pipe(process.stdout);
-      runProcess.stderr.pipe(process.stderr);
-
-      await waitForPrometheusReady(prometheusEndpoint);
-      resolve(runProcess);
+  fs.writeFileSync(configFilename, ymlTxt, 'utf-8');
+  return new Promise(async (resolve, reject) => {
+    const commandArguments = ['--config.file', configFilename];
+    commandArguments.push(...args);
+    const runProcess = child_process.spawn('/root/shadowbox/bin/prometheus', commandArguments);
+    runProcess.on('error', (error) => {
+      logging.error(`Error spawning prometheus: ${error}`);
     });
+    // TODO(fortuna): Add restart logic.
+    runProcess.on('exit', (code, signal) => {
+      logging.info(`prometheus has exited with error. Code: ${code}, Signal: ${signal}`);
+    });
+    // TODO(fortuna): Disable this for production.
+    // TODO(fortuna): Consider saving the output and expose it through the manager service.
+    runProcess.stdout.pipe(process.stdout);
+    runProcess.stderr.pipe(process.stderr);
+
+    await waitForPrometheusReady(prometheusEndpoint);
+    resolve(runProcess);
   });
 }
 
 async function waitForPrometheusReady(prometheusEndpoint: string) {
   logging.debug('Waiting for Prometheus to be ready...');
-  let ready = false;
-  while (!ready) {
-    ready = await isPrometheusReady(prometheusEndpoint);
+  while (!(await isHttpEndpointHealthy(prometheusEndpoint))) {
+    await new Promise((resolve) => setTimeout(() => {
+                        resolve();
+                      }, 1000));
   }
   logging.debug('Prometheus is ready');
 }
 
-function isPrometheusReady(prometheusEndpoint: string): Promise<boolean> {
+function isHttpEndpointHealthy(endpoint: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    http.get(prometheusEndpoint, (response) => {
+    http.get(endpoint, (response) => {
           resolve(true);
         }).on('error', (e) => {
       // Prometheus is not ready yet.

--- a/src/shadowbox/infrastructure/prometheus_scraper.ts
+++ b/src/shadowbox/infrastructure/prometheus_scraper.ts
@@ -94,7 +94,6 @@ export async function runPrometheusScraper(
   runProcess.on('exit', (code, signal) => {
     logging.info(`prometheus has exited with error. Code: ${code}, Signal: ${signal}`);
   });
-  // TODO(fortuna): Disable this for production.
   // TODO(fortuna): Consider saving the output and expose it through the manager service.
   runProcess.stdout.pipe(process.stdout);
   runProcess.stderr.pipe(process.stderr);

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -29,16 +29,8 @@ export interface ProxyParams {
   readonly password: string;
 }
 
-// Data transfer limit measured in bytes.
-export interface AccessKeyDataLimit { readonly bytes: number; }
-
-// Parameters needed to limit access key data usage.
-export interface AccessKeyDataLimitUsage {
-  // Data transfer limit on this access key.
-  readonly limit: AccessKeyDataLimit;
-  // Data transferred by this access key over a timeframe specified by the server.
-  usageBytes: number;
-}
+// Data transfer measured in bytes.
+export interface DataUsage { readonly bytes: number; }
 
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.
 export interface AccessKey {
@@ -51,7 +43,9 @@ export interface AccessKey {
   // Parameters to access the proxy
   readonly proxyParams: ProxyParams;
   // Admin-controlled, data transfer limit for this access key. Unlimited if unset.
-  readonly dataLimitUsage?: AccessKeyDataLimitUsage;
+  readonly dataLimit?: DataUsage;
+  // Data transferred by this access key over a timeframe specified by the server.
+  readonly dataUsage: DataUsage;
   // Returns whether the access key has exceeded its data transfer limit.
   isOverDataLimit(): boolean;
 }
@@ -70,7 +64,7 @@ export interface AccessKeyRepository {
   // Gets the metrics id for a given Access Key.
   getMetricsId(id: AccessKeyId): AccessKeyMetricsId|undefined;
   // Sets the transfer limit for the specified access key. Throws on failure.
-  setAccessKeyDataLimit(id: AccessKeyId, limit: AccessKeyDataLimit): Promise<void>;
+  setAccessKeyDataLimit(id: AccessKeyId, limit: DataUsage): Promise<void>;
   // Clears the transfer limit for the specified access key. Throws on failure.
   removeAccessKeyDataLimit(id: AccessKeyId): Promise<void>;
   // Sets the data usage timeframe for access key data limit enforcement. Throws on failure.

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -74,5 +74,5 @@ export interface AccessKeyRepository {
   // Clears the transfer limit for the specified access key. Throws on failure.
   removeAccessKeyDataLimit(id: AccessKeyId): Promise<void>;
   // Sets the data usage timeframe for access key data limit enforcement. Throws on failure.
-  setDataLimitTimeframe(timeframe: DataUsageTimeframe): Promise<void>;
+  setDataUsageTimeframe(timeframe: DataUsageTimeframe): Promise<void>;
 }

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DataUsageTimeframe} from '../model/metrics';
+
 export type AccessKeyId = string;
 export type AccessKeyMetricsId = string;
 
@@ -27,20 +29,15 @@ export interface ProxyParams {
   readonly password: string;
 }
 
-// Parameters needed to limit access key data usage over a sliding timeframe.
-export interface AccessKeyDataLimit {
-  // The allowed metered data transfer measured in bytes.
-  readonly data: {bytes: number};
-  // The sliding timeframe size in hours.
-  readonly timeframe: {hours: number};
-}
+// Data transfer limit measured in bytes.
+export interface AccessKeyDataLimit { readonly bytes: number; }
 
-// Parameters needed to enforce an access key data transfer limit.
+// Parameters needed to limit access key data usage.
 export interface AccessKeyDataLimitUsage {
   // Data transfer limit on this access key.
   readonly limit: AccessKeyDataLimit;
-  // Data transferred by this access key over the limit timeframe.
-  readonly usage: {bytes: number};
+  // Data transferred by this access key over a timeframe specified by the server.
+  usageBytes: number;
 }
 
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.
@@ -76,4 +73,6 @@ export interface AccessKeyRepository {
   setAccessKeyDataLimit(id: AccessKeyId, limit: AccessKeyDataLimit): Promise<void>;
   // Clears the transfer limit for the specified access key. Throws on failure.
   removeAccessKeyDataLimit(id: AccessKeyId): Promise<void>;
+  // Sets the data usage timeframe for access key data limit enforcement. Throws on failure.
+  setDataLimitTimeframe(timeframe: DataUsageTimeframe): Promise<void>;
 }

--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -41,7 +41,12 @@ export class AccessKeyNotFound extends OutlineError {
 
 export class InvalidAccessKeyDataLimit extends OutlineError {
   constructor() {
-    super(
-        'Must provide a limit value with positive integer values for "data.bytes" and "timeframe.hours"');
+    super('Must provide a limit with a positive integer value for "bytes"');
+  }
+}
+
+export class InvalidDataLimitTimeframe extends OutlineError {
+  constructor() {
+    super('Must provide a timeframe with a positive integer values for "hours"');
   }
 }

--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -41,7 +41,7 @@ export class AccessKeyNotFound extends OutlineError {
 
 export class InvalidAccessKeyDataLimit extends OutlineError {
   constructor() {
-    super('Must provide a limit with a positive integer value for "bytes"');
+    super('Must provide a limit with a non-negative integer value for "bytes"');
   }
 }
 

--- a/src/shadowbox/model/metrics.ts
+++ b/src/shadowbox/model/metrics.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Byte transfer metrics for the past 30 days, including both inbound and outbound.
+// Byte transfer metrics for a sliding timeframe, including both inbound and outbound.
 // TODO: this is copied at src/model/server.ts.  Both copies should
 // be kept in sync, until we can find a way to share code between the web_app
 // and shadowbox.
@@ -23,3 +23,6 @@ export interface DataUsageByUser {
   // TODO: rename this to AccessKeyId in a backwards compatible way.
   bytesTransferredByUserId: {[userId: string]: number};
 }
+
+// Sliding time frame for measuring data utilization.
+export interface DataUsageTimeframe { hours: number; }

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -52,6 +52,26 @@ paths:
           description: The requested port wasn't an integer from 1 through 65535, or the request had no port parameter.
         '409':
           description: The requested port was already in use by another service.
+  /server/data-usage-timeframe:
+    put:
+      description: Sets the sliding timeframe for measuring data usage and enforcing access keys data limits.
+      tags:
+        - Server
+        - Data limit
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DataUsageTimeframe"
+            examples:
+              '0':
+                value: "{hours: 24}"
+      responses:
+        '204':
+          description: The data usage timeframe was sucessfully changed.
+        '400':
+          description: Invalid timeframe value.
 
   /name:
     put:
@@ -165,10 +185,10 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
+              $ref: "#/components/schemas/AccessKeyDataLimit"
+            examples:
+              '0':
+                value: "{bytes: 10000}"
       responses:
         '204':
           description: Access key renamed successfully
@@ -195,10 +215,12 @@ paths:
                 $ref: "#/components/schemas/AccessKeyDataLimit"
               examples:
                 '0':
-                  value: "{limitBytes: 1000000, timeframeHours: 24}"
+                  value: "{bytes: 10000}"
       responses:
         '204':
           description: Access key limit set successfully
+        '400':
+          description: Invalid data limit
         '404':
           description: Access key inexistent
     delete:
@@ -292,18 +314,19 @@ components:
           type: number
         portForNewAccessKeys:
           type: integer
+        dataUsageTimeframe:
+          $ref: "#/components/schemas/DataUsageTimeframe"
+
+    DataUsageTimeframe:
+      properties:
+        hours:
+          type: integer
+
     AccessKeyDataLimit:
       properties:
-        data:
-          type: object
-          properties:
-            bytes:
-              type: integer
-        timeframe:
-          type: object
-          properties:
-            hours:
-              type: integer
+        bytes:
+          type: integer
+
     AccessKey:
       required:
         - id

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -321,11 +321,13 @@ components:
       properties:
         hours:
           type: integer
+          minimum: 1
 
     DataUsage:
       properties:
         bytes:
           type: integer
+          minimum: 0
 
     AccessKey:
       required:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -185,7 +185,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AccessKeyDataLimit"
+              $ref: "#/components/schemas/DataUsage"
             examples:
               '0':
                 value: "{bytes: 10000}"
@@ -212,7 +212,7 @@ paths:
         content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AccessKeyDataLimit"
+                $ref: "#/components/schemas/DataUsage"
               examples:
                 '0':
                   value: "{bytes: 10000}"
@@ -322,7 +322,7 @@ components:
         hours:
           type: integer
 
-    AccessKeyDataLimit:
+    DataUsage:
       properties:
         bytes:
           type: integer
@@ -344,4 +344,4 @@ components:
         accessUrl:
           type: string
         limit:
-          $ref: "#/components/schemas/AccessKeyDataLimit"
+          $ref: "#/components/schemas/DataUsage"

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -127,15 +127,17 @@ async function main() {
       new OutlineShadowsocksServer(
           getPersistentFilename('outline-ss-server/config.yml'), verbose, ssMetricsLocation)
           .enableCountryMetrics(MMDB_LOCATION);
-  runPrometheusScraper(
+  const prometheusEndpoint = `http://${prometheusLocation}`;
+  // Wait for Prometheus to be up and running.
+  await runPrometheusScraper(
       [
         '--storage.tsdb.retention', '31d', '--storage.tsdb.path',
         getPersistentFilename('prometheus/data'), '--web.listen-address', prometheusLocation,
         '--log.level', verbose ? 'debug' : 'info'
       ],
-      getPersistentFilename('prometheus/config.yml'), prometheusConfigJson);
+      getPersistentFilename('prometheus/config.yml'), prometheusConfigJson, prometheusEndpoint);
 
-  const prometheusClient = new PrometheusClient(`http://${prometheusLocation}`);
+  const prometheusClient = new PrometheusClient(prometheusEndpoint);
   if (!serverConfig.data().portForNewAccessKeys) {
     serverConfig.data().portForNewAccessKeys = await portProvider.reserveNewPort();
     serverConfig.write();

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -142,7 +142,7 @@ async function main() {
   }
   const accessKeyRepository = new ServerAccessKeyRepository(
       serverConfig.data().portForNewAccessKeys, proxyHostname, accessKeyConfig, shadowsocksServer,
-      prometheusClient);
+      prometheusClient, serverConfig.data().dataUsageTimeframe);
 
   const metricsReader = new PrometheusUsageMetrics(prometheusClient);
   const toMetricsId = (id: AccessKeyId) => {

--- a/src/shadowbox/server/manager_metrics.spec.ts
+++ b/src/shadowbox/server/manager_metrics.spec.ts
@@ -18,10 +18,10 @@ import {PrometheusManagerMetrics} from './manager_metrics';
 import {FakePrometheusClient} from './mocks/mocks';
 
 describe('PrometheusManagerMetrics', () => {
-  it('get30DayByteTransfer', async (done) => {
+  it('getOutboundByteTransfer', async (done) => {
     const managerMetrics = new PrometheusManagerMetrics(
         new FakePrometheusClient({'access-key-1': 1000, 'access-key-2': 10000}));
-    const dataUsage = await managerMetrics.get30DayByteTransfer();
+    const dataUsage = await managerMetrics.getOutboundByteTransfer({hours: 0});
     const bytesTransferredByUserId = dataUsage.bytesTransferredByUserId;
     expect(Object.keys(bytesTransferredByUserId).length).toEqual(2);
     expect(bytesTransferredByUserId['access-key-1']).toEqual(1000);

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -541,6 +541,9 @@ describe('ShadowsocksManagerService', () => {
       await service.setDataUsageTimeframe({params: {hours: -1}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
       });
+      await service.setDataUsageTimeframe({params: {hours: 0}}, res, (error) => {
+        expect(error.statusCode).toEqual(400);
+      });
       await service.setDataUsageTimeframe({params: {hours: 0.1}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
         responseProcessed = true;  // required for afterEach to pass.

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -535,16 +535,16 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerService('default name', null, repo, null, null);
       const res = {send: (httpCode, data) => {}};
-      await service.setDataUsageTimeframe({params: {}}, res, (error) => {
+      service.setDataUsageTimeframe({params: {}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
       });
-      await service.setDataUsageTimeframe({params: {hours: -1}}, res, (error) => {
+      service.setDataUsageTimeframe({params: {hours: -1}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
       });
-      await service.setDataUsageTimeframe({params: {hours: 0}}, res, (error) => {
+      service.setDataUsageTimeframe({params: {hours: 0}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
       });
-      await service.setDataUsageTimeframe({params: {hours: 0.1}}, res, (error) => {
+      service.setDataUsageTimeframe({params: {hours: 0.1}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
         responseProcessed = true;  // required for afterEach to pass.
         done();

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -552,7 +552,7 @@ describe('ShadowsocksManagerService', () => {
     });
     it('returns 500 when the repository throws an exception', async (done) => {
       const repo = getAccessKeyRepository();
-      spyOn(repo, 'setDataLimitTimeframe').and.throwError('cannot write to disk');
+      spyOn(repo, 'setDataUsageTimeframe').and.throwError('cannot write to disk');
       const serverConfig = new InMemoryConfig({} as ServerConfigJson);
       const service = new ShadowsocksManagerService('default name', serverConfig, repo, null, null);
       serverConfig.data().dataUsageTimeframe = {hours: 123};

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -266,7 +266,7 @@ export class ShadowsocksManagerService {
     try {
       logging.debug(`setDataUsageTimeframe request ${JSON.stringify(req.params)}`);
       const hours = req.params.hours;
-      if (!hours) {
+      if (hours === undefined) {  // The access key repository will validate the value.
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Missing `hours` parameter'));
       }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -231,6 +231,9 @@ export class ShadowsocksManagerService {
       if (!limit) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Missing `limit` parameter'));
+      } else if (!Number.isInteger(limit.bytes)) {
+        return next(
+            new restify.InvalidArgumentError({statusCode: 400}, '`limit` must be an integer'));
       }
       await this.accessKeys.setAccessKeyDataLimit(accessKeyId, limit);
       res.send(HttpSuccess.NO_CONTENT);
@@ -270,8 +273,8 @@ export class ShadowsocksManagerService {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Missing `hours` parameter'));
       } else if (!Number.isInteger(hours)) {
-        return next(new restify.InvalidArgumentError(
-            {statusCode: 400}, '`hours` must be an integer'));
+        return next(
+            new restify.InvalidArgumentError({statusCode: 400}, '`hours` must be an integer'));
       }
       const dataUsageTimeframe = {hours};
       this.accessKeys.setDataUsageTimeframe(dataUsageTimeframe);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -292,6 +292,8 @@ export class ShadowsocksManagerService {
   }
 
   public async getDataUsage(req: RequestType, res: ResponseType, next: restify.Next) {
+    // TODO(alalama): use AccessKey.dataUsage to avoid querying Prometheus. Deprecate this call in
+    // the manager in favor of `GET /access-keys`.
     try {
       const timeframe = this.serverConfig.data().dataUsageTimeframe;
       res.send(HttpSuccess.OK, await this.managerMetrics.getOutboundByteTransfer(timeframe));

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -52,7 +52,7 @@ interface RequestParams {
   id?: string;
   name?: string;
   metricsEnabled?: boolean;
-  limit?: DataUsage;
+  limit?: DataUsage|{};
   port?: number;
   hours?: number;
 }
@@ -227,7 +227,7 @@ export class ShadowsocksManagerService {
     try {
       logging.debug(`setAccessKeyDataLimit request ${JSON.stringify(req.params)}`);
       const accessKeyId = req.params.id;
-      const limit = req.params.limit;
+      const limit = req.params.limit as DataUsage;
       if (!limit) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Missing `limit` parameter'));

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -262,16 +262,19 @@ export class ShadowsocksManagerService {
     }
   }
 
-  public async setDataUsageTimeframe(req: RequestType, res: ResponseType, next: restify.Next) {
+  public setDataUsageTimeframe(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`setDataUsageTimeframe request ${JSON.stringify(req.params)}`);
       const hours = req.params.hours;
       if (hours === undefined) {  // The access key repository will validate the value.
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Missing `hours` parameter'));
+      } else if (!Number.isInteger(hours)) {
+        return next(new restify.InvalidArgumentError(
+            {statusCode: 400}, '`hours` must be an integer'));
       }
       const dataUsageTimeframe = {hours};
-      await this.accessKeys.setDataUsageTimeframe(dataUsageTimeframe);
+      this.accessKeys.setDataUsageTimeframe(dataUsageTimeframe);
       this.serverConfig.data().dataUsageTimeframe = dataUsageTimeframe;
       this.serverConfig.write();
       res.send(HttpSuccess.NO_CONTENT);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -54,6 +54,7 @@ interface RequestParams {
   metricsEnabled?: boolean;
   limit?: AccessKeyDataLimit;
   port?: number;
+  hours?: number;
 }
 interface RequestType {
   params: RequestParams;
@@ -74,6 +75,8 @@ export function bindService(
   apiServer.put(
       `${apiPrefix}/server/port-for-new-access-keys`,
       service.setPortForNewAccessKeys.bind(service));
+  apiServer.put(
+      `${apiPrefix}/server/data-usage-timeframe`, service.setDataUsageTimeframe.bind(service));
 
   apiServer.post(`${apiPrefix}/access-keys`, service.createNewAccessKey.bind(service));
   apiServer.get(`${apiPrefix}/access-keys`, service.listAccessKeys.bind(service));
@@ -122,7 +125,8 @@ export class ShadowsocksManagerService {
       serverId: this.serverConfig.data().serverId,
       metricsEnabled: this.serverConfig.data().metricsEnabled || false,
       createdTimestampMs: this.serverConfig.data().createdTimestampMs,
-      portForNewAccessKeys: this.serverConfig.data().portForNewAccessKeys
+      portForNewAccessKeys: this.serverConfig.data().portForNewAccessKeys,
+      dataUsageTimeframe: this.serverConfig.data().dataUsageTimeframe
     });
     next();
   }
@@ -258,9 +262,33 @@ export class ShadowsocksManagerService {
     }
   }
 
+  public async setDataUsageTimeframe(req: RequestType, res: ResponseType, next: restify.Next) {
+    try {
+      logging.debug(`setDataUsageTimeframe request ${JSON.stringify(req.params)}`);
+      const hours = req.params.hours;
+      if (!hours) {
+        return next(
+            new restify.MissingParameterError({statusCode: 400}, 'Missing `hours` parameter'));
+      }
+      const dataUsageTimeframe = {hours};
+      await this.accessKeys.setDataLimitTimeframe(dataUsageTimeframe);
+      this.serverConfig.data().dataUsageTimeframe = dataUsageTimeframe;
+      this.serverConfig.write();
+      res.send(HttpSuccess.NO_CONTENT);
+      return next();
+    } catch (error) {
+      logging.error(error);
+      if (error instanceof errors.InvalidDataLimitTimeframe) {
+        return next(new restify.InvalidArgumentError({statusCode: 400}, error.message));
+      }
+      return next(new restify.InternalServerError());
+    }
+  }
+
   public async getDataUsage(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
-      res.send(HttpSuccess.OK, await this.managerMetrics.get30DayByteTransfer());
+      const timeframe = this.serverConfig.data().dataUsageTimeframe;
+      res.send(HttpSuccess.OK, await this.managerMetrics.getOutboundByteTransfer(timeframe));
       return next();
     } catch (error) {
       logging.error(error);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -271,7 +271,7 @@ export class ShadowsocksManagerService {
             new restify.MissingParameterError({statusCode: 400}, 'Missing `hours` parameter'));
       }
       const dataUsageTimeframe = {hours};
-      await this.accessKeys.setDataLimitTimeframe(dataUsageTimeframe);
+      await this.accessKeys.setDataUsageTimeframe(dataUsageTimeframe);
       this.serverConfig.data().dataUsageTimeframe = dataUsageTimeframe;
       this.serverConfig.write();
       res.send(HttpSuccess.NO_CONTENT);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -17,7 +17,7 @@ import {makeConfig, SIP002_URI} from 'ShadowsocksConfig/shadowsocks_config';
 
 import {JsonConfig} from '../infrastructure/json_config';
 import * as logging from '../infrastructure/logging';
-import {AccessKey, AccessKeyDataLimit, AccessKeyRepository} from '../model/access_key';
+import {AccessKey, AccessKeyRepository, DataUsage} from '../model/access_key';
 import * as errors from '../model/errors';
 
 import {ManagerMetrics} from './manager_metrics';
@@ -42,7 +42,7 @@ function accessKeyToJson(accessKey: AccessKey) {
       password: accessKey.proxyParams.password,
       outline: 1,
     })),
-    limit: accessKey.dataLimitUsage ? accessKey.dataLimitUsage.limit : undefined
+    dataLimit: accessKey.dataLimit
   };
 }
 
@@ -52,7 +52,7 @@ interface RequestParams {
   id?: string;
   name?: string;
   metricsEnabled?: boolean;
-  limit?: AccessKeyDataLimit;
+  limit?: DataUsage;
   port?: number;
   hours?: number;
 }

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -56,9 +56,8 @@ export class FakePrometheusClient extends PrometheusClient {
 
   async query(query: string): Promise<QueryResultData> {
     const accessKeyIdMatch = query.match(/access_key="(.*?)"/);
-    const accessKeyIds = Object.keys(this.bytesTransferredById);
     const queryResultData = {result: []} as QueryResultData;
-    for (const accessKeyId of accessKeyIds) {
+    for (const accessKeyId of Object.keys(this.bytesTransferredById)) {
       const bytesTransferred = this.bytesTransferredById[accessKeyId] || 0;
       queryResultData.result.push(
           {metric: {'access_key': accessKeyId}, value: [bytesTransferred, `${bytesTransferred}`]});

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -56,13 +56,7 @@ export class FakePrometheusClient extends PrometheusClient {
 
   async query(query: string): Promise<QueryResultData> {
     const accessKeyIdMatch = query.match(/access_key="(.*?)"/);
-    let accessKeyIds: string[];
-    if (accessKeyIdMatch && accessKeyIdMatch[1]) {
-      // Return query results only for the specified access key.
-      accessKeyIds = [accessKeyIdMatch[1]];
-    } else {
-      accessKeyIds = Object.keys(this.bytesTransferredById);
-    }
+    const accessKeyIds = Object.keys(this.bytesTransferredById);
     const queryResultData = {result: []} as QueryResultData;
     for (const accessKeyId of accessKeyIds) {
       const bytesTransferred = this.bytesTransferredById[accessKeyId] || 0;

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -432,18 +432,18 @@ describe('ServerAccessKeyRepository', () => {
     done();
   });
 
-  it('getOutboundByteTransfer', async (done) => {
+  it('getUsageBytes', async (done) => {
     const prometheusClient = new FakePrometheusClient({'0': 1024});
     const repo = new RepoBuilder().prometheusClient(prometheusClient).build();
-    const bytesTransferred = await repo.getOutboundByteTransfer('0');
+    const bytesTransferred = await repo.getUsageBytes('0');
     expect(bytesTransferred).toEqual(1024);
     done();
   });
 
-  it('getOutboundByteTransfer returns zero when ID is missing', async (done) => {
+  it('getUsageBytes returns zero when ID is missing', async (done) => {
     const prometheusClient = new FakePrometheusClient({'0': 1024});
     const repo = new RepoBuilder().prometheusClient(prometheusClient).build();
-    const bytesTransferred = await repo.getOutboundByteTransfer('doesnotexist');
+    const bytesTransferred = await repo.getUsageBytes('doesnotexist');
     expect(bytesTransferred).toEqual(0);
     done();
   });

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -448,18 +448,18 @@ describe('ServerAccessKeyRepository', () => {
     done();
   });
 
-  it('getDataLimitTimeframe returns the data limit timeframe', async (done) => {
+  it('getDataUsageTimeframe returns the data limit timeframe', async (done) => {
     const timeframe = {hours: 12345};
     const repo = new RepoBuilder().dataUsageTimeframe(timeframe).build();
-    expect(repo.getDataLimitTimeframe()).toEqual(timeframe);
+    expect(repo.getDataUsageTimeframe()).toEqual(timeframe);
     done();
   });
 
-  it('setDataLimitTimeframe sets the data limit timeframe', async (done) => {
+  it('setDataUsageTimeframe sets the data limit timeframe', async (done) => {
     const repo = new RepoBuilder().build();
     const timeframe = {hours: 12345};
-    await repo.setDataLimitTimeframe(timeframe);
-    expect(repo.getDataLimitTimeframe()).toEqual(timeframe);
+    await repo.setDataUsageTimeframe(timeframe);
+    expect(repo.getDataUsageTimeframe()).toEqual(timeframe);
     done();
   });
 });

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -59,7 +59,7 @@ class ServerAccessKey implements AccessKey {
   }
 }
 
-function isValidAccessKeyDataLimit(limit: DataUsage) {
+function isValidAccessKeyDataLimit(limit: DataUsage): boolean {
   return limit && limit.bytes >= 0;
 }
 

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -60,7 +60,7 @@ class ServerAccessKey implements AccessKey {
 }
 
 function isValidAccessKeyDataLimit(limit: DataUsage) {
-  return limit && Number.isInteger(limit.bytes) && limit.bytes >= 0;
+  return limit && limit.bytes >= 0;
 }
 
 // Generates a random password for Shadowsocks access keys.

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -208,7 +208,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
   }
 
   async setDataLimitTimeframe(timeframe: DataUsageTimeframe) {
-    if (!timeframe || !Number.isInteger(timeframe.hours) || timeframe.hours < 0) {
+    if (!timeframe || !Number.isInteger(timeframe.hours) || timeframe.hours <= 0) {
       throw new errors.InvalidDataLimitTimeframe();
     }
     this.dataLimitTimeframe = timeframe;

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -190,7 +190,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
       throw new errors.InvalidAccessKeyDataLimit();
     }
     const accessKey = this.getAccessKey(id);
-    const usageBytes = await this.getOutboundByteTransfer(id);
+    const usageBytes = await this.getUsageBytes(id);
     const limitStatusChanged = this.updateAccessKeyDataLimitStatus(accessKey, {limit, usageBytes});
     this.saveAccessKeys();
     if (limitStatusChanged) {
@@ -258,7 +258,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
 
   // Retrieves access key outbound data transfer in bytes for `accessKeyId` from a Prometheus
   // instance.
-  async getOutboundByteTransfer(accessKeyId: string): Promise<number> {
+  async getUsageBytes(accessKeyId: string): Promise<number> {
     const escapedAccessKeyId = JSON.stringify(accessKeyId);
     let bytesTransferred = 0;
     const result = await this.prometheusClient.query(

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -207,7 +207,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
     }
   }
 
-  async setDataLimitTimeframe(timeframe: DataUsageTimeframe) {
+  async setDataUsageTimeframe(timeframe: DataUsageTimeframe) {
     if (!timeframe || !Number.isInteger(timeframe.hours) || timeframe.hours <= 0) {
       throw new errors.InvalidDataLimitTimeframe();
     }
@@ -215,7 +215,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
     await this.enforceAccessKeyDataLimits();
   }
 
-  getDataLimitTimeframe(): DataUsageTimeframe {
+  getDataUsageTimeframe(): DataUsageTimeframe {
     return this.dataLimitTimeframe;
   }
 

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -211,7 +211,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
   }
 
   setDataUsageTimeframe(timeframe: DataUsageTimeframe): Promise<void> {
-    if (!timeframe || !Number.isInteger(timeframe.hours) || timeframe.hours <= 0) {
+    if (!timeframe || timeframe.hours <= 0) {
       throw new errors.InvalidDataLimitTimeframe();
     }
     this.dataLimitTimeframe = timeframe;

--- a/src/shadowbox/server/server_config.ts
+++ b/src/shadowbox/server/server_config.ts
@@ -15,6 +15,7 @@
 import * as uuidv4 from 'uuid/v4';
 
 import * as json_config from '../infrastructure/json_config';
+import {DataUsageTimeframe} from '../model/metrics';
 
 // Serialized format for the server config.
 // WARNING: Renaming fields will break backwards-compatibility.
@@ -31,6 +32,8 @@ export interface ServerConfigJson {
   portForNewAccessKeys?: number;
   // Which staged rollouts we should force enabled or disabled.
   rollouts?: RolloutConfigJson[];
+  // Sliding timeframe, in hours, used to measure data usage and enforce data limits.
+  dataUsageTimeframe?: DataUsageTimeframe;
 }
 
 // Serialized format for rollouts.
@@ -49,6 +52,7 @@ export function readServerConfig(filename: string): json_config.JsonConfig<Serve
     config.data().serverId = config.data().serverId || uuidv4();
     config.data().metricsEnabled = config.data().metricsEnabled || false;
     config.data().createdTimestampMs = config.data().createdTimestampMs || Date.now();
+    config.data().dataUsageTimeframe = config.data().dataUsageTimeframe || {hours: 30 * 24};
     config.write();
     return config;
   } catch (error) {


### PR DESCRIPTION
* Implements a server data usage timeframe, used to report access key data usage metrics (`GET /metrics/transfer`) and to enforce access key data limits.
* Exposes an API endpoint, `PUT /server/data-usage-timeframe`, to configure this value. The default is 30 days for backwards compatibility with the existing `GET metrics/transfer` timeframe.
* The data usage timeframe can be retrieved through the `GET /server` endpoint.
* Previously, access key data limits supported individual timeframes per key in order to calculate data utlization. The timeframe is now shared between all access keys with data limits.
* Updates the `PUT /access-key/[:id]/data-limit` API to reflect the shared timeframe.