### PR TITLE
Clean up language logic

### DIFF
--- a/src/server_manager/bower.json
+++ b/src/server_manager/bower.json
@@ -23,7 +23,6 @@
     "iron-collapse": "PolymerElements/iron-collapse#^2.2.1",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^2.1.0",
     "iron-pages": "PolymerElements/iron-pages#^2.0.1",
-    "outline-i18n": "Jigsaw-Code/outline-i18n#^0.0.7",
     "paper-button": "PolymerElements/paper-button#^2.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^2.0.4",
     "paper-dialog": "PolymerElements/paper-dialog#^2.0.1",

--- a/src/server_manager/index.html
+++ b/src/server_manager/index.html
@@ -36,5 +36,7 @@
 
     <title>Outline Manager</title>
   </head>
-  <body></body>
+  <body>
+    <app-root id="appRoot"></app-root>
+  </body>
 </html>

--- a/src/server_manager/index.html
+++ b/src/server_manager/index.html
@@ -25,7 +25,6 @@
 
     <link rel="stylesheet" href="/ui_components/style.css" />
     <script src="/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
-    <script src="/bower_components/outline-i18n/index.js"></script>
     <link rel="import" href="/ui_components/app-root.html" />
     <script src="server_manager/web_app/main.js"></script>
 
@@ -37,8 +36,5 @@
 
     <title>Outline Manager</title>
   </head>
-
-  <body>
-    <app-root id="appRoot"></app-root>
-  </body>
+  <body></body>
 </html>

--- a/src/server_manager/infrastructure/i18n.spec.ts
+++ b/src/server_manager/infrastructure/i18n.spec.ts
@@ -1,0 +1,49 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as i18n from './i18n';
+
+describe('LanguageMatcher', () => {
+  it('returns supported language on match', () => {
+    const SUPPORTED_LANGUAGES = i18n.languageList(["es", "pt-BR", "ru"]);
+    const matcher = new i18n.LanguageMatcher(SUPPORTED_LANGUAGES, undefined);
+    const supportedLanguage = matcher.getBestSupportedLanguage(i18n.languageList(["pt-PT"]));
+    expect(supportedLanguage.string()).toEqual('pt-BR');
+  });
+  it('returns the right variant', () => {
+    const SUPPORTED_LANGUAGES = i18n.languageList(['en-GB', 'en-IN', 'en-US']);
+    const matcher = new i18n.LanguageMatcher(SUPPORTED_LANGUAGES, undefined);
+    const supportedLanguage = matcher.getBestSupportedLanguage(i18n.languageList(['en-IN']));
+    expect(supportedLanguage.string()).toEqual('en-IN');
+  });
+  it('prefers first matched user language', () => {
+    const SUPPORTED_LANGUAGES = i18n.languageList(['en-US', 'pt-BR']);
+    const matcher = new i18n.LanguageMatcher(SUPPORTED_LANGUAGES, undefined);
+    const supportedLanguage =
+        matcher.getBestSupportedLanguage(i18n.languageList(['cn', 'en-GB', 'pt-BR']));
+    expect(supportedLanguage.string()).toEqual('en-US');
+  });
+  it('returns default on no match', () => {
+    const SUPPORTED_LANGUAGES = i18n.languageList(['es', 'pt-BR', 'ru']);
+    const matcher = new i18n.LanguageMatcher(SUPPORTED_LANGUAGES, new i18n.LanguageCode('fr'));
+    const supportedLanguage = matcher.getBestSupportedLanguage(i18n.languageList(['cn']));
+    expect(supportedLanguage.string()).toEqual('fr');
+  });
+  it('returns undefined on no match and no default', () => {
+    const SUPPORTED_LANGUAGES = i18n.languageList(["es", "pt-BR", "ru"]);
+    const matcher = new i18n.LanguageMatcher(SUPPORTED_LANGUAGES);
+    const supportedLanguage = matcher.getBestSupportedLanguage(i18n.languageList(["cn"]));
+    expect(supportedLanguage).toBeUndefined();
+  });
+});

