### PR TITLE
Update outline-ss-server to v1.0.7 and docker node to v8.15.0

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -16,7 +16,7 @@
 FROM node:8.14.0-alpine
 
 # Versions can be found at https://github.com/Jigsaw-Code/outline-ss-server/releases
-ARG SS_VERSION=1.0.4
+ARG SS_VERSION=1.0.7
 
 # Save metadata on the software versions we are using.
 LABEL shadowbox.node_version=8.14.0

--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 # See versions at https://hub.docker.com/_/node/
-FROM node:8.14.0-alpine
+FROM node:8.15.0-alpine
 
 # Versions can be found at https://github.com/Jigsaw-Code/outline-ss-server/releases
 ARG SS_VERSION=1.0.7
 
 # Save metadata on the software versions we are using.
-LABEL shadowbox.node_version=8.14.0
+LABEL shadowbox.node_version=8.15.0
 LABEL shadowbox.outline-ss-server_version="${SS_VERSION}"
 
 ARG GITHUB_RELEASE


### PR DESCRIPTION
* See https://github.com/Jigsaw-Code/outline-ss-server/releases/tag/v1.0.7
* Docker image node:8.15.0 is the latest one that is signed. See https://github.com/nodejs/docker-node/issues/1065.