### PR TITLE
Only lint HTML files with prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "yarn tslint --fix 'src/**/*.ts' -e '**/bower_components/**' -e '**/node_modules/**' && yarn git-clang-format && yarn pretty-quick --staged"
+      "pre-commit": "yarn tslint --fix 'src/**/*.ts' -e '**/bower_components/**' -e '**/node_modules/**' && yarn git-clang-format && yarn pretty-quick --staged --pattern '**/*.html'"
     }
   }
 }


### PR DESCRIPTION
We don't want prettier to override tslint for TS files.