--- a/src/server_manager/infrastructure/i18n.ts
+++ b/src/server_manager/infrastructure/i18n.ts
@@ -14,14 +14,14 @@
 
 export class LanguageCode {
   private language: string;
-  private normalized: string;
+  private normalizedLanguage: string;
 
   constructor(languageCodeStr: string) {
     this.language = languageCodeStr;
-    this.normalized = languageCodeStr.toLowerCase();
+    this.normalizedLanguage = languageCodeStr.toLowerCase();
   }
   matches(other: LanguageCode): boolean {
-    return this.normalized === other.normalized;
+    return this.normalizedLanguage === other.normalizedLanguage;
   }
   string(): string {
     return this.language;

--- a/src/server_manager/infrastructure/i18n.ts
+++ b/src/server_manager/infrastructure/i18n.ts
@@ -1,0 +1,87 @@
+// Copyright 2018 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class LanguageCode {
+  private language: string;
+  private normalized: string;
+
+  constructor(languageCodeStr: string) {
+    this.language = languageCodeStr;
+    this.normalized = languageCodeStr.toLowerCase();
+  }
+  matches(other: LanguageCode): boolean {
+    return this.normalized === other.normalized;
+  }
+  string(): string {
+    return this.language;
+  }
+  split(): string[] {
+    return this.language.split('-');
+  }
+}
+
+export class LanguageMatcher {
+  constructor(
+      private supportedLanguages: LanguageCode[],
+      private defaultLanguage: LanguageCode = undefined) {}
+
+  // Goes over each user language, trying to find the supported language that matches
+  // the best. We'll trim variants of the user and supported languages in order to find
+  // a match, but the language base is guaranteed to match.
+  getBestSupportedLanguage(userLanguages: LanguageCode[]): LanguageCode | undefined {
+    for (const userLanguage of userLanguages) {
+      const parts = userLanguage.split();
+      while (parts.length > 0) {
+        const trimmedUserLanguage = new LanguageCode(parts.join('-'));
+        const supportedLanguage = this.getSupportedLanguage(trimmedUserLanguage);
+        if (supportedLanguage) {
+          return supportedLanguage;
+        }
+        parts.pop();
+      }
+    }
+    return this.defaultLanguage;
+  }
+
+  // Returns the closest supported language that matches the user language.
+  // We make sure the language matches, but the variant may differ.
+  private getSupportedLanguage(userLanguage: LanguageCode): LanguageCode | undefined {
+    for (const supportedLanguage of this.supportedLanguages) {
+      const parts = supportedLanguage.split();
+      while (parts.length > 0) {
+        const trimmedSupportedLanguage = new LanguageCode(parts.join('-'));
+        if (userLanguage.matches(trimmedSupportedLanguage)) {
+          return supportedLanguage;
+        }
+        parts.pop();
+      }
+    }
+    return undefined;
+  }
+}
+
+export function languageList(languagesAsStr: string[]): LanguageCode[] {
+  return languagesAsStr.map(l => new LanguageCode(l));
+}
+
+// Returns the languages supported by the browser.
+export function getBrowserLanguages(): LanguageCode[] {
+  // Ensure that navigator.languages is defined and not empty, as can be the case with some browsers
+  // (i.e. Chrome 59 on Electron).
+  let languages = navigator.languages as string[];
+  if (!languages || languages.length === 0) {
+    languages = [navigator.language];
+  }
+  return languageList(languages);
+}

--- a/src/server_manager/ui_components/app-root.html
+++ b/src/server_manager/ui_components/app-root.html
@@ -532,126 +532,125 @@
   </template>
   <script>
     const TOS_ACK_LOCAL_STORAGE_KEY = "tos-ack";
-    Polymer({
-      is: "app-root",
-      behaviors: [Polymer.AppLocalizeBehavior],
-      properties: {
-        LANGUAGES_AVAILABLE: {
-          type: Object,
-          readonly: true,
-          value: {
-            am: {id: "am", dir: "ltr"},
-            ar: {id: "ar", dir: "rtl"},
-            bg: {id: "bg", dir: "ltr"},
-            ca: {id: "ca", dir: "ltr"},
-            cs: {id: "cs", dir: "ltr"},
-            da: {id: "da", dir: "ltr"},
-            de: {id: "de", dir: "ltr"},
-            el: {id: "el", dir: "ltr"},
-            en: {id: "en", dir: "ltr"},
-            "es-419": {id: "es-419", dir: "ltr"},
-            fa: {id: "fa", dir: "rtl"},
-            fi: {id: "fi", dir: "ltr"},
-            fil: {id: "fil", dir: "ltr"},
-            fr: {id: "fr", dir: "ltr"},
-            he: {id: "he", dir: "rtl"},
-            hi: {id: "hi", dir: "ltr"},
-            hr: {id: "hr", dir: "ltr"},
-            hu: {id: "hu", dir: "ltr"},
-            id: {id: "id", dir: "ltr"},
-            it: {id: "it", dir: "ltr"},
-            ja: {id: "ja", dir: "ltr"},
-            ko: {id: "ko", dir: "ltr"},
-            km: {id: "km", dir: "ltr"},
-            lt: {id: "lt", dir: "ltr"},
-            lv: {id: "lv", dir: "ltr"},
-            nl: {id: "nl", dir: "ltr"},
-            no: {id: "no", dir: "ltr"},
-            pl: {id: "pl", dir: "ltr"},
-            "pt-BR": {id: "pt-BR", dir: "ltr"},
-            ro: {id: "ro", dir: "ltr"},
-            ru: {id: "ru", dir: "ltr"},
-            sk: {id: "sk", dir: "ltr"},
-            sl: {id: "sl", dir: "ltr"},
-            sr: {id: "sr", dir: "ltr"},
-            "sr-Latn": {id: "sr-Latn", dir: "ltr"},
-            sv: {id: "sv", dir: "ltr"},
-            th: {id: "th", dir: "ltr"},
-            tr: {id: "tr", dir: "ltr"},
-            uk: {id: "uk", dir: "ltr"},
-            ur: {id: "ur", dir: "rtl"},
-            vi: {id: "vi", dir: "ltr"},
-            zh: {id: "zh", dir: "ltr"},
-            "zh-CN": {id: "zh-CN", dir: "ltr"},
-            "zh-TW": {id: "zh-TW", dir: "ltr"},
+
+    class AppRoot extends Polymer.mixinBehaviors([Polymer.AppLocalizeBehavior], Polymer.Element) {
+      static get is() {
+        return "app-root";
+      }
+
+      static get properties() {
+        return {
+          LANGUAGES_AVAILABLE: {
+            type: Object,
+            readonly: true,
+            value: {
+              am: {id: "am", dir: "ltr"},
+              ar: {id: "ar", dir: "rtl"},
+              bg: {id: "bg", dir: "ltr"},
+              ca: {id: "ca", dir: "ltr"},
+              cs: {id: "cs", dir: "ltr"},
+              da: {id: "da", dir: "ltr"},
+              de: {id: "de", dir: "ltr"},
+              el: {id: "el", dir: "ltr"},
+              en: {id: "en", dir: "ltr"},
+              "es-419": {id: "es-419", dir: "ltr"},
+              fa: {id: "fa", dir: "rtl"},
+              fi: {id: "fi", dir: "ltr"},
+              fil: {id: "fil", dir: "ltr"},
+              fr: {id: "fr", dir: "ltr"},
+              he: {id: "he", dir: "rtl"},
+              hi: {id: "hi", dir: "ltr"},
+              hr: {id: "hr", dir: "ltr"},
+              hu: {id: "hu", dir: "ltr"},
+              id: {id: "id", dir: "ltr"},
+              it: {id: "it", dir: "ltr"},
+              ja: {id: "ja", dir: "ltr"},
+              ko: {id: "ko", dir: "ltr"},
+              km: {id: "km", dir: "ltr"},
+              lt: {id: "lt", dir: "ltr"},
+              lv: {id: "lv", dir: "ltr"},
+              nl: {id: "nl", dir: "ltr"},
+              no: {id: "no", dir: "ltr"},
+              pl: {id: "pl", dir: "ltr"},
+              "pt-BR": {id: "pt-BR", dir: "ltr"},
+              ro: {id: "ro", dir: "ltr"},
+              ru: {id: "ru", dir: "ltr"},
+              sk: {id: "sk", dir: "ltr"},
+              sl: {id: "sl", dir: "ltr"},
+              sr: {id: "sr", dir: "ltr"},
+              "sr-Latn": {id: "sr-Latn", dir: "ltr"},
+              sv: {id: "sv", dir: "ltr"},
+              th: {id: "th", dir: "ltr"},
+              tr: {id: "tr", dir: "ltr"},
+              uk: {id: "uk", dir: "ltr"},
+              ur: {id: "ur", dir: "rtl"},
+              vi: {id: "vi", dir: "ltr"},
+              zh: {id: "zh", dir: "ltr"},
+              "zh-CN": {id: "zh-CN", dir: "ltr"},
+              "zh-TW": {id: "zh-TW", dir: "ltr"},
+            },
           },
-        },
-        DEFAULT_LANGUAGE: {
-          type: String,
-          readonly: true,
-          value: "en",
-        },
-        useKeyIfMissing: {
-          type: Boolean,
-          value: true,
-        },
-        language: {
-          type: String,
-          readonly: true,
-          computed: "_computeLanguage(LANGUAGES_AVAILABLE, DEFAULT_LANGUAGE)",
-        },
-        serverList: {
-          type: Array,
-          value: [],
-        },
-        selectedServer: {
-          type: Object, // DisplayServer in display_server.ts
-          value: undefined,
-        },
-        hasManualServers: {
-          type: Boolean,
-          computed: "_computeHasManualServers(serverList.*)",
-        },
-        adminEmail: {
-          type: String,
-          value: "",
-        },
-        isSignedInToDigitalOcean: {
-          type: Boolean,
-          computed: "_computeIsSignedInToDigitalOcean(adminEmail)",
-        },
-        outlineVersion: String,
-        userAcceptedTos: {
-          type: Boolean,
-          // Get notified when the user clicks the OK button in the ToS view
-          observer: "_userAcceptedTosChanged",
-        },
-        hasAcceptedTos: {
-          type: Boolean,
-          computed: "_computeHasAcceptedTermsOfService(userAcceptedTos)",
-        },
-        currentPage: {
-          type: String,
-          value: "intro",
-        },
-        shouldShowSideBar: {
-          type: Boolean,
-          value: false,
-        },
-        sideBarMarginClass: {
-          type: String,
-          computed: "_computeSideBarMarginClass(shouldShowSideBar)",
-        },
-      },
-      listeners: {
-        RegionSelected: "handleRegionSelected",
-        MetricsChoiceSelected: "handleMetricsChoiceSelected",
-        SetUpGenericCloudProviderRequested: "handleSetUpGenericCloudProviderRequested",
-        SetUpAwsRequested: "handleSetUpAwsRequested",
-        SetUpGcpRequested: "handleSetUpGcpRequested",
-        ManualServerEntryCancelled: "handleManualCancelled",
-      },
-      ready: function() {
+          DEFAULT_LANGUAGE: {
+            type: String,
+            readonly: true,
+            value: "en",
+          },
+          useKeyIfMissing: {
+            type: Boolean,
+            value: true,
+          },
+          language: {
+            type: String,
+            readonly: true,
+            computed: "_computeLanguage(LANGUAGES_AVAILABLE, DEFAULT_LANGUAGE)",
+          },
+          serverList: {
+            type: Array,
+            value: [],
+          },
+          selectedServer: {
+            type: Object, // DisplayServer in display_server.ts
+            value: undefined,
+          },
+          hasManualServers: {
+            type: Boolean,
+            computed: "_computeHasManualServers(serverList.*)",
+          },
+          adminEmail: {
+            type: String,
+            value: "",
+          },
+          isSignedInToDigitalOcean: {
+            type: Boolean,
+            computed: "_computeIsSignedInToDigitalOcean(adminEmail)",
+          },
+          outlineVersion: String,
+          userAcceptedTos: {
+            type: Boolean,
+            // Get notified when the user clicks the OK button in the ToS view
+            observer: "_userAcceptedTosChanged",
+          },
+          hasAcceptedTos: {
+            type: Boolean,
+            computed: "_computeHasAcceptedTermsOfService(userAcceptedTos)",
+          },
+          currentPage: {
+            type: String,
+            value: "intro",
+          },
+          shouldShowSideBar: {
+            type: Boolean,
+            value: false,
+          },
+          sideBarMarginClass: {
+            type: String,
+            computed: "_computeSideBarMarginClass(shouldShowSideBar)",
+          },
+        };
+      }
+
+      ready() {
+        super.ready();
         const messagesUrl = `/messages/${this.language}.json`;
         this.loadResources(messagesUrl, this.language);
         const languageProperties = this.LANGUAGES_AVAILABLE[this.language];
@@ -660,80 +659,103 @@
           this.$.appDrawer.align = "right";
           this.$.sideBar.align = "right";
         }
-      },
-      showIntro: function() {
+        this.addEventListener("RegionSelected", this.handleRegionSelected);
+        this.addEventListener("SetUpGenericCloudProviderRequested", this.handleSetUpGenericCloudProviderRequested);
+        this.addEventListener("SetUpAwsRequested", this.handleSetUpAwsRequested);
+        this.addEventListener("SetUpGcpRequested", this.handleSetUpGcpRequested);
+        this.addEventListener("ManualServerEntryCancelled", this.handleManualCancelled);
+      }
+
+      showIntro() {
         this.maybeCloseDrawer();
         this.selectedServer = undefined;
         this.currentPage = "intro";
-      },
-      getDigitalOceanOauthFlow: function(onCancel) {
+      }
+
+      getDigitalOceanOauthFlow(onCancel) {
         const oauthFlow = this.$.digitalOceanOauth;
         oauthFlow.onCancel = onCancel;
         return oauthFlow;
-      },
-      showDigitalOceanOauthFlow: function() {
+      }
+
+      showDigitalOceanOauthFlow() {
         this.currentPage = "digitalOceanOauth";
-      },
-      getAndShowDigitalOceanOauthFlow: function(onCancel) {
+      }
+
+      getAndShowDigitalOceanOauthFlow(onCancel) {
         this.currentPage = "digitalOceanOauth";
         const oauthFlow = this.getDigitalOceanOauthFlow(onCancel);
         oauthFlow.showConnectAccount();
         return oauthFlow;
-      },
-      getAndShowRegionPicker: function() {
+      }
+
+      getAndShowRegionPicker() {
         this.currentPage = "regionPicker";
         this.$.regionPicker.init();
         return this.$.regionPicker;
-      },
-      getManualServerEntry: function() {
+      }
+
+      getManualServerEntry() {
         return this.$.manualEntry;
-      },
-      showProgress: function(serverName, showCancelButton) {
+      }
+
+      showProgress(serverName, showCancelButton) {
         this.currentPage = "serverProgressStep";
         this.$.serverProgressStep.serverName = serverName;
         this.$.serverProgressStep.showCancelButton = showCancelButton;
         this.$.serverProgressStep.start();
-      },
-      showServerView: function() {
+      }
+
+      showServerView() {
         this.$.serverProgressStep.stop();
         this.currentPage = "serverView";
-      },
-      getServerView: function(displayServerId) {
+      }
+
+      getServerView(displayServerId) {
         if (!displayServerId) {
           return null;
         }
         const selectedServerId = this._base64Encode(displayServerId);
         return this.$.serverView.querySelector(`#serverView-${selectedServerId}`);
-      },
-      handleRegionSelected: function(e) {
+      }
+
+      handleRegionSelected(e) {
         this.fire("SetUpServerRequested", {
           regionId: this.$.regionPicker.getSelectedRegionId(),
         });
-      },
-      handleSetUpGenericCloudProviderRequested: function() {
+      }
+
+      handleSetUpGenericCloudProviderRequested() {
         this.handleManualServerSelected("generic");
-      },
-      handleSetUpAwsRequested: function() {
+      }
+
+      handleSetUpAwsRequested() {
         this.handleManualServerSelected("aws");
-      },
-      handleSetUpGcpRequested: function() {
+      }
+
+      handleSetUpGcpRequested() {
         this.handleManualServerSelected("gcp");
-      },
-      handleManualServerSelected: function(cloudProvider) {
+      }
+
+      handleManualServerSelected(cloudProvider) {
         this.$.manualEntry.clear();
         this.$.manualEntry.cloudProvider = cloudProvider;
         this.currentPage = "manualEntry";
-      },
-      handleManualCancelled: function() {
+      }
+
+      handleManualCancelled() {
         this.currentPage = "intro";
-      },
-      showError: function(errorMsg) {
+      }
+
+      showError(errorMsg) {
         this.showToast(errorMsg, Infinity);
-      },
-      showNotification: function(message, durationMs = 3000) {
+      }
+
+      showNotification(message, durationMs = 3000) {
         this.showToast(message, durationMs);
-      },
-      showToast: function(message, duration) {
+      }
+
+      showToast(message, duration) {
         const toast = this.$.toast;
         toast.close();
         // Defer in order to trigger the toast animation, otherwise the
@@ -745,13 +767,15 @@
             noOverlap: true,
           });
         }, 0);
-      },
-      closeError: function() {
+      }
+
+      closeError() {
         this.$.toast.close();
-      },
+      }
+
       // cb is a function which accepts a single boolean which is true iff
       // the user chose to retry the failing operation.
