### PR TITLE
Improve type safety of manager service request parameters

### DIFF
--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -45,7 +45,7 @@ export class InvalidAccessKeyDataLimit extends OutlineError {
   }
 }
 
-export class InvalidDataLimitTimeframe extends OutlineError {
+export class InvalidDataUsageTimeframe extends OutlineError {
   constructor() {
     super('Must provide a timeframe with a positive integer values for "hours"');
   }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -98,7 +98,7 @@ interface SetShareMetricsParams {
 }
 
 // User type guard to validate that `params` is of type RequestParams and contains `property`.
-function hasParameter(params: RequestParams|{}, property: string): params is RequestParams {
+function isRequestParam(params: RequestParams|{}, property: string): params is RequestParams {
   return property in (params as RequestParams);
 }
 
@@ -113,7 +113,7 @@ export class ShadowsocksManagerService {
 
   public renameServer(req: RequestType, res: ResponseType, next: restify.Next): void {
     logging.debug(`renameServer request ${JSON.stringify(req.params)}`);
-    if (!hasParameter(req.params, 'name')) {
+    if (!isRequestParam(req.params, 'name')) {
       return next(
           new restify.MissingParameterError({statusCode: 400}, 'Parameter `name` is missing'));
     }
@@ -173,7 +173,7 @@ export class ShadowsocksManagerService {
       Promise<void> {
     try {
       logging.debug(`setPortForNewAccessKeys request ${JSON.stringify(req.params)}`);
-      if (!hasParameter(req.params, 'port')) {
+      if (!isRequestParam(req.params, 'port')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `port` is missing'));
       }
@@ -203,7 +203,7 @@ export class ShadowsocksManagerService {
   public removeAccessKey(req: RequestType, res: ResponseType, next: restify.Next): void {
     try {
       logging.debug(`removeAccessKey request ${JSON.stringify(req.params)}`);
-      if (!hasParameter(req.params, 'id')) {
+      if (!isRequestParam(req.params, 'id')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
       }
@@ -223,10 +223,11 @@ export class ShadowsocksManagerService {
   public renameAccessKey(req: RequestType, res: ResponseType, next: restify.Next): void {
     try {
       logging.debug(`renameAccessKey request ${JSON.stringify(req.params)}`);
-      if (!hasParameter(req.params, 'id')) {
+      if (!isRequestParam(req.params, 'id')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
-      } else if (!hasParameter(req.params, 'name')) {
+      }
+      if (!isRequestParam(req.params, 'name')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `name` is missing'));
       }
@@ -246,10 +247,11 @@ export class ShadowsocksManagerService {
   public async setAccessKeyDataLimit(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`setAccessKeyDataLimit request ${JSON.stringify(req.params)}`);
-      if (!hasParameter(req.params, 'id')) {
+      if (!isRequestParam(req.params, 'id')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
-      } else if (!hasParameter(req.params, 'limit')) {
+      }
+      if (!isRequestParam(req.params, 'limit')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `limit` is missing'));
       }
@@ -279,7 +281,7 @@ export class ShadowsocksManagerService {
   public async removeAccessKeyDataLimit(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`removeAccessKeyDataLimit request ${JSON.stringify(req.params)}`);
-      if (!hasParameter(req.params, 'id')) {
+      if (!isRequestParam(req.params, 'id')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
       }
@@ -299,7 +301,7 @@ export class ShadowsocksManagerService {
   public setDataUsageTimeframe(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`setDataUsageTimeframe request ${JSON.stringify(req.params)}`);
-      if (!hasParameter(req.params, 'hours')) {
+      if (!isRequestParam(req.params, 'hours')) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `hours` is missing'));
       }
@@ -343,7 +345,7 @@ export class ShadowsocksManagerService {
 
   public setShareMetrics(req: RequestType, res: ResponseType, next: restify.Next): void {
     logging.debug(`setShareMetrics request ${JSON.stringify(req.params)}`);
-    if (!hasParameter(req.params, 'metricsEnabled')) {
+    if (!isRequestParam(req.params, 'metricsEnabled')) {
       return next(new restify.MissingParameterError(
           {statusCode: 400}, 'Parameter `metricsEnabled` is missing'));
     }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -318,7 +318,7 @@ export class ShadowsocksManagerService {
       return next();
     } catch (error) {
       logging.error(error);
-      if (error instanceof errors.InvalidDataLimitTimeframe) {
+      if (error instanceof errors.InvalidDataUsageTimeframe) {
         return next(new restify.InvalidArgumentError({statusCode: 400}, error.message));
       }
       return next(new restify.InternalServerError());

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -46,18 +46,21 @@ function accessKeyToJson(accessKey: AccessKey) {
   };
 }
 
+// Type to reflect that we receive untyped JSON request parameters.
+interface RequestParams {
+  // Supported parameters:
+  //   id: string
+  //   name: string
+  //   metricsEnabled: boolean
+  //   limit: DataUsage
+  //   port: number
+  //   hours: number
+  [param: string]: unknown;
+}
 // Simplified request and response type interfaces containing only the
 // properties we actually use, to make testing easier.
-interface RequestParams {
-  id?: string;
-  name?: string;
-  metricsEnabled?: boolean;
-  limit?: DataUsage;
-  port?: number;
-  hours?: number;
-}
 interface RequestType {
-  params: RequestParams|{};
+  params: RequestParams;
 }
 interface ResponseType {
   send(code: number, data?: {}): void;
@@ -93,13 +96,14 @@ export function bindService(
   apiServer.put(`${apiPrefix}/metrics/enabled`, service.setShareMetrics.bind(service));
 }
 
-interface SetShareMetricsParams {
-  metricsEnabled: boolean;
-}
-
-// User type guard to validate that `params` is of type RequestParams and contains `property`.
-function isRequestParam(params: RequestParams|{}, property: string): params is RequestParams {
-  return property in (params as RequestParams);
+function validateAccessKeyId(accessKeyId: unknown): string {
+  if (!accessKeyId) {
+    throw new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing');
+  } else if (typeof accessKeyId !== 'string') {
+    throw new restify.InvalidArgumentError(
+        {statusCode: 400}, 'Parameter `id` must be of type string');
+  }
+  return accessKeyId;
 }
 
 // The ShadowsocksManagerService manages the access keys that can use the server
@@ -113,11 +117,11 @@ export class ShadowsocksManagerService {
 
   public renameServer(req: RequestType, res: ResponseType, next: restify.Next): void {
     logging.debug(`renameServer request ${JSON.stringify(req.params)}`);
-    if (!isRequestParam(req.params, 'name')) {
+    const name = req.params.name;
+    if (!name) {
       return next(
           new restify.MissingParameterError({statusCode: 400}, 'Parameter `name` is missing'));
     }
-    const name = req.params.name;
     if (typeof name !== 'string' || name.length > 100) {
       next(new restify.InvalidArgumentError(
           `Requested server name should be a string <= 100 characters long.  Got ${name}`));
@@ -173,15 +177,14 @@ export class ShadowsocksManagerService {
       Promise<void> {
     try {
       logging.debug(`setPortForNewAccessKeys request ${JSON.stringify(req.params)}`);
-      if (!isRequestParam(req.params, 'port')) {
+      const port = req.params.port;
+      if (!port) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `port` is missing'));
-      }
-      const port = req.params.port;
-      if (typeof port !== 'number') {
+      } else if (typeof port !== 'number') {
         return next(new restify.InvalidArgumentError(
             {statusCode: 400},
-            `Expected an numeric port, instead got ${port} of type ${typeof port}`));
+            `Expected a numeric port, instead got ${port} of type ${typeof port}`));
       }
       await this.accessKeys.setPortForNewAccessKeys(port);
       this.serverConfig.data().portForNewAccessKeys = port;
@@ -203,11 +206,7 @@ export class ShadowsocksManagerService {
   public removeAccessKey(req: RequestType, res: ResponseType, next: restify.Next): void {
     try {
       logging.debug(`removeAccessKey request ${JSON.stringify(req.params)}`);
-      if (!isRequestParam(req.params, 'id')) {
-        return next(
-            new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
-      }
-      const accessKeyId = req.params.id;
+      const accessKeyId = validateAccessKeyId(req.params.id);
       this.accessKeys.removeAccessKey(accessKeyId);
       res.send(HttpSuccess.NO_CONTENT);
       return next();
@@ -215,6 +214,8 @@ export class ShadowsocksManagerService {
       logging.error(error);
       if (error instanceof errors.AccessKeyNotFound) {
         return next(new restify.NotFoundError(error.message));
+      } else if (error instanceof restify.HttpError) {
+        return next(error);
       }
       return next(new restify.InternalServerError());
     }
@@ -223,22 +224,24 @@ export class ShadowsocksManagerService {
   public renameAccessKey(req: RequestType, res: ResponseType, next: restify.Next): void {
     try {
       logging.debug(`renameAccessKey request ${JSON.stringify(req.params)}`);
-      if (!isRequestParam(req.params, 'id')) {
-        return next(
-            new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
-      }
-      if (!isRequestParam(req.params, 'name')) {
+      const accessKeyId = validateAccessKeyId(req.params.id);
+      const name = req.params.name;
+      if (!name) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `name` is missing'));
+      } else if (typeof name !== 'string') {
+        return next(new restify.InvalidArgumentError(
+            {statusCode: 400}, 'Parameter `name` must be of type string'));
       }
-      const accessKeyId = req.params.id;
-      this.accessKeys.renameAccessKey(accessKeyId, req.params.name);
+      this.accessKeys.renameAccessKey(accessKeyId, name);
       res.send(HttpSuccess.NO_CONTENT);
       return next();
     } catch (error) {
       logging.error(error);
       if (error instanceof errors.AccessKeyNotFound) {
         return next(new restify.NotFoundError(error.message));
+      } else if (error instanceof restify.HttpError) {
+        return next(error);
       }
       return next(new restify.InternalServerError());
     }
@@ -247,22 +250,14 @@ export class ShadowsocksManagerService {
   public async setAccessKeyDataLimit(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`setAccessKeyDataLimit request ${JSON.stringify(req.params)}`);
-      if (!isRequestParam(req.params, 'id')) {
-        return next(
-            new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
-      }
-      if (!isRequestParam(req.params, 'limit')) {
-        return next(
-            new restify.MissingParameterError({statusCode: 400}, 'Parameter `limit` is missing'));
-      }
-      const accessKeyId = req.params.id;
+      const accessKeyId = validateAccessKeyId(req.params.id);
       const limit = req.params.limit as DataUsage;
       if (!limit) {
         return next(
-            new restify.MissingParameterError({statusCode: 400}, 'Missing `limit` parameter'));
+            new restify.MissingParameterError({statusCode: 400}, 'Parameter `limit` is missing'));
       } else if (!Number.isInteger(limit.bytes)) {
-        return next(
-            new restify.InvalidArgumentError({statusCode: 400}, '`limit` must be an integer'));
+        return next(new restify.InvalidArgumentError(
+            {statusCode: 400}, 'Parameter `limit.bytes` must be an integer'));
       }
       await this.accessKeys.setAccessKeyDataLimit(accessKeyId, limit);
       res.send(HttpSuccess.NO_CONTENT);
@@ -273,6 +268,8 @@ export class ShadowsocksManagerService {
         return next(new restify.InvalidArgumentError({statusCode: 400}, error.message));
       } else if (error instanceof errors.AccessKeyNotFound) {
         return next(new restify.NotFoundError(error.message));
+      } else if (error instanceof restify.HttpError) {
+        return next(error);
       }
       return next(new restify.InternalServerError());
     }
@@ -281,11 +278,7 @@ export class ShadowsocksManagerService {
   public async removeAccessKeyDataLimit(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`removeAccessKeyDataLimit request ${JSON.stringify(req.params)}`);
-      if (!isRequestParam(req.params, 'id')) {
-        return next(
-            new restify.MissingParameterError({statusCode: 400}, 'Parameter `id` is missing'));
-      }
-      const accessKeyId = req.params.id;
+      const accessKeyId = validateAccessKeyId(req.params.id);
       await this.accessKeys.removeAccessKeyDataLimit(accessKeyId);
       res.send(HttpSuccess.NO_CONTENT);
       return next();
@@ -293,6 +286,8 @@ export class ShadowsocksManagerService {
       logging.error(error);
       if (error instanceof errors.AccessKeyNotFound) {
         return next(new restify.NotFoundError(error.message));
+      } else if (error instanceof restify.HttpError) {
+        return next(error);
       }
       return next(new restify.InternalServerError());
     }
@@ -301,14 +296,15 @@ export class ShadowsocksManagerService {
   public setDataUsageTimeframe(req: RequestType, res: ResponseType, next: restify.Next) {
     try {
       logging.debug(`setDataUsageTimeframe request ${JSON.stringify(req.params)}`);
-      if (!isRequestParam(req.params, 'hours')) {
+      const hours = req.params.hours;
+      if (!hours) {
         return next(
             new restify.MissingParameterError({statusCode: 400}, 'Parameter `hours` is missing'));
       }
-      const hours = req.params.hours;
-      if (!Number.isInteger(hours)) {  // The access key repository will validate the value.
-        return next(
-            new restify.InvalidArgumentError({statusCode: 400}, '`hours` must be an integer'));
+      if (typeof hours !== 'number' ||
+          !Number.isInteger(hours)) {  // The access key repository will validate the value.
+        return next(new restify.InvalidArgumentError(
+            {statusCode: 400}, 'Parameter `hours` must be an integer'));
       }
       const dataUsageTimeframe = {hours};
       this.accessKeys.setDataUsageTimeframe(dataUsageTimeframe);
@@ -345,18 +341,15 @@ export class ShadowsocksManagerService {
 
   public setShareMetrics(req: RequestType, res: ResponseType, next: restify.Next): void {
     logging.debug(`setShareMetrics request ${JSON.stringify(req.params)}`);
-    if (!isRequestParam(req.params, 'metricsEnabled')) {
+    const metricsEnabled = req.params.metricsEnabled;
+    if (metricsEnabled === undefined || metricsEnabled === null) {
       return next(new restify.MissingParameterError(
           {statusCode: 400}, 'Parameter `metricsEnabled` is missing'));
+    } else if (typeof metricsEnabled !== 'boolean') {
+      return next(new restify.InvalidArgumentError(
+          {statusCode: 400}, 'Parameter `hours` must be an integer'));
     }
-    const enabledType = typeof req.params.metricsEnabled;
-    if (enabledType !== 'boolean') {
-      return next(
-          new restify.BadRequestError(`Expected metricsEnabled to be boolean.  Instead got ${
-              req.params.metricsEnabled}, with type ${enabledType}.`));
-    }
-    const enabled = req.params.metricsEnabled;
-    if (enabled) {
+    if (metricsEnabled) {
       this.metricsPublisher.startSharing();
     } else {
       this.metricsPublisher.stopSharing();

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -55,7 +55,6 @@ export class FakePrometheusClient extends PrometheusClient {
   }
 
   async query(query: string): Promise<QueryResultData> {
-    const accessKeyIdMatch = query.match(/access_key="(.*?)"/);
     const queryResultData = {result: []} as QueryResultData;
     for (const accessKeyId of Object.keys(this.bytesTransferredById)) {
       const bytesTransferred = this.bytesTransferredById[accessKeyId] || 0;

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -212,7 +212,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
 
   setDataUsageTimeframe(timeframe: DataUsageTimeframe): Promise<void> {
     if (!timeframe || timeframe.hours <= 0) {
-      throw new errors.InvalidDataLimitTimeframe();
+      throw new errors.InvalidDataUsageTimeframe();
     }
     this.dataLimitTimeframe = timeframe;
     return this.enforceAccessKeyDataLimits();


### PR DESCRIPTION
* Follow up to a review comment of #485.
* Adds a user type guard to the manager API request parameters.
* Changes the type of `RequestType.params` to  `RequestParams|{}` to reflect incoming untyped data.
* `s/errors.InvalidDataLimitTimeframe/errors.InvalidDataUsageTimeframe`

FYI, @fortuna, @JonathanDCohen.