### PR TITLE
Set -x in the integration test

### DIFF
--- a/src/shadowbox/integration_test/run_action.sh
+++ b/src/shadowbox/integration_test/run_action.sh
@@ -16,5 +16,19 @@
 
 do_action shadowbox/docker/build
 
+LOGFILE=$(mktemp)
+echo "Running Shadowbox integration test.  Logs at $LOGFILE."
+
 cd src/shadowbox/integration_test
-./test.sh
+./test.sh > $LOGFILE
+
+result=$?
+if [[ $result -eq 0 ]]; then
+  echo "Test Passed!"
+else
+  echo "Test Failed!  Logs:"
+  cat $LOGFILE   
+fi
+
+rm $LOGFILE
+exit $result

--- a/src/shadowbox/integration_test/run_action.sh
+++ b/src/shadowbox/integration_test/run_action.sh
@@ -17,15 +17,16 @@
 do_action shadowbox/docker/build
 
 LOGFILE=$(mktemp)
-echo "Running Shadowbox integration test.  Logs at $LOGFILE."
+echo "Running Shadowbox integration test.  Logs at $LOGFILE"
 
 cd src/shadowbox/integration_test
-./test.sh > $LOGFILE
 
-result=$?
-if [[ $result -eq 0 ]]; then
+result=0
+
+if ./test.sh > $LOGFILE 2>&1 ; then
   echo "Test Passed!"
 else
+  result=$?
   echo "Test Failed!  Logs:"
   cat $LOGFILE   
 fi

--- a/src/shadowbox/integration_test/run_action.sh
+++ b/src/shadowbox/integration_test/run_action.sh
@@ -25,11 +25,11 @@ result=0
 
 if ./test.sh > $LOGFILE 2>&1 ; then
   echo "Test Passed!"
+  rm $LOGFILE
 else
   result=$?
   echo "Test Failed!  Logs:"
   cat $LOGFILE   
 fi
 
-rm $LOGFILE
 exit $result

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -30,6 +30,8 @@
 #
 # Each node runs on a different Docker container.
 
+set -x
+
 export DOCKER_CONTENT_TRUST=${DOCKER_CONTENT_TRUST:-1}
 
 readonly OUTPUT_DIR=$(mktemp -d)


### PR DESCRIPTION
The integration test has been flaking from time to time on Travis with no obvious failures, indicating this is happening unexpectedly outside a `fail` call.  `set -x` will help us diagnose when it happens again.