-      showConnectivityDialog: function(cb) {
+      showConnectivityDialog(cb) {
         const dialogTitle = this.localize("error-connectivity-title");
         const dialogText = this.localize("error-connectivity");
         this.showModalDialog(dialogTitle, dialogText, [this.localize("cancel"), this.localize("retry")]).then(
@@ -759,16 +783,18 @@
             cb(clickedButtonIndex === 1); // pass true if user clicked retry
           }
         );
-      },
-      getConfirmation: function(title, text, confirmButtonText, continueFunc) {
+      }
+
+      getConfirmation(title, text, confirmButtonText, continueFunc) {
         this.showModalDialog(title, text, [this.localize("cancel"), confirmButtonText]).then(clickedButtonIndex => {
           if (clickedButtonIndex === 1) {
             // user clicked to confirm.
             continueFunc();
           }
         });
-      },
-      showManualServerError: function(errorTitle, errorText) {
+      }
+
+      showManualServerError(errorTitle, errorText) {
         this.showModalDialog(errorTitle, errorText, [this.localize("cancel"), this.localize("retry")]).then(
           clickedButtonIndex => {
             if (clickedButtonIndex == 1) {
@@ -778,22 +804,26 @@
             }
           }
         );
-      },
-      _computeIsSignedInToDigitalOcean: function(adminEmail) {
+      }
+      _computeIsSignedInToDigitalOcean(adminEmail) {
         return Boolean(adminEmail);
-      },
-      _computeHasManualServers: function(serverList) {
+      }
+
+      _computeHasManualServers(serverList) {
         return this.serverList.filter(server => !server.isManaged).length > 0;
-      },
-      _userAcceptedTosChanged: function(userAcceptedTos) {
+      }
+
+      _userAcceptedTosChanged(userAcceptedTos) {
         if (userAcceptedTos) {
           window.localStorage[TOS_ACK_LOCAL_STORAGE_KEY] = Date.now();
         }
-      },
-      _computeHasAcceptedTermsOfService: function(userAcceptedTos) {
+      }
+
+      _computeHasAcceptedTermsOfService(userAcceptedTos) {
         return userAcceptedTos || !!window.localStorage[TOS_ACK_LOCAL_STORAGE_KEY];
-      },
-      _toggleAppDrawer: function() {
+      }
+
+      _toggleAppDrawer() {
         const drawerNarrow = this.$.drawerLayout.narrow;
         const forceNarrow = this.$.drawerLayout.forceNarrow;
         if (drawerNarrow) {
@@ -807,28 +837,35 @@
           // collapses the drawer. Conversely, reverting force narrow expands the drawer.
           this.$.drawerLayout.forceNarrow = !forceNarrow;
         }
-      },
-      maybeCloseDrawer: function() {
+      }
+
+      maybeCloseDrawer() {
         if (this.$.drawerLayout.narrow || this.$.drawerLayout.forceNarrow) {
           this.$.appDrawer.close();
         }
-      },
-      submitFeedbackTapped: function() {
+      }
+
+      submitFeedbackTapped() {
         this.$.feedbackDialog.open();
-      },
-      aboutTapped: function() {
+      }
+
+      aboutTapped() {
         this.$.aboutDialog.open();
-      },
-      signOutTapped: function() {
+      }
+
+      signOutTapped() {
         this.fire("SignOutRequested");
-      },
-      openManualInstallFeedback: function(prepopulatedMessage) {
+      }
+
+      openManualInstallFeedback(prepopulatedMessage) {
         this.$.feedbackDialog.open(prepopulatedMessage, true);
-      },
-      openShareDialog: function(accessKey, s3Url) {
+      }
+
+      openShareDialog(accessKey, s3Url) {
         this.$.shareDialog.open(accessKey, s3Url);
-      },
-      openGetConnectedDialog: function(inviteUrl) {
+      }
+
+      openGetConnectedDialog(inviteUrl) {
         const dialog = this.$.getConnectedDialog;
         if (dialog.children.length > 1) {
           return; // The iframe is already loading.
@@ -843,24 +880,29 @@
         };
         iframe.src = inviteUrl;
         dialog.insertBefore(iframe, dialog.children[0]);
-      },
-      closeGetConnectedDialog: function() {
+      }
+
+      closeGetConnectedDialog() {
         const dialog = this.$.getConnectedDialog;
         dialog.close();
         const oldIframe = dialog.children[0];
         dialog.removeChild(oldIframe);
-      },
-      showMetricsDialogForNewServer: function() {
+      }
+
+      showMetricsDialogForNewServer() {
         this.$.metricsDialog.showMetricsOptInDialog();
-      },
+      }
+
       // Returns a Promise which fulfills with the index of the button clicked.
