### PR TITLE
Fix waiting for Prometheus ready

### DIFF
--- a/src/shadowbox/infrastructure/prometheus_scraper.ts
+++ b/src/shadowbox/infrastructure/prometheus_scraper.ts
@@ -97,8 +97,7 @@ export async function runPrometheusScraper(
   // TODO(fortuna): Consider saving the output and expose it through the manager service.
   runProcess.stdout.pipe(process.stdout);
   runProcess.stderr.pipe(process.stderr);
-
-  await waitForPrometheusReady(prometheusEndpoint);
+  await waitForPrometheusReady(`${prometheusEndpoint}/api/v1/status/flags`);
   return runProcess;
 }
 
@@ -113,7 +112,7 @@ async function waitForPrometheusReady(prometheusEndpoint: string) {
 function isHttpEndpointHealthy(endpoint: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     http.get(endpoint, (response) => {
-          resolve(true);
+          resolve(response.statusCode >= 200 && response.statusCode < 300);
         }).on('error', (e) => {
       // Prometheus is not ready yet.
       resolve(false);

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -117,15 +117,17 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
   // Starts the Shadowsocks server and exposes the access key configuration to the server.
   // Periodically enforces access key limits.
   async start(clock: Clock): Promise<void> {
-    await this.enforceAccessKeyDataLimits();
-    await this.updateServer();
-    clock.setInterval(async () => {
+    const tryEnforceDataLimits = async () => {
       try {
         await this.enforceAccessKeyDataLimits();
       } catch (e) {
         logging.error(`Failed to enforce access key limits: ${e}`);
       }
-    }, ServerAccessKeyRepository.DATA_LIMITS_ENFORCEMENT_INTERVAL_MS);
+    };
+    await tryEnforceDataLimits();
+    await this.updateServer();
+    clock.setInterval(
+        tryEnforceDataLimits, ServerAccessKeyRepository.DATA_LIMITS_ENFORCEMENT_INTERVAL_MS);
   }
 
   private isExistingAccessKeyPort(port: number): boolean {


### PR DESCRIPTION
* This error in the canary server suggests that Promehteus is not ready to receive queries when the access key repository starts, resulting the main process to abort.
```
E2019-09-18T06:47:57.987Z 7 main.js:166] Error: Got error 503
    at ClientRequest.http.get (/root/shadowbox/app/infrastructure/prometheus_scraper.js:40:28)
    at Object.onceWrapper (events.js:315:30)
    at emitOne (events.js:116:13)
    at ClientRequest.emit (events.js:211:7)
    at HTTPParser.parserOnIncomingClient (_http_client.js:558:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:119:17)
    at Socket.socketOnData (_http_client.js:454:20)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
```
* `ServerAccessKeyRepository.start` does not throw.
* Query `/api/v1/status/flags` and wait for Prometheus to return 200s.