### PR TITLE
Expand buttons when their label is too wide to fit

### DIFF
--- a/src/server_manager/ui_components/outline-validated-input.html
+++ b/src/server_manager/ui_components/outline-validated-input.html
@@ -54,7 +54,7 @@
 
       paper-button {
         height: 36px;
-        width: 83px;
+        min-width: 83px;
         text-align: center;
       }
 


### PR DESCRIPTION
Before:
![fixed](https://user-images.githubusercontent.com/3297872/75728702-aa593e00-5cb6-11ea-94f1-7c3385b9634d.png)

After:
![expanded](https://user-images.githubusercontent.com/3297872/75728721-ba711d80-5cb6-11ea-949d-2b48607964bf.png)