-      showModalDialog: function(title, text, buttons) {
+      showModalDialog(title, text, buttons) {
         return this.$.modalDialog.open(title, text, buttons);
-      },
-      closeModalDialog: function(title, text, buttons) {
+      }
+
+      closeModalDialog(title, text, buttons) {
         return this.$.modalDialog.close();
-      },
-      showLicensesTapped: function() {
+      }
+
+      showLicensesTapped() {
         var xhr = new XMLHttpRequest();
         xhr.onload = () => {
           this.$.licensesText.innerText = xhr.responseText;
@@ -871,8 +913,9 @@
         };
         xhr.open("GET", "/ui_components/licenses/licenses.txt", true);
         xhr.send();
-      },
-      _computeShouldShowSideBar: function() {
+      }
+
+      _computeShouldShowSideBar() {
         const drawerNarrow = this.$.drawerLayout.narrow;
         const drawerOpened = this.$.appDrawer.opened;
         if (drawerOpened && drawerNarrow) {
@@ -880,17 +923,21 @@
         } else {
           this.shouldShowSideBar = drawerNarrow;
         }
-      },
-      _computeSideBarMarginClass: function(shouldShowSideBar) {
+      }
+
+      _computeSideBarMarginClass(shouldShowSideBar) {
         return shouldShowSideBar ? "side-bar-margin" : "";
-      },
-      _isServerManaged: function(server) {
+      }
+
+      _isServerManaged(server) {
         return server.isManaged;
-      },
-      _isServerManual: function(server) {
+      }
+
+      _isServerManual(server) {
         return !server.isManaged;
-      },
-      _sortServersByName: function(a, b) {
+      }
+
+      _sortServersByName(a, b) {
         const aName = a.name.toUpperCase();
         const bName = b.name.toUpperCase();
         if (aName < bName) {
@@ -899,8 +946,9 @@
           return 1;
         }
         return 0;
-      },
-      _computeServerClasses: function(selectedServer, server) {
+      }
+
+      _computeServerClasses(selectedServer, server) {
         let serverClasses = [];
         if (this._isServerSelected(selectedServer, server)) {
           serverClasses.push("selected");
@@ -909,30 +957,36 @@
           serverClasses.push("syncing");
         }
         return serverClasses.join(" ");
-      },
-      _computeServerImage: function(selectedServer, server) {
+      }
+
+      _computeServerImage(selectedServer, server) {
         if (this._isServerSelected(selectedServer, server)) {
           return "server-icon-selected.png";
         }
         return "server-icon.png";
-      },
-      _isServerSelected: function(selectedServer, server) {
+      }
+
+      _isServerSelected(selectedServer, server) {
         return !!selectedServer && selectedServer.id === server.id;
-      },
-      _showServer: function(event) {
+      }
+
+      _showServer(event) {
         const server = event.model.server;
         this.fire("ShowServerRequested", {displayServerId: server.id});
         this.maybeCloseDrawer();
-      },
-      _computeLanguage: function(LANGUAGES_AVAILABLE, DEFAULT_LANGUAGE) {
+      }
+
+      _computeLanguage(LANGUAGES_AVAILABLE, DEFAULT_LANGUAGE) {
         return OutlineI18n.getBestMatchingLanguage(Object.keys(LANGUAGES_AVAILABLE)) || DEFAULT_LANGUAGE;
-      },
+      }
+
       // Wrapper to encode a string in base64. This is necessary to set the server view IDs to
       // the display server IDs, which are URLs, so they can be used with selector methods. The IDs
       // are never decoded.
