### PR TITLE
Optimize Dockerfile

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -24,8 +24,15 @@ FROM ${NODE_IMAGE} AS build
 RUN apk add --no-cache --upgrade bash
 WORKDIR /
 
-COPY . .
+# Don't copy node_modules and other things not needed for install.
+COPY package.json yarn.lock ./
+COPY src/shadowbox/package.json src/shadowbox/
 RUN yarn install
+
+# We copy the source code only after yarn install, so that source code changes don't trigger re-installs.
+COPY scripts scripts/
+COPY src src/
+COPY tsconfig.json ./
 RUN ROOT_DIR=/ yarn do shadowbox/server/build
 
 # shadowbox image

--- a/src/shadowbox/package.json
+++ b/src/shadowbox/package.json
@@ -17,8 +17,8 @@
     "randomstring": "^1.1.5",
     "request-lite": "^2.40.1",
     "restify": "^8.5.1",
-    "restify-errors": "^8.0.2",
     "restify-cors-middleware": "^1.1.1",
+    "restify-errors": "^8.0.2",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
@@ -26,6 +26,9 @@
     "@types/node": "^8",
     "@types/randomstring": "^1.1.6",
     "@types/restify": "^8.4.2",
-    "@types/restify-cors-middleware": "^1.0.1"
+    "@types/restify-cors-middleware": "^1.0.1",
+    "ts-loader": "^7.0.4",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8568,7 +8568,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-ts-loader@^7.0.1:
+ts-loader@^7.0.1, ts-loader@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-7.0.4.tgz#5d9b95227de5afb91fdd9668f8920eb193cfe0cc"
   integrity sha512-5du6OQHl+4ZjO4crEyoYUyWSrmmo7bAO+inkaILZ68mvahqrfoa4nn0DRmpQ4ruT4l+cuJCgF0xD7SBIyLeeow==


### PR DESCRIPTION
This makes the first build faster by not copying node_modules and not adding the package.json for all workspaces: 50s vs 128s.
(NOTE: it will have to change with cross-workspace dependencies)

It makes subsequent runs *a lot* faster by not re-running yarn install on every code change: 17s vs 128s.