### PR TITLE
Fix getSentryApiUrl

### DIFF
--- a/src/server_manager/infrastructure/sentry.spec.ts
+++ b/src/server_manager/infrastructure/sentry.spec.ts
@@ -1,0 +1,23 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as sentry from './sentry';
+
+describe('getSentryApiUrl', () => {
+  it('returns the right URL', () => {
+    const url = sentry.getSentryApiUrl('https://_key_@_org_.ingest.sentry.io/_project_');
+    expect(url).toEqual(
+        'https://_org_.ingest.sentry.io/api/_project_/store/?sentry_version=7&sentry_key=_key_');
+  });
+});

--- a/src/server_manager/infrastructure/sentry.ts
+++ b/src/server_manager/infrastructure/sentry.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Returns Sentry URL for DSN string or undefined if `sentryDsn` is falsy.
-// e.g. for DSN "https://[API_KEY]@[SUBDOMAIN]ingest.sentry.io/[PROJECT_ID]"
+// e.g. for DSN "https://[API_KEY]@[SUBDOMAIN].ingest.sentry.io/[PROJECT_ID]"
 // this will return
 // "https://[SUBDOMAIN].ingest.sentry.io/api/[PROJECT_ID]/store/?sentry_version=7&sentry_key=[API_KEY]"
 export function getSentryApiUrl(sentryDsn?: string): string|undefined {

--- a/src/server_manager/infrastructure/sentry.ts
+++ b/src/server_manager/infrastructure/sentry.ts
@@ -1,0 +1,29 @@
+// Copyright 2020 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Returns Sentry URL for DSN string or undefined if `sentryDsn` is falsy.
+// e.g. for DSN "https://[API_KEY]@[SUBDOMAIN]ingest.sentry.io/[PROJECT_ID]"
+// this will return
+// "https://[SUBDOMAIN].ingest.sentry.io/api/[PROJECT_ID]/store/?sentry_version=7&sentry_key=[API_KEY]"
+export function getSentryApiUrl(sentryDsn?: string): string|undefined {
+  if (!sentryDsn) {
+    return undefined;
+  }
+  const dsnUrl = new URL(sentryDsn);
+  const sentryKey = dsnUrl.username;
+  // Trims leading '/';
+  const project = dsnUrl.pathname.substr(1);
+  return `https://${encodeURIComponent(dsnUrl.hostname)}/api/${
+      encodeURIComponent(project)}/store/?sentry_version=7&sentry_key=${sentryKey}`;
+}

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -14,6 +14,7 @@
 
 import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as i18n from '../infrastructure/i18n';
+import {getSentryApiUrl} from '../infrastructure/sentry';
 
 import {App, DATA_LIMITS_AVAILABILITY_DATE} from './app';
 import {DigitalOceanTokenManager} from './digitalocean_oauth';
@@ -110,14 +111,3 @@ document.addEventListener('WebComponentsReady', () => {
       .start();
 });
 
-// Returns Sentry URL for DSN string or undefined if `sentryDsn` is falsy.
-// e.g. for DSN "https://[API_KEY]@sentry.io/[PROJECT_ID]"
-// this will return
-// "https://sentry.io/api/[PROJECT_ID]/store/?sentry_version=7&sentry_key=[API_KEY]"
-function getSentryApiUrl(sentryDsn?: string): string|undefined {
-  if (!sentryDsn) {
-    return undefined;
-  }
-  const matches = sentryDsn.match(/https:\/\/(\S+)@sentry\.io\/(\d+)/);
-  return `https://sentry.io/api/${matches[2]}/store/?sentry_version=7&sentry_key=${matches[1]}`;
-}


### PR DESCRIPTION
Master is broken, so we should fix this as soon as possible. At least it wasn't working with the DSN I'm using and the ones I found in the project page. On side effect of the breakage is not seeing the DO servers in the manager (because of the failure).

We may want to re-release. This may fix the issue you were seeing on Windows.