### PR TITLE
Return the port for new access keys from GET /server.  

### DIFF
--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -142,6 +142,7 @@ export class ShadowsocksManagerService {
       metricsEnabled: this.serverConfig.data().metricsEnabled || false,
       createdTimestampMs: this.serverConfig.data().createdTimestampMs,
       version,
+      portForNewAccessKeys: this.serverConfig.data().portForNewAccessKeys,
       accessKeyDataLimit: this.serverConfig.data().accessKeyDataLimit
     });
     next();


### PR DESCRIPTION
This was accidentally removed in #537.