### PR TITLE
Allow navigation to the Mac App Store

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -91,7 +91,8 @@ function createMainWindow() {
   const handleNavigation = (event: Event, url: string) => {
     try {
       const parsed: URL = new URL(url);
-      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:' ||
+          parsed.protocol === 'macappstore:') {
         shell.openExternal(url);
       } else {
         console.warn(`Refusing to open URL with protocol "${parsed.protocol}"`);


### PR DESCRIPTION
Fixes a bug that would prevent the user from installing the Outline macOS client in the "Get Connected" flow.