### PR TITLE
Upgrade to the new version of Digital Ocean's Metrics agent

### DIFF
--- a/src/server_manager/install_scripts/do_install_server.sh
+++ b/src/server_manager/install_scripts/do_install_server.sh
@@ -188,7 +188,7 @@ wait $install_pid
 
 # Install the DigitalOcean Agent, for improved monitoring:
 # https://www.digitalocean.com/docs/monitoring/quickstart/#enable-the-digitalocean-agent-on-existing-droplets
-# 
+#
 # Since the server manager looks only for the tags created in the previous
 # step, this does not slow down server creation.
-curl -sSL https://agent.digitalocean.com/install.sh | sh
+curl -sSL https://repos.insights.digitalocean.com/install.sh | bash


### PR DESCRIPTION
Hello,

This is an update for #143. DigitalOcean phased out their legacy metrics client and changed the location of the install script.

https://www.digitalocean.com/docs/monitoring/quickstart/#enable-the-digitalocean-agent-on-existing-droplets

I've updated the URL to the `install.sh` script. `bash` was required for installation to succeed. The script from DO automates adding DO apt repositories and installing `do-agent`. I stood up several Outline servers to test that it is working correctly. FWIW, I didn't see any race conditions as noted in https://github.com/Jigsaw-Code/outline-server/pull/143#issuecomment-406316212.

Before: 
![Before](https://user-images.githubusercontent.com/7257660/67890245-bbd2e380-fb26-11e9-85fa-4cdbcda603f3.png)

After: 
![After](https://user-images.githubusercontent.com/7257660/67890247-bfff0100-fb26-11e9-9944-c1f03482ae2f.png)

```
> cat /var/log/apt/history.log
...
Start-Date: 2019-10-30  18:43:36
Commandline: apt-get -qq install -y do-agent
Install: do-agent:amd64 (3.5.6)
End-Date: 2019-10-30  18:43:36

> apt list | grep do-agent

do-agent/now 3.5.6 amd64 [installed,local]

> apt edit-sources

# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
# newer versions of the distribution.
deb http://mirrors.digitalocean.com/ubuntu/ bionic main restricted
# deb-src http://mirrors.digitalocean.com/ubuntu/ bionic main restricted

## Major bug fix updates produced after the final release of the
## distribution.
deb http://mirrors.digitalocean.com/ubuntu/ bionic-updates main restricted
# deb-src http://mirrors.digitalocean.com/ubuntu/ bionic-updates main restricted

## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
## team. Also, please note that software in universe WILL NOT receive any
## review or updates from the Ubuntu security team.
deb http://mirrors.digitalocean.com/ubuntu/ bionic universe
# deb-src http://mirrors.digitalocean.com/ubuntu/ bionic universe
deb http://mirrors.digitalocean.com/ubuntu/ bionic-updates universe
# deb-src http://mirrors.digitalocean.com/ubuntu/ bionic-updates universe

## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
## team, and may not be under a free licence. Please satisfy yourself as to
## your rights to use the software. Also, please note that software in
## multiverse WILL NOT receive any review or updates from the Ubuntu
## security team.
deb http://mirrors.digitalocean.com/ubuntu/ bionic multiverse
# deb-src http://mirrors.digitalocean.com/ubuntu/ bionic multiverse
deb http://mirrors.digitalocean.com/ubuntu/ bionic-updates multiverse
# deb-src http://mirrors.digitalocean.com/ubuntu/ bionic-updates multiverse
```
