### PR TITLE
Increase Server Manager version to 1.3.0

### DIFF
--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-manager",
   "productName": "Outline Manager",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Create and manage access to Outline servers",
   "homepage": "https://getoutline.org/",
   "author": {


### PR DESCRIPTION
Minor version bumped due to new functionality of changing the port
number for new access keys.