### PR TITLE
Add rollout for the replay protection

### DIFF
--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -57,15 +57,15 @@ function reserveExistingAccessKeyPorts(
   dedupedPorts.forEach(p => portProvider.addReservedPort(p));
 }
 
-function createRolloutTracker(serverConfig: json_config.JsonConfig<server_config.ServerConfigJson>):	
-    RolloutTracker {	
+function createRolloutTracker(serverConfig: json_config.JsonConfig<server_config.ServerConfigJson>):
+    RolloutTracker {
   const rollouts = new RolloutTracker(serverConfig.data().serverId);
-  if (serverConfig.data().rollouts) {	
-    for (const rollout of serverConfig.data().rollouts) {	
-      rollouts.forceRollout(rollout.id, rollout.enabled);	
-    }	
-  }	
-  return rollouts;	
+  if (serverConfig.data().rollouts) {
+    for (const rollout of serverConfig.data().rollouts) {
+      rollouts.forceRollout(rollout.id, rollout.enabled);
+    }
+  }
+  return rollouts;
 }
 
 async function main() {
@@ -140,9 +140,9 @@ async function main() {
           getPersistentFilename('outline-ss-server/config.yml'), verbose, ssMetricsLocation)
           .enableCountryMetrics(MMDB_LOCATION);
   // Add rollout at 0%, so we can override in the config.
-  const replayProtectionEnabled = createRolloutTracker(serverConfig).isRolloutEnabled('replay-protection', 0);
-  logging.info(`Replay protection enabled: ${replayProtectionEnabled}`);
-  if (replayProtectionEnabled) {
+  const isReplayProtectionEnabled = createRolloutTracker(serverConfig).isRolloutEnabled('replay-protection', 0);
+  logging.info(`Replay protection enabled: ${isReplayProtectionEnabled}`);
+  if (isReplayProtectionEnabled) {
     shadowsocksServer.enableReplayProtection();
   }
   const prometheusEndpoint = `http://${prometheusLocation}`;

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -25,6 +25,7 @@ import {ShadowsocksAccessKey, ShadowsocksServer} from '../model/shadowsocks_serv
 export class OutlineShadowsocksServer implements ShadowsocksServer {
   private ssProcess: child_process.ChildProcess;
   private ipCountryFilename = '';
+  private replayProtectionEnabled = false;
 
   // configFilename is the location for the outline-ss-server config.
   constructor(
@@ -35,6 +36,11 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
   // ipCountryFilename is the location of the ip-country.mmdb IP-to-country database file.
   enableCountryMetrics(ipCountryFilename: string): OutlineShadowsocksServer {
     this.ipCountryFilename = ipCountryFilename;
+    return this;
+  }
+  
+  enableReplayProtection(): OutlineShadowsocksServer {
+    this.replayProtectionEnabled = true;
     return this;
   }
 
@@ -81,6 +87,9 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     }
     if (this.verbose) {
       commandArguments.push('-verbose');
+    }
+    if (this.replayProtectionEnabled) {
+      commandArguments.push('--replay_history=10000');
     }
     this.ssProcess = child_process.spawn('/root/shadowbox/bin/outline-ss-server', commandArguments);
     this.ssProcess.on('error', (error) => {

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -25,7 +25,7 @@ import {ShadowsocksAccessKey, ShadowsocksServer} from '../model/shadowsocks_serv
 export class OutlineShadowsocksServer implements ShadowsocksServer {
   private ssProcess: child_process.ChildProcess;
   private ipCountryFilename = '';
-  private replayProtectionEnabled = false;
+  private isReplayProtectionEnabled = false;
 
   // configFilename is the location for the outline-ss-server config.
   constructor(
@@ -40,7 +40,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
   }
   
   enableReplayProtection(): OutlineShadowsocksServer {
-    this.replayProtectionEnabled = true;
+    this.isReplayProtectionEnabled = true;
     return this;
   }
 
@@ -88,7 +88,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     if (this.verbose) {
       commandArguments.push('-verbose');
     }
-    if (this.replayProtectionEnabled) {
+    if (this.isReplayProtectionEnabled) {
       commandArguments.push('--replay_history=10000');
     }
     this.ssProcess = child_process.spawn('/root/shadowbox/bin/outline-ss-server', commandArguments);


### PR DESCRIPTION
I'm adding the rollout with 0% for now, but anyone can enabled it by adding this to `shadowbox_server_config.json`:
```
"rollouts":[{"id":"replay-protection","enabled":true}]
```

When enabled, you will see the following output:
```
I2020-02-28T00:39:04.251Z 11 main.js:130] Replay protection enabled: true
```

And you can use `ps` to verify that `outline-ss-server` is running with the right flag:
```
$ ps a | grep outline-ss-server | grep --invert grep 
251367 pts/0    Sl+    0:00 /root/shadowbox/bin/outline-ss-server -config /root/shadowbox/persisted-state/outline-ss-server/config.yml -metrics 127.0.0.1:9092 -ip_country_db /var/lib/libmaxminddb/ip-country.mmdb -verbose --replay_history=10000
```

cc: @bemasc @JonathanDCohen 