### PR TITLE
Deprecate server data usage timeframe API

### DIFF
--- a/src/server_manager/model/server.ts
+++ b/src/server_manager/model/server.ts
@@ -157,7 +157,7 @@ export interface AccessKey {
   accessUrl: string;
 }
 
-// Byte transfer stats for a sliding timeframe, including both inbound and outbound.
+// Byte transfer stats for the past 30 days, including both inbound and outbound.
 // TODO: this is copied at src/shadowbox/model/metrics.ts.  Both copies should
 // be kept in sync, until we can find a way to share code between the web_app
 // and shadowbox.

--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -120,7 +120,7 @@ curl --insecure -X DELETE $API_URL/access-keys/2
 ```
 
 Set an access key data limit
-(e.g. limit outbound data transfer for access key 2 to 1MB over a 24 hour sliding timeframe)
+(e.g. limit outbound data transfer for access key 2 to 1MB over 30 days)
 ```
 curl -v --insecure -X PUT -H "Content-Type: application/json" -d '{"limit": {"bytes": 1000}}' $API_URL/access-keys/2/data-limit
 ```

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DataUsageTimeframe} from '../model/metrics';
-
 export type AccessKeyId = string;
 export type AccessKeyMetricsId = string;
 
@@ -44,7 +42,7 @@ export interface AccessKey {
   readonly proxyParams: ProxyParams;
   // Admin-controlled, data transfer limit for this access key. Unlimited if unset.
   readonly dataLimit?: DataUsage;
-  // Data transferred by this access key over a timeframe specified by the server.
+  // Data transferred by this access key over a 30 day sliding timeframe.
   readonly dataUsage: DataUsage;
   // Returns whether the access key has exceeded its data transfer limit.
   isOverDataLimit(): boolean;
@@ -67,6 +65,4 @@ export interface AccessKeyRepository {
   setAccessKeyDataLimit(id: AccessKeyId, limit: DataUsage): Promise<void>;
   // Clears the transfer limit for the specified access key. Throws on failure.
   removeAccessKeyDataLimit(id: AccessKeyId): Promise<void>;
-  // Sets the data usage timeframe for access key data limit enforcement. Throws on failure.
-  setDataUsageTimeframe(timeframe: DataUsageTimeframe): Promise<void>;
 }

--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -44,9 +44,3 @@ export class InvalidAccessKeyDataLimit extends OutlineError {
     super('Must provide a limit with a non-negative integer value for "bytes"');
   }
 }
-
-export class InvalidDataUsageTimeframe extends OutlineError {
-  constructor() {
-    super('Must provide a timeframe with a positive integer values for "hours"');
-  }
-}

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -52,26 +52,6 @@ paths:
           description: The requested port wasn't an integer from 1 through 65535, or the request had no port parameter.
         '409':
           description: The requested port was already in use by another service.
-  /server/data-usage-timeframe:
-    put:
-      description: Sets the sliding timeframe for measuring data usage and enforcing access keys data limits.
-      tags:
-        - Server
-        - Data limit
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DataUsageTimeframe"
-            examples:
-              '0':
-                value: "{hours: 24}"
-      responses:
-        '204':
-          description: The data usage timeframe was sucessfully changed.
-        '400':
-          description: Invalid timeframe value.
 
   /name:
     put:
@@ -314,14 +294,6 @@ components:
           type: number
         portForNewAccessKeys:
           type: integer
-        dataUsageTimeframe:
-          $ref: "#/components/schemas/DataUsageTimeframe"
-
-    DataUsageTimeframe:
-      properties:
-        hours:
-          type: integer
-          minimum: 1
 
     DataUsage:
       properties:

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -144,7 +144,7 @@ async function main() {
   }
   const accessKeyRepository = new ServerAccessKeyRepository(
       serverConfig.data().portForNewAccessKeys, proxyHostname, accessKeyConfig, shadowsocksServer,
-      prometheusClient, serverConfig.data().dataUsageTimeframe);
+      prometheusClient);
 
   const metricsReader = new PrometheusUsageMetrics(prometheusClient);
   const toMetricsId = (id: AccessKeyId) => {

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -19,7 +19,6 @@ import {PortProvider} from '../infrastructure/get_port';
 import {InMemoryConfig} from '../infrastructure/json_config';
 import {AccessKeyRepository, DataUsage} from '../model/access_key';
 import * as errors from '../model/errors';
-import {DataUsageTimeframe} from '../model/metrics';
 
 import {FakePrometheusClient, FakeShadowsocksServer} from './mocks/mocks';
 import {AccessKeyConfigJson, ServerAccessKeyRepository} from './server_access_key';
@@ -430,21 +429,6 @@ describe('ServerAccessKeyRepository', () => {
     expect(serverAccessKeys[1].id).toEqual(accessKey3.id);
     done();
   });
-
-  it('getDataUsageTimeframe returns the data limit timeframe', async (done) => {
-    const timeframe = {hours: 12345};
-    const repo = new RepoBuilder().dataUsageTimeframe(timeframe).build();
-    expect(repo.getDataUsageTimeframe()).toEqual(timeframe);
-    done();
-  });
-
-  it('setDataUsageTimeframe sets the data limit timeframe', async (done) => {
-    const repo = new RepoBuilder().build();
-    const timeframe = {hours: 12345};
-    await repo.setDataUsageTimeframe(timeframe);
-    expect(repo.getDataUsageTimeframe()).toEqual(timeframe);
-    done();
-  });
 });
 
 // Convenience function to expect that an asynchronous function does not throw an error. Note that
@@ -480,7 +464,6 @@ class RepoBuilder {
   private keyConfig_ = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
   private shadowsocksServer_ = new FakeShadowsocksServer();
   private prometheusClient_ = new FakePrometheusClient({});
-  private dataUsageTimeframe_ = {hours: 30 * 24};
 
   public port(port: number): RepoBuilder {
     this.port_ = port;
@@ -498,14 +481,9 @@ class RepoBuilder {
     this.prometheusClient_ = prometheusClient;
     return this;
   }
-  public dataUsageTimeframe(dataUsageTimeframe: DataUsageTimeframe) {
-    this.dataUsageTimeframe_ = dataUsageTimeframe;
-    return this;
-  }
 
   public build(): ServerAccessKeyRepository {
     return new ServerAccessKeyRepository(
-        this.port_, 'hostname', this.keyConfig_, this.shadowsocksServer_, this.prometheusClient_,
-        this.dataUsageTimeframe_);
+        this.port_, 'hostname', this.keyConfig_, this.shadowsocksServer_, this.prometheusClient_);
   }
 }

--- a/src/shadowbox/server/server_config.ts
+++ b/src/shadowbox/server/server_config.ts
@@ -15,7 +15,6 @@
 import * as uuidv4 from 'uuid/v4';
 
 import * as json_config from '../infrastructure/json_config';
-import {DataUsageTimeframe} from '../model/metrics';
 
 // Serialized format for the server config.
 // WARNING: Renaming fields will break backwards-compatibility.
@@ -32,8 +31,6 @@ export interface ServerConfigJson {
   portForNewAccessKeys?: number;
   // Which staged rollouts we should force enabled or disabled.
   rollouts?: RolloutConfigJson[];
-  // Sliding timeframe, in hours, used to measure data usage and enforce data limits.
-  dataUsageTimeframe?: DataUsageTimeframe;
   // We don't serialize the shadowbox version, this is obtained dynamically from node.
   // Public proxy hostname.
   hostname?: string;
@@ -55,7 +52,6 @@ export function readServerConfig(filename: string): json_config.JsonConfig<Serve
     config.data().serverId = config.data().serverId || uuidv4();
     config.data().metricsEnabled = config.data().metricsEnabled || false;
     config.data().createdTimestampMs = config.data().createdTimestampMs || Date.now();
-    config.data().dataUsageTimeframe = config.data().dataUsageTimeframe || {hours: 30 * 24};
     config.data().hostname = config.data().hostname || process.env.SB_PUBLIC_IP;
     config.write();
     return config;


### PR DESCRIPTION
* Removes the `/server/data-usage-timeframe` API.
* Removes the `dataUsageTimeframe` property from the server config and access key repository.
* Removes associated unit tests.
* Note that metrics model still defines `DataUsageTimeframe`, which is used by `ManagerMetrics.getOutboundByteTransfer`. This flexibility will be useful for some implementations of data limits.