### PR TITLE
Specify macOS image in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,8 @@ jobs:
 
     - stage: release
       os: osx
+      # electron-builder requires macOS >=10.13.6 for signing to work.
+      osx_image: xcode10.1
       env:
         - DESC=macos manager
       script:


### PR DESCRIPTION
* electron-builder v21+ requires macOS 10.13.6+ for signing to work.
* Specify the macOS image on Travis: `osx_image: xcode10.1` runs in macOS 10.13.6.