### PR TITLE
Fix `yarn do shadowbox/server/run`

### DIFF
--- a/src/shadowbox/README.md
+++ b/src/shadowbox/README.md
@@ -25,14 +25,12 @@ Use `sudo --preserve-env` if you need to pass environment variables. Use `bash -
 
 ### Prerequisites
 
-Besides [Node](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/en/docs/install), you will also need:
+You will need [Node](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/en/docs/install), and [curl](https://https://curl.haxx.se/).  If you want to run Shadowbox as a Docker container, you will also need:
 
 1. [Docker 1.13+](https://docs.docker.com/engine/installation/)
 1. [docker-compose 1.11+](https://docs.docker.com/compose/install/)
 
 ### Running Shadowbox as a Node.js app
-
-> **NOTE:**: This is currently broken. Use the docker option instead.
 
 Build and run the server as a Node.js app:
 ```

--- a/src/shadowbox/infrastructure/prometheus_scraper.ts
+++ b/src/shadowbox/infrastructure/prometheus_scraper.ts
@@ -19,6 +19,7 @@ import * as http from 'http';
 import * as jsyaml from 'js-yaml';
 import * as mkdirp from 'mkdirp';
 import * as path from 'path';
+import * as process from 'process';
 
 import * as logging from '../infrastructure/logging';
 
@@ -86,7 +87,8 @@ export async function runPrometheusScraper(
   });
   const commandArguments = ['--config.file', configFilename];
   commandArguments.push(...args);
-  const runProcess = child_process.spawn('/root/shadowbox/bin/prometheus', commandArguments);
+  const sbBinDir = process.env.SB_BIN_DIR || '/root/shadowbox/bin';
+  const runProcess = child_process.spawn(`${sbBinDir}/prometheus`, commandArguments);
   runProcess.on('error', (error) => {
     logging.error(`Error spawning prometheus: ${error}`);
   });

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -17,6 +17,7 @@ import * as fs from 'fs';
 import * as jsyaml from 'js-yaml';
 import * as mkdirp from 'mkdirp';
 import * as path from 'path';
+import * as process from 'process';
 
 import * as logging from '../infrastructure/logging';
 import {ShadowsocksAccessKey, ShadowsocksServer} from '../model/shadowsocks_server';
@@ -82,7 +83,8 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     if (this.verbose) {
       commandArguments.push('-verbose');
     }
-    this.ssProcess = child_process.spawn('/root/shadowbox/bin/outline-ss-server', commandArguments);
+    const sbBinDir = process.env.SB_BIN_DIR || '/root/shadowbox/bin';
+    this.ssProcess = child_process.spawn(`${sbBinDir}/outline-ss-server`, commandArguments);
     this.ssProcess.on('error', (error) => {
       logging.error(`Error spawning outline-ss-server: ${error}`);
     });

--- a/src/shadowbox/server/run_action.sh
+++ b/src/shadowbox/server/run_action.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "** Currently broken, use yarn do shadowbox/docker/run instead **" >&2
-exit 1
-
 do_action shadowbox/server/build
 
 export LOG_LEVEL="${LOG_LEVEL:-debug}"
@@ -25,9 +22,15 @@ export SB_PUBLIC_IP="${SB_PUBLIC_IP:-$(curl https://ipinfo.io/ip)}"
 export SB_API_PREFIX=TestApiPrefix
 export SB_METRICS_URL=https://metrics-test.uproxy.org
 export SB_STATE_DIR=/tmp/outline
+mkdir -p ${SB_STATE_DIR}
+export SB_BIN_DIR=${SB_BIN_DIR:-$(mktemp -d)}
+mkdir -p ${SB_BIN_DIR}
 
-source $ROOT_DIR/src/shadowbox/scripts/make_test_certificate.sh $SB_STATE_DIR
+cp third_party/prometheus/prometheus ${SB_BIN_DIR}/prometheus
+SS_VERSION=1.0.8
+curl -SsL https://github.com/Jigsaw-Code/outline-ss-server/releases/download/v${SS_VERSION}/outline-ss-server_${SS_VERSION}_linux_x86_64.tar.gz \
+    | tar xz -C ${SB_BIN_DIR} outline-ss-server
 
-# This will fail because it expects prometheus and outline-ss-server to be in /root/shadowbox/bin.
-# TODO: Fix it
+source src/shadowbox/scripts/make_test_certificate.sh $SB_STATE_DIR
+
 node $BUILD_DIR/shadowbox/app/server/main


### PR DESCRIPTION
This allows us to run a local shadowbox without having to go through Docker

Also adds a new env var SB_BIN_DIR which tells us where to find the prometheus and outline-ss-server binaries