### PR TITLE
Restore Docker CMD for backwards compatibility

### DIFF
--- a/src/shadowbox/docker/Dockerfile
+++ b/src/shadowbox/docker/Dockerfile
@@ -62,8 +62,8 @@ WORKDIR /opt/outline-server
 # The shadowbox build directory has the following structure:
 #   - app/          (bundled node app)
 #   - bin/          (binary dependencies)
-#   - cmd.sh        (docker entry script)
 #   - package.json  (shadowbox package.json)
 COPY --from=build /build/shadowbox/ .
 
-CMD ./cmd.sh
+COPY src/shadowbox/docker/cmd.sh /
+CMD /cmd.sh

--- a/src/shadowbox/server/build_action.sh
+++ b/src/shadowbox/server/build_action.sh
@@ -27,8 +27,5 @@ mkdir -p $BIN_DIR
 cp "$ROOT_DIR/third_party/prometheus/$OS/prometheus" $BIN_DIR/
 cp "$ROOT_DIR/third_party/outline-ss-server/$OS/outline-ss-server" $BIN_DIR/
 
-# Copy docker entry point script
-cp "$ROOT_DIR/src/shadowbox/docker/cmd.sh" $OUT_DIR/
-
 # Copy shadowbox package.json
 cp "$ROOT_DIR/src/shadowbox/package.json" $OUT_DIR/


### PR DESCRIPTION
* Reverts the Docker CMD change in #674.
* watchtower uses the original CMD to restart the image, causing the latest image update to fail.
* Copies `cmd.sh` to the container root directory in order to address this issue.