### PR TITLE
Use latest docker version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   # https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Travis-CI-supports-yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
   - export PATH="$HOME/.yarn/bin:$PATH"
-  # Install Docker 19.03.8 for BuildKit support if running on linux. See https://docs.travis-ci.com/user/docker/
+  # Install latest Docker for BuildKit support if running on linux. See https://docs.travis-ci.com/user/docker/
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
       sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
       sudo apt-get update
-      sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce=5:19.03.8~3-0~ubuntu-xenial
+      sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
     fi;
 
 stages:

--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -15,11 +15,10 @@
 # Newer node images have no valid content trust data.
 # Pin the image node:12.16.3-alpine (linux/amd64) by hash.
 # See versions at https://hub.docker.com/_/node?tab=tags&name=alpine
-ARG NODE_IMAGE="node@sha256:12b2154fb459fa5f42c54771524609db041e7ef3465935d0ca82940d2d72669d"
 
 # Multi-stage build: use a build image to prevent bloating the shadowbox image with dependencies.
 # Run `yarn` and build inside the container to package the right dependencies for the image.
-FROM ${NODE_IMAGE} AS build
+FROM node@sha256:12b2154fb459fa5f42c54771524609db041e7ef3465935d0ca82940d2d72669d AS build
 
 RUN apk add --no-cache --upgrade bash
 WORKDIR /
@@ -36,7 +35,7 @@ COPY tsconfig.json ./
 RUN ROOT_DIR=/ yarn do shadowbox/server/build
 
 # shadowbox image
-FROM ${NODE_IMAGE}
+FROM node@sha256:12b2154fb459fa5f42c54771524609db041e7ef3465935d0ca82940d2d72669d
 
 # Versions can be found at https://github.com/Jigsaw-Code/outline-ss-server/releases
 ARG SS_VERSION=1.1.3
@@ -60,10 +59,10 @@ RUN /etc/periodic/weekly/update_mmdb
 WORKDIR /root/shadowbox
 
 # Install shadowbox and third party dependencies.
-COPY --from=build /build/shadowbox/app app
 RUN mkdir bin && curl -SsL https://github.com/Jigsaw-Code/outline-ss-server/releases/download/v${SS_VERSION}/outline-ss-server_${SS_VERSION}_linux_x86_64.tar.gz | tar xz -C bin outline-ss-server
 COPY third_party/prometheus/prometheus ./bin/
 COPY src/shadowbox/package.json .
+COPY --from=build /build/shadowbox/app app
 
 # Create default state directory.
 RUN mkdir -p /root/shadowbox/persisted-state

--- a/src/shadowbox/docker/build_action.sh
+++ b/src/shadowbox/docker/build_action.sh
@@ -16,5 +16,6 @@
 
 export DOCKER_CONTENT_TRUST=${DOCKER_CONTENT_TRUST:-1}
 # Enable Docker BuildKit (https://docs.docker.com/develop/develop-images/build_enhancements)
-export DOCKER_BUILDKIT=1
+# TODO(fortuna): Re-enable after we figure out how to make it work on Travis.
+# export DOCKER_BUILDKIT=1
 docker build --force-rm --build-arg GITHUB_RELEASE="${TRAVIS_TAG:-none}" -t ${SB_IMAGE:-outline/shadowbox} $ROOT_DIR -f src/shadowbox/docker/Dockerfile

--- a/src/shadowbox/docker/build_action.sh
+++ b/src/shadowbox/docker/build_action.sh
@@ -16,6 +16,6 @@
 
 export DOCKER_CONTENT_TRUST=${DOCKER_CONTENT_TRUST:-1}
 # Enable Docker BuildKit (https://docs.docker.com/develop/develop-images/build_enhancements)
-# TODO(fortuna): Re-enable after we figure out how to make it work on Travis.
+# TODO(fortuna): Re-enable after we figure out how to make it work on Travis: https://github.com/moby/buildkit/issues/606
 # export DOCKER_BUILDKIT=1
 docker build --force-rm --build-arg GITHUB_RELEASE="${TRAVIS_TAG:-none}" -t ${SB_IMAGE:-outline/shadowbox} $ROOT_DIR -f src/shadowbox/docker/Dockerfile


### PR DESCRIPTION
If we don't specify the version, we get a more recent one: `5:19.03.9~3-0~ubuntu-xenial`

This is a failed attempt to fix the broken build, which seems to be related to Buildkit:
- https://github.com/moby/buildkit/issues/606
- https://github.com/moby/buildkit/pull/1397