### PR TITLE
Initialize Sentry only when SENTRY_DSN is set

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -35,23 +35,24 @@ const IMAGES_BASENAME =
     `${path.join(__dirname.replace('app.asar', 'app.asar.unpacked'), 'server_manager', 'web_app')}`;
 
 const sentryDsn = process.env.SENTRY_DSN;
-
-sentry.init({
-  // Error reporting is a no-op when `sentryDsn` is undefined.
-  dsn: sentryDsn || '',
-  // Sentry provides a sensible default but we would prefer without the leading "outline-manager@".
-  release: electron.app.getVersion(),
-  maxBreadcrumbs: 100,
-  beforeBreadcrumb: (breadcrumb: sentry.Breadcrumb) => {
-    // Don't submit breadcrumbs for console.debug.
-    if (breadcrumb.category === 'console') {
-      if (breadcrumb.level === sentry.Severity.Debug) {
-        return null;
+if (sentryDsn) {
+  sentry.init({
+    dsn: sentryDsn,
+    // Sentry provides a sensible default but we would prefer without the leading
+    // "outline-manager@".
+    release: electron.app.getVersion(),
+    maxBreadcrumbs: 100,
+    beforeBreadcrumb: (breadcrumb: sentry.Breadcrumb) => {
+      // Don't submit breadcrumbs for console.debug.
+      if (breadcrumb.category === 'console') {
+        if (breadcrumb.level === sentry.Severity.Debug) {
+          return null;
+        }
       }
+      return breadcrumb;
     }
-    return breadcrumb;
-  }
-});
+  });
+}
 // To clearly identify app restarts in Sentry.
 console.info(`Outline Manager is starting`);
 


### PR DESCRIPTION
* `@sentry/electron` v1.3.1 throws an error when it is initialized with an empty DSN.
* Fixes this isssue by only initializing sentry when the `SENTRY_DSN` environment variable is set.
* Tested that submitting feedback is still a no-op when `SENTRY_DSN` is unset.