### PR TITLE
Stop depending on Node code in the browser code

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "husky": "^1.3.1",
     "jasmine": "^2.6.0",
     "tslint": "^5.9.1",
-    "typescript": "^3.7.4"
+    "typescript": "^3.8.3"
   },
   "engines": {
     "yarn": ">=1.0"

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -17,6 +17,7 @@
     }
   },
   "dependencies": {
+    "@sentry/browser": "^5.15.5",
     "@sentry/electron": "^0.8.1",
     "body-parser": "^1.18.3",
     "byte-size": "^6.2.0",

--- a/src/server_manager/ui_components/outline-server-view.html
+++ b/src/server_manager/ui_components/outline-server-view.html
@@ -787,6 +787,7 @@
         this.totalInboundBytes = totalBytes;
       },
       updateAccessKeyRow(accessKeyId, fields) {
+        let newAccessKeyRow;
         if (accessKeyId === MY_CONNECTION_USER_ID) {
           newAccessKeyRow = Object.assign({}, this.get("myConnection"), fields);
           this.set("myConnection", newAccessKeyRow);

--- a/src/server_manager/web_app/app.spec.ts
+++ b/src/server_manager/web_app/app.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as events from 'events';
+import {EventEmitter} from 'eventemitter3';
 
 import * as digitalocean_api from '../cloud/digitalocean_api';
 import {InMemoryStorage} from '../infrastructure/memory_storage';
@@ -258,7 +258,7 @@ enum AppRootScreen {
 }
 
 class FakePolymerAppRoot implements polymer.Base {
-  events = new events.EventEmitter();
+  events = new EventEmitter();
   backgroundScreen = AppRootScreen.NONE;
   currentScreen = AppRootScreen.NONE;
   serverView = {setServerTransferredData: () => {}, serverId: '', initHelpBubbles: () => {}};

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as sentry from '@sentry/electron';
-import * as events from 'events';
+import * as sentry from '@sentry/browser';
+import {EventEmitter} from 'eventemitter3';
 import * as semver from 'semver';
 
 import * as digitalocean_api from '../cloud/digitalocean_api';
@@ -480,7 +480,7 @@ export class App {
   // resolves with the servers present in the account.
   private enterDigitalOceanMode(accessToken: string): Promise<server.ManagedServer[]> {
     const doSession = this.createDigitalOceanSession(accessToken);
-    const authEvents = new events.EventEmitter();
+    const authEvents = new EventEmitter();
     let cancelled = false;
     let activatingAccount = false;
 

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -90,12 +90,12 @@ function ensureString(queryParam: string|string[]): string {
 
 document.addEventListener('WebComponentsReady', () => {
   // Parse URL query params.
-  const queryParams = url.parse(document.URL, true).query;
-  const debugMode = ensureString(queryParams.outlineDebugMode) === 'true';
-  const metricsUrl = ensureString(queryParams.metricsUrl);
-  const shadowboxImage = ensureString(queryParams.image);
-  const version = ensureString(queryParams.version);
-  const sentryDsn = ensureString(queryParams.sentryDsn);
+  const params = new URL(document.URL).searchParams;
+  const debugMode = params.get('outlineDebugMode') === 'true';
+  const metricsUrl = params.get('metricsUrl');
+  const shadowboxImage = params.get('image');
+  const version = params.get('version');
+  const sentryDsn = params.get('sentryDsn');
 
   // Set DigitalOcean server repository parameters.
   const digitalOceanServerRepositoryFactory = (session: digitalocean_api.DigitalOceanSession) => {

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -79,15 +79,6 @@ function getLanguageToUse(): i18n.LanguageCode {
       .getBestSupportedLanguage(userLanguages);
 }
 
-function ensureString(queryParam: string|string[]): string {
-  if (Array.isArray(queryParam)) {
-    // We pick the last one if the parameter appears multiple times.
-    return queryParam[queryParam.length - 1];
-  } else {
-    return queryParam;
-  }
-}
-
 document.addEventListener('WebComponentsReady', () => {
   // Parse URL query params.
   const params = new URL(document.URL).searchParams;

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as url from 'url';
-
 import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as i18n from '../infrastructure/i18n';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "removeComments": false,
     "noImplicitAny": true,
     "noImplicitThis": true,
+    // We must use commonjs because browserify doesn't support es2015 modules.
+    // TODO: Delete and add "moduleResolution: Node" once we move to webpack.
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "build/server_manager/web_app/js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6930,7 +6930,7 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.4:
+typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,16 @@
     "@sentry/types" "4.0.0-beta.12"
     "@sentry/utils" "4.0.0-beta.12"
 
+"@sentry/browser@^5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.15.5.tgz#d9a51f1388581067b50d30ed9b1aed2cbb333a36"
+  integrity sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==
+  dependencies:
+    "@sentry/core" "5.15.5"
+    "@sentry/types" "5.15.5"
+    "@sentry/utils" "5.15.5"
+    tslib "^1.9.3"
+
 "@sentry/core@4.0.0-beta.12":
   version "4.0.0-beta.12"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-4.0.0-beta.12.tgz#c821e41b02c1d66e48fbef16da744f0173575558"
@@ -166,6 +176,17 @@
     "@sentry/minimal" "4.0.0-beta.12"
     "@sentry/types" "4.0.0-beta.12"
     "@sentry/utils" "4.0.0-beta.12"
+
+"@sentry/core@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.15.5.tgz#40ea79bff5272d3fbbeeb4a98cdc59e1adbd2c92"
+  integrity sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==
+  dependencies:
+    "@sentry/hub" "5.15.5"
+    "@sentry/minimal" "5.15.5"
+    "@sentry/types" "5.15.5"
+    "@sentry/utils" "5.15.5"
+    tslib "^1.9.3"
 
 "@sentry/electron@^0.8.1":
   version "0.8.1"
@@ -191,6 +212,15 @@
     "@sentry/types" "4.0.0-beta.12"
     "@sentry/utils" "4.0.0-beta.12"
 
+"@sentry/hub@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.15.5.tgz#f5abbcdbe656a70e2ff02c02a5a4cffa0f125935"
+  integrity sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==
+  dependencies:
+    "@sentry/types" "5.15.5"
+    "@sentry/utils" "5.15.5"
+    tslib "^1.9.3"
+
 "@sentry/minimal@4.0.0-beta.12":
   version "4.0.0-beta.12"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-4.0.0-beta.12.tgz#534e8edd065646e0e5f8d71443a63f6ce7187573"
@@ -198,6 +228,15 @@
   dependencies:
     "@sentry/hub" "4.0.0-beta.12"
     "@sentry/types" "4.0.0-beta.12"
+
+"@sentry/minimal@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.15.5.tgz#a0e4e071f01d9c4d808094ae7203f6c4cca9348a"
+  integrity sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==
+  dependencies:
+    "@sentry/hub" "5.15.5"
+    "@sentry/types" "5.15.5"
+    tslib "^1.9.3"
 
 "@sentry/node@4.0.0-beta.12":
   version "4.0.0-beta.12"
@@ -219,6 +258,11 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.0.0-beta.12.tgz#0abd303692e48c0fc11afbfea8cbad87e625357a"
   integrity sha512-xRsTfRcb8OvMbLjl64bPNv3feHiXBprtRZqTlVUbDJmSNrm8wg+tKIPYsP90dxKc50CZBk59urIbgvpPg0mCLw==
 
+"@sentry/types@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.15.5.tgz#16c97e464cf09bbd1d2e8ce90d130e781709076e"
+  integrity sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw==
+
 "@sentry/types@^4.4.1":
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-4.5.3.tgz#3350dce2b7f9b936a8c327891c12e3aef7bd8852"
@@ -230,6 +274,14 @@
   integrity sha512-lpTE2GlaztATlFfIWMN8RSQFP0z6PkPPoDz0KKRmK4ZxjPxVX2sAGbKJGCpf9fdUG23NVg3FNiqfpUbjhvd9YA==
   dependencies:
     "@sentry/types" "4.0.0-beta.12"
+
+"@sentry/utils@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.15.5.tgz#dec1d4c79037c4da08b386f5d34409234dcbfb15"
+  integrity sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==
+  dependencies:
+    "@sentry/types" "5.15.5"
+    tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -6790,7 +6842,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-tslib@^1.8.0, tslib@^1.8.1:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
This is an issue I ran into when migrating to Webpack. We are depending on some Node.js code in browser code. I believe the only reason why it works is because browserify must insert some polyfill. Still, it's better to not depend on that, especially given browser alternatives are available.

After this change, I believe I'll be able to migrate to webpack, which may allow us to use node_modules dependencies in the html javascript and move towards a single javascript entry point.