### PR TITLE
Fix at electron v7.0.0

### DIFF
--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -28,7 +28,7 @@
     "@types/semver": "^5.5.0",
     "bower": "^1.8.0",
     "browserify": "^14.5.0",
-    "electron": "^7.0.0",
+    "electron": "7.0.0",
     "electron-builder": "^21.2.0",
     "electron-icon-maker": "^0.0.4",
     "gulp": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,7 +2208,7 @@ electron-updater@^4.1.2:
     pako "^1.0.10"
     semver "^6.2.0"
 
-electron@^7.0.0:
+electron@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/electron/-/electron-7.0.0.tgz#47a5b15ca213f32c20d85f82a1be615a74cdf55f"
   integrity sha512-vrF1loRW1p0vQCbduqO0EZpo8ePJOuxUT6tSoUSU3lsbGK3VnlJop+0PpCIPzbe2K4G4Gk7WexH08V9se7mJcA==


### PR DESCRIPTION
electron-builder has trouble finding a set version of electron when it is specified as ^7.0.0.  Since 7.0.0 is the latest electron version, we can fix at that version.  We will set ^7.0.0 when more become available.