### PR TITLE
Fix update_mmdb and the Docker image to work on Alpine

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -16,7 +16,7 @@
 FROM node:8.15.0-alpine
 
 # Versions can be found at https://github.com/Jigsaw-Code/outline-ss-server/releases
-ARG SS_VERSION=1.0.7
+ARG SS_VERSION=1.0.8
 
 # Save metadata on the software versions we are using.
 LABEL shadowbox.node_version=8.15.0
@@ -27,6 +27,9 @@ LABEL shadowbox.github.release="${GITHUB_RELEASE}"
 
 # We use curl to detect the server's public IP.
 RUN apk add --no-cache curl
+
+# We need to use the --date option in `date` to safely grab the ip-to-country database
+RUN apk add --update coreutils
 
 COPY src/shadowbox/scripts scripts/
 COPY src/shadowbox/scripts/update_mmdb.sh /etc/periodic/weekly/update_mmdb

--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -25,11 +25,9 @@ LABEL shadowbox.outline-ss-server_version="${SS_VERSION}"
 ARG GITHUB_RELEASE
 LABEL shadowbox.github.release="${GITHUB_RELEASE}"
 
-# We use curl to detect the server's public IP.
-RUN apk add --no-cache curl
-
-# We need to use the --date option in `date` to safely grab the ip-to-country database
-RUN apk add --update coreutils
+# We use curl to detect the server's public IP. We need to use the --date option in `date` to
+# safely grab the ip-to-country database
+RUN apk add --no-cache --upgrade coreutils curl
 
 COPY src/shadowbox/scripts scripts/
 COPY src/shadowbox/scripts/update_mmdb.sh /etc/periodic/weekly/update_mmdb

--- a/src/shadowbox/scripts/update_mmdb.sh
+++ b/src/shadowbox/scripts/update_mmdb.sh
@@ -9,7 +9,7 @@ TMPDIR="$(mktemp -d)"
 FILENAME="ip-country.mmdb"
 
 # We need to make sure that we grab an existing database at install-time
-for monthdelta in {0..10}; do
+for monthdelta in 0 1 2 3 4 5 6 7 8 9 10; do
     newdate=$(date --date="-$monthdelta month" +%Y-%m)
     ADDRESS="https://download.db-ip.com/free/ip-country-${newdate}.mmdb.gz"
     curl --fail --silent "${ADDRESS}" -o "$TMPDIR/$FILENAME.gz" > /dev/null && break

--- a/src/shadowbox/scripts/update_mmdb.sh
+++ b/src/shadowbox/scripts/update_mmdb.sh
@@ -5,11 +5,13 @@
 
 # IP Geolocation by DB-IP (https://db-ip.com)
 
+# Note that this runs on BusyBox sh, which lacks bash features.
+
 TMPDIR="$(mktemp -d)"
 FILENAME="ip-country.mmdb"
 
 # We need to make sure that we grab an existing database at install-time
-for monthdelta in 0 1 2 3 4 5 6 7 8 9 10; do
+for monthdelta in $(seq 10); do
     newdate=$(date --date="-$monthdelta months" +%Y-%m)
     ADDRESS="https://download.db-ip.com/free/dbip-country-lite-${newdate}.mmdb.gz"
     curl --fail --silent "${ADDRESS}" -o "$TMPDIR/$FILENAME.gz" > /dev/null && break  

--- a/src/shadowbox/scripts/update_mmdb.sh
+++ b/src/shadowbox/scripts/update_mmdb.sh
@@ -10,10 +10,10 @@ FILENAME="ip-country.mmdb"
 
 # We need to make sure that we grab an existing database at install-time
 for monthdelta in 0 1 2 3 4 5 6 7 8 9 10; do
-    newdate=$(date --date="-$monthdelta month" +%Y-%m)
-    ADDRESS="https://download.db-ip.com/free/ip-country-${newdate}.mmdb.gz"
-    curl --fail --silent "${ADDRESS}" -o "$TMPDIR/$FILENAME.gz" > /dev/null && break
-    if (( monthdelta == 10 )); then
+    newdate=$(date --date="-$monthdelta months" +%Y-%m)
+    ADDRESS="https://download.db-ip.com/free/dbip-country-lite-${newdate}.mmdb.gz"
+    curl --fail --silent "${ADDRESS}" -o "$TMPDIR/$FILENAME.gz" > /dev/null && break  
+    if [[ $monthdelta -eq 10 ]]; then
         # A weird exit code on purpose -- we should catch this long before it triggers
         exit 2
     fi


### PR DESCRIPTION
* `for x in {a..b}` is bash-only, and alpine's default shell is `dash`.
* Use `[[` instead of `((` for the branch
* Make sure to update to GNU coreutils in the image in order to use
`date --date`

* Also updates to use `outline-ss-server` v1.0.8