### PR TITLE
Skip app notarization when packaging

### DIFF
--- a/src/server_manager/electron_app/release/notarize.js
+++ b/src/server_manager/electron_app/release/notarize.js
@@ -21,6 +21,7 @@ exports.default = async function(context) {
   const {electronPlatformName, appOutDir} = context;
   if (electronPlatformName !== 'darwin' || !process.env.CSC_LINK) {
     // Skip notarization if not releasing macOS or if the app is unsigned (i.e. packaging).
+    // `CSC_LINK` is the path to a signing certificate; setting it makes Electron sign the app.
     return;
   }
 

--- a/src/server_manager/electron_app/release/notarize.js
+++ b/src/server_manager/electron_app/release/notarize.js
@@ -19,7 +19,8 @@ const {notarize} = require('electron-notarize');
 // and `APPLE_PASSWORD`, the password to the account.
 exports.default = async function(context) {
   const {electronPlatformName, appOutDir} = context;
-  if (electronPlatformName !== 'darwin') {
+  if (electronPlatformName !== 'darwin' || !process.env.CSC_LINK) {
+    // Skip notarization if not releasing macOS or if the app is unsigned (i.e. packaging).
     return;
   }
 


### PR DESCRIPTION
* The package action does not sign binaries; however, the "afterSign" hook still runs and app notarization fails due to missing signing credentials.
* Fixes the macOS packaging action by skipping notarization when the app is unsigned.
 