### PR TITLE
Fire metrics request only on user interaction

### DIFF
--- a/src/server_manager/ui_components/outline-server-settings.html
+++ b/src/server_manager/ui_components/outline-server-settings.html
@@ -353,7 +353,7 @@
       properties: {
         isServerManaged: Boolean,
         serverName: String,
-        metricsEnabled: {type: Boolean, observer: "_metricsEnabledChanged"},
+        metricsEnabled: {type: Boolean, value: null, observer: "_metricsEnabledChanged"},
         // Initialize to null so we can use the hidden attribute, which does not work well with undefined values.
         serverId: {type: String, value: null},
         serverHostname: {type: String, value: null},
@@ -373,10 +373,9 @@
         localize: {type: Function, readonly: true},
         shouldShowExperiments: {type: Boolean, computed: "_computeShouldShowExperiments(supportsAccessKeyDataLimit)"},
       },
-      update: function(name, metricsEnabled) {
+      update: function(name) {
         this.initialName = name;
         this.name = name;
-        this.metricsEnabled = metricsEnabled;
       },
       _handleNameInputKeyDown: function(event) {
         if (event.key === "Escape") {
@@ -398,7 +397,13 @@
         }
       },
       _metricsEnabledChanged: function(newMetricsEnabled, oldMetricsEnabled) {
-        if (oldMetricsEnabled === undefined || newMetricsEnabled === undefined) {
+        // metricsEnabled is initialized to null to avoid firing the first time it is set.
+        if (
+          oldMetricsEnabled === undefined ||
+          newMetricsEnabled === undefined ||
+          oldMetricsEnabled === null ||
+          newMetricsEnabled === null
+        ) {
           return;
         }
         // Fire signal if metrics changed.

--- a/src/server_manager/ui_components/outline-server-view.html
+++ b/src/server_manager/ui_components/outline-server-view.html
@@ -598,6 +598,7 @@
             server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]"
             is-server-managed="[[isServerManaged]]"
             server-location="[[serverLocation]]"
+            metrics-enabled="[[metricsEnabled]]"
             localize="[[localize]]"
           >
           </outline-server-settings>

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -1202,14 +1202,18 @@ export class App {
   }
 
   private async setMetricsEnabled(metricsEnabled: boolean) {
+    const serverView = this.appRoot.getServerView(this.appRoot.selectedServer.id);
     try {
       await this.selectedServer.setMetricsEnabled(metricsEnabled);
       this.appRoot.showNotification(this.appRoot.localize('saved'));
       // Change metricsEnabled property on polymer element to update display.
-      this.appRoot.getServerView(this.appRoot.selectedServer.id).metricsEnabled = metricsEnabled;
+      serverView.metricsEnabled = metricsEnabled;
     } catch (error) {
       console.error(`Failed to set metrics enabled: ${error}`);
       this.appRoot.showError(this.appRoot.localize('error-metrics'));
+      // Restore `metricsEnabled` by first setting to null to prevent firing infinitely.
+      serverView.metricsEnabled = null;
+      serverView.metricsEnabled = !metricsEnabled;
     }
   }
 


### PR DESCRIPTION
* Currently, when the user navigates to the settings page we make an API call to set metrics enabled to the existing value. In addition to performing an unecessary network request, we display a "Saved" toast.
* Fixes this behavior by only making an API request when the user interacts with the UI. This is accomplished by using a sentinel value of `null` for the server view's `metricsEnabled` property.
* Restores the UI metrics enabled checkbox to its previous value when the API fails.