### PR TITLE
Update @types/express

### DIFF
--- a/src/metrics_server/index.ts
+++ b/src/metrics_server/index.ts
@@ -46,7 +46,7 @@ app.use(express.json());
 
 // Accepts hourly connection metrics and inserts them into BigQuery.
 // Request body should contain an HourlyServerMetricsReport.
-app.post('/connections', async (req: express.Request, res: express.Response) => {
+app.post('/connections', async (req: express.Request, res: express.Response<string>) => {
   try {
     if (!connections.isValidConnectionMetricsReport(req.body)) {
       res.status(400).send('Invalid request');
@@ -61,7 +61,7 @@ app.post('/connections', async (req: express.Request, res: express.Response) => 
 
 // Accepts daily feature metrics and inserts them into BigQuery.
 // Request body should contain a `DailyFeatureMetricsReport`.
-app.post('/features', async (req: express.Request, res: express.Response) => {
+app.post('/features', async (req: express.Request, res: express.Response<string>) => {
   try {
     if (!features.isValidFeatureMetricsReport(req.body)) {
       res.status(400).send('Invalid request');

--- a/src/sentry_webhook/index.ts
+++ b/src/sentry_webhook/index.ts
@@ -17,7 +17,7 @@ import * as express from 'express';
 
 import {postSentryEventToSalesforce, shouldPostEventToSalesforce} from './post_sentry_event_to_salesforce';
 
-exports.postSentryEventToSalesforce = (req: express.Request, res: express.Response) => {
+exports.postSentryEventToSalesforce = (req: express.Request, res: express.Response<string>) => {
   if (req.method !== 'POST') {
     return res.status(405).send('Method not allowed');
   }

--- a/src/sentry_webhook/package.json
+++ b/src/sentry_webhook/package.json
@@ -8,6 +8,6 @@
   "dependencies": {},
   "devDependencies": {
     "@sentry/types": "^4.4.1",
-    "@types/express": "^4.0.36"
+    "@types/express": "^4.17.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,7 +295,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.0.36", "@types/express@^4.17.3":
+"@types/express@^4.17.3":
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.3.tgz#38e4458ce2067873b09a73908df488870c303bd9"
   integrity sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==


### PR DESCRIPTION
- @types/express v1.17.3 added support for generic `Response`. Because of this change the `metrics_server` build is failing.
- Updated code that depends on express in `metrics_server` to fix the build.
- Updated express types in `sentry_webhook` to prevent a transitive dependendency collison (express-serve-static-core).
- For details see: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42812