-      _base64Encode: function(s) {
+      _base64Encode(s) {
         return btoa(s).replace(/=/g, "");
-      },
-    });
+      }
+    }
+    customElements.define(AppRoot.is, AppRoot);
   </script>
 </dom-module>

--- a/src/server_manager/ui_components/app-root.html
+++ b/src/server_manager/ui_components/app-root.html
@@ -594,20 +594,23 @@
         };
       }
 
-      ready() {
-        super.ready();
-        const messagesUrl = `/messages/${this.language}.json`;
-        this.loadResources(messagesUrl, this.language);
-        const langDir = this.getAttribute("dir");
-        if (langDir === "rtl") {
-          this.$.appDrawer.align = "right";
-          this.$.sideBar.align = "right";
-        }
+      constructor() {
+        super();
         this.addEventListener("RegionSelected", this.handleRegionSelected);
         this.addEventListener("SetUpGenericCloudProviderRequested", this.handleSetUpGenericCloudProviderRequested);
         this.addEventListener("SetUpAwsRequested", this.handleSetUpAwsRequested);
         this.addEventListener("SetUpGcpRequested", this.handleSetUpGcpRequested);
         this.addEventListener("ManualServerEntryCancelled", this.handleManualCancelled);
+      }
+
+      setLanguage(newLanguage, langDir) {
+        const messagesUrl = `/messages/${newLanguage}.json`;
+        this.loadResources(messagesUrl, newLanguage);
+        if (langDir === "rtl") {
+          this.$.appDrawer.align = "right";
+          this.$.sideBar.align = "right";
+        }
+        this.language = newLanguage;
       }
 
       showIntro() {

--- a/src/server_manager/ui_components/app-root.html
+++ b/src/server_manager/ui_components/app-root.html
@@ -540,69 +540,14 @@
 
       static get properties() {
         return {
-          LANGUAGES_AVAILABLE: {
-            type: Object,
-            readonly: true,
-            value: {
-              am: {id: "am", dir: "ltr"},
-              ar: {id: "ar", dir: "rtl"},
-              bg: {id: "bg", dir: "ltr"},
-              ca: {id: "ca", dir: "ltr"},
-              cs: {id: "cs", dir: "ltr"},
-              da: {id: "da", dir: "ltr"},
-              de: {id: "de", dir: "ltr"},
-              el: {id: "el", dir: "ltr"},
-              en: {id: "en", dir: "ltr"},
-              "es-419": {id: "es-419", dir: "ltr"},
-              fa: {id: "fa", dir: "rtl"},
-              fi: {id: "fi", dir: "ltr"},
-              fil: {id: "fil", dir: "ltr"},
-              fr: {id: "fr", dir: "ltr"},
-              he: {id: "he", dir: "rtl"},
-              hi: {id: "hi", dir: "ltr"},
-              hr: {id: "hr", dir: "ltr"},
-              hu: {id: "hu", dir: "ltr"},
-              id: {id: "id", dir: "ltr"},
-              it: {id: "it", dir: "ltr"},
-              ja: {id: "ja", dir: "ltr"},
-              ko: {id: "ko", dir: "ltr"},
-              km: {id: "km", dir: "ltr"},
-              lt: {id: "lt", dir: "ltr"},
-              lv: {id: "lv", dir: "ltr"},
-              nl: {id: "nl", dir: "ltr"},
-              no: {id: "no", dir: "ltr"},
-              pl: {id: "pl", dir: "ltr"},
-              "pt-BR": {id: "pt-BR", dir: "ltr"},
-              ro: {id: "ro", dir: "ltr"},
-              ru: {id: "ru", dir: "ltr"},
-              sk: {id: "sk", dir: "ltr"},
-              sl: {id: "sl", dir: "ltr"},
-              sr: {id: "sr", dir: "ltr"},
-              "sr-Latn": {id: "sr-Latn", dir: "ltr"},
-              sv: {id: "sv", dir: "ltr"},
-              th: {id: "th", dir: "ltr"},
-              tr: {id: "tr", dir: "ltr"},
-              uk: {id: "uk", dir: "ltr"},
-              ur: {id: "ur", dir: "rtl"},
-              vi: {id: "vi", dir: "ltr"},
-              zh: {id: "zh", dir: "ltr"},
-              "zh-CN": {id: "zh-CN", dir: "ltr"},
-              "zh-TW": {id: "zh-TW", dir: "ltr"},
-            },
-          },
-          DEFAULT_LANGUAGE: {
+          // Properties language and useKeyIfMissing are used by Polymer.AppLocalizeBehavior.
+          language: {
             type: String,
             readonly: true,
-            value: "en",
           },
           useKeyIfMissing: {
             type: Boolean,
             value: true,
-          },
-          language: {
-            type: String,
-            readonly: true,
-            computed: "_computeLanguage(LANGUAGES_AVAILABLE, DEFAULT_LANGUAGE)",
           },
           serverList: {
             type: Array,
@@ -653,9 +598,8 @@
         super.ready();
         const messagesUrl = `/messages/${this.language}.json`;
         this.loadResources(messagesUrl, this.language);
-        const languageProperties = this.LANGUAGES_AVAILABLE[this.language];
-        if (languageProperties && languageProperties.dir === "rtl") {
-          document.documentElement.setAttribute("dir", "rtl");
+        const langDir = this.getAttribute("dir");
+        if (langDir === "rtl") {
           this.$.appDrawer.align = "right";
           this.$.sideBar.align = "right";
         }
@@ -974,10 +918,6 @@
         const server = event.model.server;
         this.fire("ShowServerRequested", {displayServerId: server.id});
         this.maybeCloseDrawer();
-      }
-
-      _computeLanguage(LANGUAGES_AVAILABLE, DEFAULT_LANGUAGE) {
-        return OutlineI18n.getBestMatchingLanguage(Object.keys(LANGUAGES_AVAILABLE)) || DEFAULT_LANGUAGE;
       }
 
       // Wrapper to encode a string in base64. This is necessary to set the server view IDs to

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -15,6 +15,7 @@
 import * as url from 'url';
 
 import * as digitalocean_api from '../cloud/digitalocean_api';
+import * as i18n from '../infrastructure/i18n';
 
 import {App, DATA_LIMITS_AVAILABILITY_DATE} from './app';
 import {DigitalOceanTokenManager} from './digitalocean_oauth';
@@ -22,6 +23,61 @@ import * as digitalocean_server from './digitalocean_server';
 import {DisplayServerRepository} from './display_server';
 import {ManualServerRepository} from './manual_server';
 import {DEFAULT_PROMPT_IMPRESSION_DELAY_MS, OutlineSurveys} from './survey';
+
+const SUPPORTED_LANGUAGES: {[key: string]: {id: string, dir: string}} = {
+  'am': {id: 'am', dir: 'ltr'},
+  'ar': {id: 'ar', dir: 'rtl'},
+  'bg': {id: 'bg', dir: 'ltr'},
+  'ca': {id: 'ca', dir: 'ltr'},
+  'cs': {id: 'cs', dir: 'ltr'},
+  'da': {id: 'da', dir: 'ltr'},
+  'de': {id: 'de', dir: 'ltr'},
+  'el': {id: 'el', dir: 'ltr'},
+  'en': {id: 'en', dir: 'ltr'},
+  'es-419': {id: 'es-419', dir: 'ltr'},
+  'fa': {id: 'fa', dir: 'rtl'},
+  'fi': {id: 'fi', dir: 'ltr'},
+  'fil': {id: 'fil', dir: 'ltr'},
+  'fr': {id: 'fr', dir: 'ltr'},
+  'he': {id: 'he', dir: 'rtl'},
+  'hi': {id: 'hi', dir: 'ltr'},
+  'hr': {id: 'hr', dir: 'ltr'},
+  'hu': {id: 'hu', dir: 'ltr'},
+  'id': {id: 'id', dir: 'ltr'},
+  'it': {id: 'it', dir: 'ltr'},
+  'ja': {id: 'ja', dir: 'ltr'},
+  'ko': {id: 'ko', dir: 'ltr'},
+  'km': {id: 'km', dir: 'ltr'},
+  'lt': {id: 'lt', dir: 'ltr'},
+  'lv': {id: 'lv', dir: 'ltr'},
+  'nl': {id: 'nl', dir: 'ltr'},
+  'no': {id: 'no', dir: 'ltr'},
+  'pl': {id: 'pl', dir: 'ltr'},
+  'pt-BR': {id: 'pt-BR', dir: 'ltr'},
+  'ro': {id: 'ro', dir: 'ltr'},
+  'ru': {id: 'ru', dir: 'ltr'},
+  'sk': {id: 'sk', dir: 'ltr'},
+  'sl': {id: 'sl', dir: 'ltr'},
+  'sr': {id: 'sr', dir: 'ltr'},
+  'sr-Latn': {id: 'sr-Latn', dir: 'ltr'},
+  'sv': {id: 'sv', dir: 'ltr'},
+  'th': {id: 'th', dir: 'ltr'},
+  'tr': {id: 'tr', dir: 'ltr'},
+  'uk': {id: 'uk', dir: 'ltr'},
+  'ur': {id: 'ur', dir: 'rtl'},
+  'vi': {id: 'vi', dir: 'ltr'},
+  'zh': {id: 'zh', dir: 'ltr'},
+  'zh-CN': {id: 'zh-CN', dir: 'ltr'},
+  'zh-TW': {id: 'zh-TW', dir: 'ltr'},
+};
+
+function languageToUse(): i18n.LanguageCode {
+  const supportedLanguages = i18n.languageList(Object.keys(SUPPORTED_LANGUAGES));
+  const defaultLanguage = new i18n.LanguageCode('en');
+  const userLanguages = i18n.getBrowserLanguages();
+  return new i18n.LanguageMatcher(supportedLanguages, defaultLanguage)
+      .getBestSupportedLanguage(userLanguages);
+}
 
 function ensureString(queryParam: string|string[]): string {
   if (Array.isArray(queryParam)) {
@@ -48,10 +104,17 @@ document.addEventListener('WebComponentsReady', () => {
   };
 
   // Create and start the app.
+  const language = languageToUse();
+  const languageDirection = SUPPORTED_LANGUAGES[language.string()].dir;
+  document.documentElement.setAttribute('dir', languageDirection);
+  const appRootEl = document.createElement('app-root');
+  appRootEl.setAttribute('language', language.string());
+  appRootEl.setAttribute('dir', languageDirection);
+  document.body.appendChild(appRootEl);
   // NOTE: this cast is safe and allows us to leverage Polymer typings since we haven't migrated to
   // Polymer 3, which adds typescript support.
   // tslint:disable-next-line:no-any
-  const appRoot: polymer.Base = (document.getElementById('appRoot') as any) as polymer.Base;
+  const appRoot = appRootEl as unknown as polymer.Base;
   new App(
       appRoot, version, digitalocean_api.createDigitalOceanSession,
       digitalOceanServerRepositoryFactory, new ManualServerRepository('manualServers'),

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -107,14 +107,10 @@ document.addEventListener('WebComponentsReady', () => {
   const language = getLanguageToUse();
   const languageDirection = SUPPORTED_LANGUAGES[language.string()].dir;
   document.documentElement.setAttribute('dir', languageDirection);
-  const appRootEl = document.createElement('app-root');
-  appRootEl.setAttribute('language', language.string());
-  appRootEl.setAttribute('dir', languageDirection);
-  document.body.appendChild(appRootEl);
   // NOTE: this cast is safe and allows us to leverage Polymer typings since we haven't migrated to
   // Polymer 3, which adds typescript support.
-  // tslint:disable-next-line:no-any
-  const appRoot = appRootEl as unknown as polymer.Base;
+  const appRoot = document.getElementById('appRoot') as unknown as polymer.Base;
+  appRoot.setLanguage(language.string(), languageDirection);
   new App(
       appRoot, version, digitalocean_api.createDigitalOceanSession,
       digitalOceanServerRepositoryFactory, new ManualServerRepository('manualServers'),

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -71,7 +71,7 @@ const SUPPORTED_LANGUAGES: {[key: string]: {id: string, dir: string}} = {
   'zh-TW': {id: 'zh-TW', dir: 'ltr'},
 };
 
-function languageToUse(): i18n.LanguageCode {
+function getLanguageToUse(): i18n.LanguageCode {
   const supportedLanguages = i18n.languageList(Object.keys(SUPPORTED_LANGUAGES));
   const defaultLanguage = new i18n.LanguageCode('en');
   const userLanguages = i18n.getBrowserLanguages();
@@ -104,7 +104,7 @@ document.addEventListener('WebComponentsReady', () => {
   };
 
   // Create and start the app.
-  const language = languageToUse();
+  const language = getLanguageToUse();
   const languageDirection = SUPPORTED_LANGUAGES[language.string()].dir;
   document.documentElement.setAttribute('dir', languageDirection);
   const appRootEl = document.createElement('app-root');


### PR DESCRIPTION
This:
- Creates a i18n library with tests
- Moves logic out of ui component (it shouldn't be there)
- Removes another entry point from index.html

I'm aiming to have one Javascript entrypoint and no cross-dependency between entry points. The current hidden dependencies makes migration hard.

Notice that this pushes more logic into Typescript.

cc: @JonathanDCohen @mpmcroy 