### PR TITLE
Notify users of all ports in use by access keys

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -342,7 +342,7 @@ function check_firewall() {
      FIREWALL_STATUS="\
 You won’t be able to access it externally, despite your server being correctly
 set up, because there's a firewall (in this machine, your router or cloud
-provider) that is preventing incoming connections to ports ${API_PORT} and ${ACCESS_KEY_PORTS}."
+provider) that is preventing incoming connections to the management port ${API_PORT} and the access key port(s) ${ACCESS_KEY_PORTS}."
   else
     FIREWALL_STATUS="\
 If you have connection problems, it may be that your router or cloud provider


### PR DESCRIPTION
The old behavior was to use the port of the first access key, but this can miss many ports in use by the others.

New output looks like

`- Access key ports [ 25356,  12345,  60000,  21274,  6675,  29941,  55826,  38810,  5604,  5568,  43112 ] for TCP and UDP`