### PR TITLE
Increase timeout for the deleted key test in the integration test

### DIFF
--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -143,7 +143,7 @@ function cleanup() {
   # Verify we can't access the URL anymore after the key is deleted
   client_curl --insecure -X DELETE ${SB_API_URL}/access-keys/0 > /dev/null
   # Exit code 56 is "Connection reset by peer".
-  client_curl -x socks5h://localhost:$LOCAL_SOCKS_PORT --connect-timeout 1 $INTERNET_TARGET_URL &> /dev/null \
+  client_curl -x socks5h://localhost:$LOCAL_SOCKS_PORT --connect-timeout 5 $INTERNET_TARGET_URL &> /dev/null \
     && fail "Deleted access key is still active" || (($? == 56))
 
   # Verify that we can change the port for new access keys


### PR DESCRIPTION
The part of the integration test which tests for reset connections after
a key is revoked is flaky on Travis.  We sometimes get an error code 52
instead: "The server didn't reply anything, which here is considered an
error."

As a first attempt to deflake this test, we increase the connection
timeout for the request.  5 seconds was chosen completely arbitrarily.