### PR TITLE
Separate server management from server provisioning

### DIFF
--- a/src/server_manager/web_app/app.spec.ts
+++ b/src/server_manager/web_app/app.spec.ts
@@ -24,6 +24,7 @@ import {TokenManager} from './digitalocean_oauth';
 import {DisplayServer, DisplayServerRepository, makeDisplayServer} from './display_server';
 import {AppRoot} from './ui_components/app-root.js';
 import {ServerView} from './ui_components/outline-server-view.js';
+import {ServerManagementApp} from "./server_management_app";
 
 const TOKEN_WITH_NO_SERVERS = 'no-server-token';
 const TOKEN_WITH_ONE_SERVER = 'one-server-token';
@@ -245,9 +246,9 @@ function createTestApp(
     displayServerRepository = new FakeDisplayServerRepository();
   }
   return new App(
-      polymerAppRoot, VERSION, fakeDigitalOceanSessionFactory,
-      fakeDigitalOceanServerRepositoryFactory, manualServerRepo, displayServerRepository,
-      digitalOceanTokenManager, new FakeSurveys());
+      polymerAppRoot, new ServerManagementApp(polymerAppRoot), VERSION,
+      fakeDigitalOceanSessionFactory, fakeDigitalOceanServerRepositoryFactory, manualServerRepo,
+      displayServerRepository, digitalOceanTokenManager, new FakeSurveys());
 }
 
 enum AppRootScreen {

--- a/src/server_manager/web_app/app.spec.ts
+++ b/src/server_manager/web_app/app.spec.ts
@@ -22,9 +22,9 @@ import {Surveys} from '../model/survey';
 import {App} from './app';
 import {TokenManager} from './digitalocean_oauth';
 import {DisplayServer, DisplayServerRepository, makeDisplayServer} from './display_server';
+import {ServerManagementApp} from './server_management_app';
 import {AppRoot} from './ui_components/app-root.js';
 import {ServerView} from './ui_components/outline-server-view.js';
-import {ServerManagementApp} from "./server_management_app";
 
 const TOKEN_WITH_NO_SERVERS = 'no-server-token';
 const TOKEN_WITH_ONE_SERVER = 'one-server-token';

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -14,7 +14,6 @@
 
 import * as sentry from '@sentry/electron';
 import {EventEmitter} from 'eventemitter3';
-import * as semver from 'semver';
 
 import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as errors from '../infrastructure/errors';
@@ -28,81 +27,12 @@ import {DisplayServer, DisplayServerRepository, makeDisplayServer} from './displ
 import {parseManualServerConfig} from './management_urls';
 
 import {AppRoot} from './ui_components/app-root.js';
-import {DisplayAccessKey, DisplayDataAmount, ServerView} from './ui_components/outline-server-view.js';
+import {DisplayAccessKey, ServerView} from './ui_components/outline-server-view.js';
+import {ServerManagementApp} from "./server_management_app";
 
 // The Outline DigitalOcean team's referral code:
 //   https://www.digitalocean.com/help/referral-program/
 const UNUSED_DIGITALOCEAN_REFERRAL_CODE = '5ddb4219b716';
-
-const CHANGE_KEYS_PORT_VERSION = '1.0.0';
-const DATA_LIMITS_VERSION = '1.1.0';
-const CHANGE_HOSTNAME_VERSION = '1.2.0';
-// Date by which the data limits feature experiment will be permanently added or removed.
-export const DATA_LIMITS_AVAILABILITY_DATE = new Date('2020-06-02');
-const MAX_ACCESS_KEY_DATA_LIMIT_BYTES = 50 * (10 ** 9);  // 50GB
-
-function dataLimitToDisplayDataAmount(limit: server.DataLimit): DisplayDataAmount|null {
-  if (!limit) {
-    return null;
-  }
-  const bytes = limit.bytes;
-  if (bytes >= 10 ** 9) {
-    return {value: Math.floor(bytes / (10 ** 9)), unit: 'GB'};
-  }
-  return {value: Math.floor(bytes / (10 ** 6)), unit: 'MB'};
-}
-
-function displayDataAmountToDataLimit(dataAmount: DisplayDataAmount): server.DataLimit|null {
-  if (!dataAmount) {
-    return null;
-  }
-  if (dataAmount.unit === 'GB') {
-    return {bytes: dataAmount.value * (10 ** 9)};
-  } else if (dataAmount.unit === 'MB') {
-    return {bytes: dataAmount.value * (10 ** 6)};
-  }
-  return {bytes: dataAmount.value};
-}
-
-// Compute the suggested data limit based on the server's transfer capacity and number of access
-// keys.
-async function computeDefaultAccessKeyDataLimit(
-    server: server.Server, accessKeys?: server.AccessKey[]): Promise<server.DataLimit> {
-  try {
-    // Assume non-managed servers have a data transfer capacity of 1TB.
-    let serverTransferCapacity: server.DataAmount = {terabytes: 1};
-    if (isManagedServer(server)) {
-      serverTransferCapacity = server.getHost().getMonthlyOutboundTransferLimit();
-    }
-    if (!accessKeys) {
-      accessKeys = await server.listAccessKeys();
-    }
-    let dataLimitBytes = serverTransferCapacity.terabytes * (10 ** 12) / (accessKeys.length || 1);
-    if (dataLimitBytes > MAX_ACCESS_KEY_DATA_LIMIT_BYTES) {
-      dataLimitBytes = MAX_ACCESS_KEY_DATA_LIMIT_BYTES;
-    }
-    return {bytes: dataLimitBytes};
-  } catch (e) {
-    console.error(`Failed to compute default access key data limit: ${e}`);
-    return {bytes: MAX_ACCESS_KEY_DATA_LIMIT_BYTES};
-  }
-}
-
-async function showHelpBubblesOnce(serverView: ServerView) {
-  if (!window.localStorage.getItem('addAccessKeyHelpBubble-dismissed')) {
-    await serverView.showAddAccessKeyHelpBubble();
-    window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
-  }
-  if (!window.localStorage.getItem('getConnectedHelpBubble-dismissed')) {
-    await serverView.showGetConnectedHelpBubble();
-    window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
-  }
-  if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') &&
-      serverView.supportsAccessKeyDataLimit) {
-    await serverView.showDataLimitsHelpBubble();
-    window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
-  }
-}
 
 function isManagedServer(testServer: server.Server): testServer is server.ManagedServer {
   return !!(testServer as server.ManagedServer).getHost;
@@ -110,10 +40,6 @@ function isManagedServer(testServer: server.Server): testServer is server.Manage
 
 function isManualServer(testServer: server.Server): testServer is server.ManualServer {
   return !!(testServer as server.ManualServer).forget;
-}
-
-function localizeDate(date: Date, language: string): string {
-  return date.toLocaleString(language, {year: 'numeric', month: 'long', day: 'numeric'});
 }
 
 type DigitalOceanSessionFactory = (accessToken: string) => digitalocean_api.DigitalOceanSession;
@@ -126,7 +52,8 @@ export class App {
   private serverBeingCreated: server.ManagedServer;
 
   constructor(
-      private appRoot: AppRoot, private readonly version: string,
+      private appRoot: AppRoot, private serverManagementApp: ServerManagementApp,
+      private readonly version: string,
       private createDigitalOceanSession: DigitalOceanSessionFactory,
       private createDigitalOceanServerRepository: DigitalOceanServerRepositoryFactory,
       private manualServerRepository: server.ManualServerRepository,
@@ -134,51 +61,24 @@ export class App {
       private digitalOceanTokenManager: TokenManager, private surveys: Surveys) {
     appRoot.setAttribute('outline-version', this.version);
 
+    // Managed server (i.e. DigitalOcean) related events
     appRoot.addEventListener('ConnectToDigitalOcean', (event: CustomEvent) => {
       this.connectToDigitalOcean();
     });
     appRoot.addEventListener('SignOutRequested', (event: CustomEvent) => {
       this.clearCredentialsAndShowIntro();
     });
-
     appRoot.addEventListener('SetUpServerRequested', (event: CustomEvent) => {
       this.createDigitalOceanServer(event.detail.regionId);
     });
-
     appRoot.addEventListener('DeleteServerRequested', (event: CustomEvent) => {
       this.deleteSelectedServer();
     });
-
     appRoot.addEventListener('ForgetServerRequested', (event: CustomEvent) => {
       this.forgetSelectedServer();
     });
-
-    appRoot.addEventListener('AddAccessKeyRequested', (event: CustomEvent) => {
-      this.addAccessKey();
-    });
-
-    appRoot.addEventListener('RemoveAccessKeyRequested', (event: CustomEvent) => {
-      this.removeAccessKey(event.detail.accessKeyId);
-    });
-
-    appRoot.addEventListener('RenameAccessKeyRequested', (event: CustomEvent) => {
-      this.renameAccessKey(event.detail.accessKeyId, event.detail.newName, event.detail.entry);
-    });
-
-    appRoot.addEventListener('SetAccessKeyDataLimitRequested', (event: CustomEvent) => {
-      this.setAccessKeyDataLimit(displayDataAmountToDataLimit(event.detail.limit));
-    });
-
-    appRoot.addEventListener('RemoveAccessKeyDataLimitRequested', (event: CustomEvent) => {
-      this.removeAccessKeyDataLimit();
-    });
-
-    appRoot.addEventListener('ChangePortForNewAccessKeysRequested', (event: CustomEvent) => {
-      this.setPortForNewAccessKeys(event.detail.validatedInput, event.detail.ui);
-    });
-
-    appRoot.addEventListener('ChangeHostnameForAccessKeysRequested', (event: CustomEvent) => {
-      this.setHostnameForAccessKeys(event.detail.validatedInput, event.detail.ui);
+    appRoot.addEventListener('CancelServerCreationRequested', (event: CustomEvent) => {
+      this.cancelServerCreation(this.selectedServer);
     });
 
     // The UI wants us to validate a server management URL.
@@ -224,14 +124,6 @@ export class App {
           });
     });
 
-    appRoot.addEventListener('EnableMetricsRequested', (event: CustomEvent) => {
-      this.setMetricsEnabled(true);
-    });
-
-    appRoot.addEventListener('DisableMetricsRequested', (event: CustomEvent) => {
-      this.setMetricsEnabled(false);
-    });
-
     appRoot.addEventListener('SubmitFeedback', (event: CustomEvent) => {
       const detail = event.detail;
       try {
@@ -245,14 +137,6 @@ export class App {
         console.error(`Failed to submit feedback: ${e}`);
         appRoot.showError(appRoot.localize('error-feedback'));
       }
-    });
-
-    appRoot.addEventListener('ServerRenameRequested', (event: CustomEvent) => {
-      this.renameServer(event.detail.newName);
-    });
-
-    appRoot.addEventListener('CancelServerCreationRequested', (event: CustomEvent) => {
-      this.cancelServerCreation(this.selectedServer);
     });
 
     appRoot.addEventListener('OpenImageRequested', (event: CustomEvent) => {
@@ -273,6 +157,64 @@ export class App {
     });
 
     onUpdateDownloaded(this.displayAppUpdateNotification.bind(this));
+
+    /**
+     * ServerManagementApp event listeners
+     */
+    // TODO: Move these event listeners to server_management_app once they no longer
+    //       depend on `selectedServer`.
+    // Server management events
+    appRoot.addEventListener('ServerRenameRequested', (event: CustomEvent) => {
+      serverManagementApp.renameServer(this.selectedServer, event.detail.newName).then(() => {
+        this.syncAndShowServer(this.selectedServer);
+      });
+    });
+    appRoot.addEventListener('ChangePortForNewAccessKeysRequested', (event: CustomEvent) => {
+      serverManagementApp.setPortForNewAccessKeys(
+        this.selectedServer, event.detail.validatedInput, event.detail.ui);
+    });
+    appRoot.addEventListener('ChangeHostnameForAccessKeysRequested', (event: CustomEvent) => {
+      serverManagementApp.setHostnameForAccessKeys(
+        this.selectedServer, event.detail.validatedInput, event.detail.ui);
+    });
+
+    // Access key events
+    appRoot.addEventListener('AddAccessKeyRequested', (event: CustomEvent) => {
+      serverManagementApp.addAccessKey(this.selectedServer);
+    });
+    appRoot.addEventListener('RemoveAccessKeyRequested', (event: CustomEvent) => {
+      serverManagementApp.removeAccessKey(this.selectedServer, event.detail.accessKeyId);
+    });
+    appRoot.addEventListener('RenameAccessKeyRequested', (event: CustomEvent) => {
+      serverManagementApp.renameAccessKey(
+        this.selectedServer, event.detail.accessKeyId, event.detail.newName, event.detail.entry);
+    });
+
+    // Metric events
+    appRoot.addEventListener('EnableMetricsRequested', (event: CustomEvent) => {
+      serverManagementApp.setMetricsEnabled(this.selectedServer, true);
+    });
+    appRoot.addEventListener('DisableMetricsRequested', (event: CustomEvent) => {
+      serverManagementApp.setMetricsEnabled(this.selectedServer, false);
+    });
+
+    // Data limits feature events
+    appRoot.addEventListener('SetAccessKeyDataLimitRequested', (event: CustomEvent) => {
+      serverManagementApp
+        .setAccessKeyDataLimit(
+          this.selectedServer,
+          ServerManagementApp.displayDataAmountToDataLimit(event.detail.limit))
+        .then((result) => {
+          if (result) {
+            this.surveys.presentDataLimitsEnabledSurvey();
+          }
+        });
+    });
+    appRoot.addEventListener('RemoveAccessKeyDataLimitRequested', (event: CustomEvent) => {
+      serverManagementApp.removeAccessKeyDataLimit(this.selectedServer).then(() => {
+        this.surveys.presentDataLimitsDisabledSurvey();
+      });
+    });
   }
 
   async start(): Promise<void> {
@@ -550,7 +492,8 @@ export class App {
       if (isHealthy) {
         // Sync the server display in case it was previously unreachable.
         this.syncServerToDisplay(server).then(() => {
-          this.showServer(server, displayServer);
+          this.displayServerRepository.storeLastDisplayedServerId(displayServer.id);
+          this.serverManagementApp.showServer(server, displayServer);
         });
       } else {
         // Display the unreachable server state within the server view.
@@ -815,155 +758,8 @@ export class App {
   private async syncAndShowServer(server: server.Server, timeoutMs = 250) {
     const displayServer = await this.syncServerToDisplay(server);
     await this.syncDisplayServersToUi();
-    this.showServer(server, displayServer);
-  }
-
-  // Show the server management screen. Assumes the server is healthy.
-  private async showServer(selectedServer: server.Server, selectedDisplayServer: DisplayServer) {
-    this.selectedServer = selectedServer;
-    this.appRoot.selectedServer = selectedDisplayServer;
-    this.displayServerRepository.storeLastDisplayedServerId(selectedDisplayServer.id);
-
-    // Show view and initialize fields from selectedServer.
-    const view = this.appRoot.getServerView(selectedDisplayServer.id);
-    view.isServerReachable = true;
-    view.serverId = selectedServer.getServerId();
-    view.serverName = selectedServer.getName();
-    view.serverHostname = selectedServer.getHostnameForAccessKeys();
-    view.serverManagementApiUrl = selectedServer.getManagementApiUrl();
-    view.serverPortForNewAccessKeys = selectedServer.getPortForNewAccessKeys();
-    view.serverCreationDate = localizeDate(selectedServer.getCreatedDate(), this.appRoot.language);
-    view.serverVersion = selectedServer.getVersion();
-    view.dataLimitsAvailabilityDate =
-        localizeDate(DATA_LIMITS_AVAILABILITY_DATE, this.appRoot.language);
-    view.accessKeyDataLimit = dataLimitToDisplayDataAmount(selectedServer.getAccessKeyDataLimit());
-    view.isAccessKeyDataLimitEnabled = !!view.accessKeyDataLimit;
-
-    const version = this.selectedServer.getVersion();
-    if (version) {
-      view.isAccessKeyPortEditable = semver.gte(version, CHANGE_KEYS_PORT_VERSION);
-      view.supportsAccessKeyDataLimit = semver.gte(version, DATA_LIMITS_VERSION);
-      view.isHostnameEditable = semver.gte(version, CHANGE_HOSTNAME_VERSION);
-    }
-
-    if (isManagedServer(selectedServer)) {
-      view.isServerManaged = true;
-      const host = selectedServer.getHost();
-      view.monthlyCost = host.getMonthlyCost().usd;
-      view.monthlyOutboundTransferBytes =
-          host.getMonthlyOutboundTransferLimit().terabytes * (10 ** 12);
-      view.serverLocation = this.getLocalizedCityName(host.getRegionId());
-    } else {
-      view.isServerManaged = false;
-    }
-
-    view.metricsEnabled = selectedServer.getMetricsEnabled();
-    this.appRoot.showServerView();
-    this.showMetricsOptInWhenNeeded(selectedServer, view);
-
-    // Load "My Connection" and other access keys.
-    try {
-      const serverAccessKeys = await selectedServer.listAccessKeys();
-      view.accessKeyRows = serverAccessKeys.map(this.convertToUiAccessKey.bind(this));
-      if (!view.accessKeyDataLimit) {
-        view.accessKeyDataLimit = dataLimitToDisplayDataAmount(
-            await computeDefaultAccessKeyDataLimit(selectedServer, serverAccessKeys));
-      }
-      // Show help bubbles once the page has rendered.
-      setTimeout(() => {
-        showHelpBubblesOnce(view);
-      }, 250);
-    } catch (error) {
-      console.error(`Failed to load access keys: ${error}`);
-      this.appRoot.showError(this.appRoot.localize('error-keys-get'));
-    }
-
-    this.showTransferStats(selectedServer, view);
-  }
-
-  private showMetricsOptInWhenNeeded(selectedServer: server.Server, serverView: ServerView) {
-    const showMetricsOptInOnce = () => {
-      // Sanity check to make sure the running server is still displayed, i.e.
-      // it hasn't been deleted.
-      if (this.selectedServer !== selectedServer) {
-        return;
-      }
-      // Show the metrics opt in prompt if the server has not already opted in,
-      // and if they haven't seen the prompt yet according to localStorage.
-      const storageKey = selectedServer.getServerId() + '-prompted-for-metrics';
-      if (!selectedServer.getMetricsEnabled() && !localStorage.getItem(storageKey)) {
-        this.appRoot.showMetricsDialogForNewServer();
-        localStorage.setItem(storageKey, 'true');
-      }
-    };
-
-    // Calculate milliseconds passed since server creation.
-    const createdDate = selectedServer.getCreatedDate();
-    const now = new Date();
-    const msSinceCreation = now.getTime() - createdDate.getTime();
-
-    // Show metrics opt-in once ONE_DAY_IN_MS has passed since server creation.
-    const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
-    if (msSinceCreation >= ONE_DAY_IN_MS) {
-      showMetricsOptInOnce();
-    } else {
-      setTimeout(showMetricsOptInOnce, ONE_DAY_IN_MS - msSinceCreation);
-    }
-  }
-
-  private async refreshTransferStats(selectedServer: server.Server, serverView: ServerView) {
-    try {
-      const stats = await selectedServer.getDataUsage();
-      let totalBytes = 0;
-      // tslint:disable-next-line:forin
-      for (const accessKeyId in stats.bytesTransferredByUserId) {
-        totalBytes += stats.bytesTransferredByUserId[accessKeyId];
-      }
-      serverView.setServerTransferredData(totalBytes);
-
-      const accessKeyDataLimit = selectedServer.getAccessKeyDataLimit();
-      if (accessKeyDataLimit) {
-        // Make access key data usage relative to the data limit.
-        totalBytes = accessKeyDataLimit.bytes;
-      }
-
-      // Update all the displayed access keys, even if usage didn't change, in case the data limit
-      // did.
-      for (const accessKey of serverView.accessKeyRows) {
-        const accessKeyId = accessKey.id;
-        const transferredBytes = stats.bytesTransferredByUserId[accessKeyId] || 0;
-        let relativeTraffic =
-            totalBytes ? 100 * transferredBytes / totalBytes : (accessKeyDataLimit ? 100 : 0);
-        if (relativeTraffic > 100) {
-          // Can happen when a data limit is set on an access key that already exceeds it.
-          relativeTraffic = 100;
-        }
-        serverView.updateAccessKeyRow(accessKeyId, {transferredBytes, relativeTraffic});
-      }
-    } catch (e) {
-      // Since failures are invisible to users we generally want exceptions here to bubble
-      // up and trigger a Sentry report. The exception is network errors, about which we can't
-      // do much (note: ShadowboxServer generates a breadcrumb for failures regardless which
-      // will show up when someone explicitly submits feedback).
-      if (e instanceof errors.ServerApiError && e.isNetworkError()) {
-        return;
-      }
-      throw e;
-    }
-  }
-
-  private showTransferStats(selectedServer: server.Server, serverView: ServerView) {
-    this.refreshTransferStats(selectedServer, serverView);
-    // Get transfer stats once per minute for as long as server is selected.
-    const statsRefreshRateMs = 60 * 1000;
-    const intervalId = setInterval(() => {
-      if (this.selectedServer !== selectedServer) {
-        // Server is no longer running, stop interval
-        clearInterval(intervalId);
-        return;
-      }
-      this.refreshTransferStats(selectedServer, serverView);
-    }, statsRefreshRateMs);
+    this.displayServerRepository.storeLastDisplayedServerId(displayServer.id);
+    await this.serverManagementApp.showServer(server, displayServer);
   }
 
   private getS3InviteUrl(accessUrl: string, isAdmin = false) {
@@ -984,107 +780,6 @@ export class App {
       transferredBytes: 0,
       relativeTraffic: 0
     };
-  }
-
-  private addAccessKey() {
-    this.selectedServer.addAccessKey()
-        .then((serverAccessKey: server.AccessKey) => {
-          const uiAccessKey = this.convertToUiAccessKey(serverAccessKey);
-          this.appRoot.getServerView(this.appRoot.selectedServer.id).addAccessKey(uiAccessKey);
-          this.appRoot.showNotification(this.appRoot.localize('notification-key-added'));
-        })
-        .catch((error) => {
-          console.error(`Failed to add access key: ${error}`);
-          this.appRoot.showError(this.appRoot.localize('error-key-add'));
-        });
-  }
-
-  private renameAccessKey(accessKeyId: string, newName: string, entry: polymer.Base) {
-    this.selectedServer.renameAccessKey(accessKeyId, newName)
-        .then(() => {
-          entry.commitName();
-        })
-        .catch((error) => {
-          console.error(`Failed to rename access key: ${error}`);
-          this.appRoot.showError(this.appRoot.localize('error-key-rename'));
-          entry.revertName();
-        });
-  }
-
-  private async setAccessKeyDataLimit(limit: server.DataLimit) {
-    if (!limit) {
-      return;
-    }
-    const previousLimit = this.selectedServer.getAccessKeyDataLimit();
-    if (previousLimit && limit.bytes === previousLimit.bytes) {
-      return;
-    }
-    const serverView = this.appRoot.getServerView(this.appRoot.selectedServer.id);
-    try {
-      await this.selectedServer.setAccessKeyDataLimit(limit);
-      this.appRoot.showNotification(this.appRoot.localize('saved'));
-      serverView.accessKeyDataLimit = dataLimitToDisplayDataAmount(limit);
-      this.refreshTransferStats(this.selectedServer, serverView);
-      this.surveys.presentDataLimitsEnabledSurvey();
-    } catch (error) {
-      console.error(`Failed to set access key data limit: ${error}`);
-      this.appRoot.showError(this.appRoot.localize('error-set-data-limit'));
-      serverView.accessKeyDataLimit = dataLimitToDisplayDataAmount(
-          previousLimit || await computeDefaultAccessKeyDataLimit(this.selectedServer));
-      serverView.isAccessKeyDataLimitEnabled = !!previousLimit;
-    }
-  }
-
-  private async removeAccessKeyDataLimit() {
-    const serverView = this.appRoot.getServerView(this.appRoot.selectedServer.id);
-    try {
-      await this.selectedServer.removeAccessKeyDataLimit();
-      this.appRoot.showNotification(this.appRoot.localize('saved'));
-      this.refreshTransferStats(this.selectedServer, serverView);
-      this.surveys.presentDataLimitsDisabledSurvey();
-    } catch (error) {
-      console.error(`Failed to remove access key data limit: ${error}`);
-      this.appRoot.showError(this.appRoot.localize('error-remove-data-limit'));
-      serverView.isAccessKeyDataLimitEnabled = true;
-    }
-  }
-
-  private async setHostnameForAccessKeys(hostname: string, serverSettings: polymer.Base) {
-    this.appRoot.showNotification(this.appRoot.localize('saving'));
-    try {
-      await this.selectedServer.setHostnameForAccessKeys(hostname);
-      this.appRoot.showNotification(this.appRoot.localize('saved'));
-      serverSettings.enterSavedState();
-    } catch (error) {
-      this.appRoot.showError(this.appRoot.localize('error-not-saved'));
-      if (error.isNetworkError()) {
-        serverSettings.enterErrorState(this.appRoot.localize('error-network'));
-        return;
-      }
-      const message = error.response.status === 400 ? 'error-hostname-invalid' : 'error-unexpected';
-      serverSettings.enterErrorState(this.appRoot.localize(message));
-    }
-  }
-
-  private async setPortForNewAccessKeys(port: number, serverSettings: polymer.Base) {
-    this.appRoot.showNotification(this.appRoot.localize('saving'));
-    try {
-      await this.selectedServer.setPortForNewAccessKeys(port);
-      this.appRoot.showNotification(this.appRoot.localize('saved'));
-      serverSettings.enterSavedState();
-    } catch (error) {
-      this.appRoot.showError(this.appRoot.localize('error-not-saved'));
-      if (error.isNetworkError()) {
-        serverSettings.enterErrorState(this.appRoot.localize('error-network'));
-        return;
-      }
-      const code = error.response.status;
-      if (code === 409) {
-        serverSettings.enterErrorState(this.appRoot.localize('error-keys-port-in-use'));
-        return;
-      }
-      serverSettings.enterErrorState(this.appRoot.localize('error-unexpected'));
-    }
   }
 
   // Returns promise which fulfills when the server is created successfully,
@@ -1121,18 +816,6 @@ export class App {
         }
       });
     });
-  }
-
-  private removeAccessKey(accessKeyId: string) {
-    this.selectedServer.removeAccessKey(accessKeyId)
-        .then(() => {
-          this.appRoot.getServerView(this.appRoot.selectedServer.id).removeAccessKey(accessKeyId);
-          this.appRoot.showNotification(this.appRoot.localize('notification-key-removed'));
-        })
-        .catch((error) => {
-          console.error(`Failed to remove access key: ${error}`);
-          this.appRoot.showError(this.appRoot.localize('error-key-remove'));
-        });
   }
 
   private deleteSelectedServer() {
@@ -1188,34 +871,6 @@ export class App {
       this.showIntro();
       this.appRoot.showNotification(this.appRoot.localize('notification-server-removed'));
     });
-  }
-
-  private async setMetricsEnabled(metricsEnabled: boolean) {
-    try {
-      await this.selectedServer.setMetricsEnabled(metricsEnabled);
-      this.appRoot.showNotification(this.appRoot.localize('saved'));
-      // Change metricsEnabled property on polymer element to update display.
-      this.appRoot.getServerView(this.appRoot.selectedServer.id).metricsEnabled = metricsEnabled;
-    } catch (error) {
-      console.error(`Failed to set metrics enabled: ${error}`);
-      this.appRoot.showError(this.appRoot.localize('error-metrics'));
-    }
-  }
-
-  private async renameServer(newName: string) {
-    const view = this.appRoot.getServerView(this.appRoot.selectedServer.id);
-    try {
-      await this.selectedServer.setName(newName);
-      view.serverName = newName;
-      this.syncAndShowServer(this.selectedServer);
-    } catch (error) {
-      console.error(`Failed to rename server: ${error}`);
-      this.appRoot.showError(this.appRoot.localize('error-server-rename'));
-      const oldName = this.selectedServer.getName();
-      view.serverName = oldName;
-      // tslint:disable-next-line:no-any
-      (view.$.serverSettings as any).serverName = oldName;
-    }
   }
 
   private cancelServerCreation(serverToCancel: server.Server): void {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -209,14 +209,13 @@ export class App {
     appRoot.addEventListener('SetAccessKeyDataLimitRequested', (event: CustomEvent) => {
       this.getServerFromRepository(event.detail.displayServer).then((server) => {
         serverManagementApp
-          .setAccessKeyDataLimit(
-            server,
-            ServerManagementApp.displayDataAmountToDataLimit(event.detail.limit))
-          .then((result) => {
-            if (result) {
-              this.surveys.presentDataLimitsEnabledSurvey();
-            }
-          });
+            .setAccessKeyDataLimit(
+                server, ServerManagementApp.displayDataAmountToDataLimit(event.detail.limit))
+            .then((result) => {
+              if (result) {
+                this.surveys.presentDataLimitsEnabledSurvey();
+              }
+            });
       });
     });
     appRoot.addEventListener('RemoveAccessKeyDataLimitRequested', (event: CustomEvent) => {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -768,19 +768,6 @@ export class App {
         encodeURIComponent(accessUrl)}`;
   }
 
-  // Converts the access key from the remote service format to the
-  // format used by outline-server-view.
-  private convertToUiAccessKey(remoteAccessKey: server.AccessKey): DisplayAccessKey {
-    return {
-      id: remoteAccessKey.id,
-      placeholderName: `${this.appRoot.localize('key', 'keyId', remoteAccessKey.id)}`,
-      name: remoteAccessKey.name,
-      accessUrl: remoteAccessKey.accessUrl,
-      transferredBytes: 0,
-      relativeTraffic: 0
-    };
-  }
-
   // Returns promise which fulfills when the server is created successfully,
   // or rejects with an error message that can be displayed to the user.
   public createManualServer(userInput: string): Promise<void> {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -25,10 +25,9 @@ import {TokenManager} from './digitalocean_oauth';
 import * as digitalocean_server from './digitalocean_server';
 import {DisplayServer, DisplayServerRepository, makeDisplayServer} from './display_server';
 import {parseManualServerConfig} from './management_urls';
-
+import {ServerManagementApp} from './server_management_app';
 import {AppRoot} from './ui_components/app-root.js';
 import {DisplayAccessKey, ServerView} from './ui_components/outline-server-view.js';
-import {ServerManagementApp} from "./server_management_app";
 
 // The Outline DigitalOcean team's referral code:
 //   https://www.digitalocean.com/help/referral-program/

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -23,9 +23,9 @@ import {DigitalOceanTokenManager} from './digitalocean_oauth';
 import * as digitalocean_server from './digitalocean_server';
 import {DisplayServerRepository} from './display_server';
 import {ManualServerRepository} from './manual_server';
+import {DATA_LIMITS_AVAILABILITY_DATE, ServerManagementApp} from './server_management_app';
 import {DEFAULT_PROMPT_IMPRESSION_DELAY_MS, OutlineSurveys} from './survey';
 import {AppRoot} from './ui_components/app-root.js';
-import {DATA_LIMITS_AVAILABILITY_DATE, ServerManagementApp} from "./server_management_app";
 
 const SUPPORTED_LANGUAGES: {[key: string]: {id: string, dir: string}} = {
   'am': {id: 'am', dir: 'ltr'},

--- a/src/server_manager/web_app/main.ts
+++ b/src/server_manager/web_app/main.ts
@@ -18,13 +18,14 @@ import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as i18n from '../infrastructure/i18n';
 import {getSentryApiUrl} from '../infrastructure/sentry';
 
-import {App, DATA_LIMITS_AVAILABILITY_DATE} from './app';
+import {App} from './app';
 import {DigitalOceanTokenManager} from './digitalocean_oauth';
 import * as digitalocean_server from './digitalocean_server';
 import {DisplayServerRepository} from './display_server';
 import {ManualServerRepository} from './manual_server';
 import {DEFAULT_PROMPT_IMPRESSION_DELAY_MS, OutlineSurveys} from './survey';
 import {AppRoot} from './ui_components/app-root.js';
+import {DATA_LIMITS_AVAILABILITY_DATE, ServerManagementApp} from "./server_management_app";
 
 const SUPPORTED_LANGUAGES: {[key: string]: {id: string, dir: string}} = {
   'am': {id: 'am', dir: 'ltr'},
@@ -78,7 +79,7 @@ function getLanguageToUse(): i18n.LanguageCode {
   const defaultLanguage = new i18n.LanguageCode('en');
   const userLanguages = i18n.getBrowserLanguages();
   return new i18n.LanguageMatcher(supportedLanguages, defaultLanguage)
-      .getBestSupportedLanguage(userLanguages);
+    .getBestSupportedLanguage(userLanguages);
 }
 
 document.addEventListener('WebComponentsReady', () => {
@@ -93,7 +94,7 @@ document.addEventListener('WebComponentsReady', () => {
   // Set DigitalOcean server repository parameters.
   const digitalOceanServerRepositoryFactory = (session: digitalocean_api.DigitalOceanSession) => {
     return new digitalocean_server.DigitaloceanServerRepository(
-        session, shadowboxImage, metricsUrl, getSentryApiUrl(sentryDsn), debugMode);
+      session, shadowboxImage, metricsUrl, getSentryApiUrl(sentryDsn), debugMode);
   };
 
   // Create and start the app.
@@ -105,12 +106,13 @@ document.addEventListener('WebComponentsReady', () => {
   const appRoot = document.getElementById('appRoot') as unknown as AppRoot;
   appRoot.setLanguage(language.string(), languageDirection);
   new App(
-      appRoot, version, digitalocean_api.createDigitalOceanSession,
-      digitalOceanServerRepositoryFactory, new ManualServerRepository('manualServers'),
-      new DisplayServerRepository(), new DigitalOceanTokenManager(),
-      new OutlineSurveys(
-          appRoot.$.surveyDialog, localStorage, DEFAULT_PROMPT_IMPRESSION_DELAY_MS,
-          DATA_LIMITS_AVAILABILITY_DATE))
-      .start();
+    appRoot, new ServerManagementApp(appRoot), version,
+    digitalocean_api.createDigitalOceanSession, digitalOceanServerRepositoryFactory,
+    new ManualServerRepository('manualServers'), new DisplayServerRepository(),
+    new DigitalOceanTokenManager(),
+    new OutlineSurveys(
+      appRoot.$.surveyDialog, localStorage, DEFAULT_PROMPT_IMPRESSION_DELAY_MS,
+      DATA_LIMITS_AVAILABILITY_DATE))
+    .start();
 });
 

--- a/src/server_manager/web_app/server_management_app.ts
+++ b/src/server_manager/web_app/server_management_app.ts
@@ -47,12 +47,12 @@ export class ServerManagementApp {
     view.serverManagementApiUrl = server.getManagementApiUrl();
     view.serverPortForNewAccessKeys = server.getPortForNewAccessKeys();
     view.serverCreationDate =
-      ServerManagementApp.localizeDate(server.getCreatedDate(), this.appRoot.language);
+        ServerManagementApp.localizeDate(server.getCreatedDate(), this.appRoot.language);
     view.serverVersion = server.getVersion();
     view.dataLimitsAvailabilityDate =
-      ServerManagementApp.localizeDate(DATA_LIMITS_AVAILABILITY_DATE, this.appRoot.language);
+        ServerManagementApp.localizeDate(DATA_LIMITS_AVAILABILITY_DATE, this.appRoot.language);
     view.accessKeyDataLimit =
-      ServerManagementApp.dataLimitToDisplayDataAmount(server.getAccessKeyDataLimit());
+        ServerManagementApp.dataLimitToDisplayDataAmount(server.getAccessKeyDataLimit());
     view.isAccessKeyDataLimitEnabled = !!view.accessKeyDataLimit;
 
     const version = server.getVersion();
@@ -67,7 +67,7 @@ export class ServerManagementApp {
       const host = server.getHost();
       view.monthlyCost = host.getMonthlyCost().usd;
       view.monthlyOutboundTransferBytes =
-        host.getMonthlyOutboundTransferLimit().terabytes * (10 ** 12);
+          host.getMonthlyOutboundTransferLimit().terabytes * (10 ** 12);
       view.serverLocation = this.getLocalizedCityName(host.getRegionId());
     } else {
       view.isServerManaged = false;
@@ -83,7 +83,7 @@ export class ServerManagementApp {
       view.accessKeyRows = serverAccessKeys.map(this.convertToUiAccessKey.bind(this));
       if (!view.accessKeyDataLimit) {
         view.accessKeyDataLimit = ServerManagementApp.dataLimitToDisplayDataAmount(
-          await ServerManagementApp.computeDefaultAccessKeyDataLimit(server, serverAccessKeys));
+            await ServerManagementApp.computeDefaultAccessKeyDataLimit(server, serverAccessKeys));
       }
       // Show help bubbles once the page has rendered.
       setTimeout(() => {
@@ -178,7 +178,7 @@ export class ServerManagementApp {
         const accessKeyId = accessKey.id;
         const transferredBytes = stats.bytesTransferredByUserId[accessKeyId] || 0;
         let relativeTraffic =
-          totalBytes ? 100 * transferredBytes / totalBytes : (accessKeyDataLimit ? 100 : 0);
+            totalBytes ? 100 * transferredBytes / totalBytes : (accessKeyDataLimit ? 100 : 0);
         if (relativeTraffic > 100) {
           // Can happen when a data limit is set on an access key that already exceeds it.
           relativeTraffic = 100;
@@ -239,7 +239,7 @@ export class ServerManagementApp {
   }
 
   public renameAccessKey(
-    server: Server, accessKeyId: string, newName: string, entry: polymer.Base) {
+      server: Server, accessKeyId: string, newName: string, entry: polymer.Base) {
     server.renameAccessKey(accessKeyId, newName)
       .then(() => {
         entry.commitName();
@@ -282,7 +282,7 @@ export class ServerManagementApp {
       console.error(`Failed to set access key data limit: ${error}`);
       this.appRoot.showError(this.appRoot.localize('error-set-data-limit'));
       serverView.accessKeyDataLimit = ServerManagementApp.dataLimitToDisplayDataAmount(
-        previousLimit || await ServerManagementApp.computeDefaultAccessKeyDataLimit(server));
+          previousLimit || await ServerManagementApp.computeDefaultAccessKeyDataLimit(server));
       serverView.isAccessKeyDataLimitEnabled = !!previousLimit;
     }
   }
@@ -301,7 +301,7 @@ export class ServerManagementApp {
   }
 
   public async setHostnameForAccessKeys(
-    server: Server, hostname: string, serverSettings: polymer.Base) {
+      server: Server, hostname: string, serverSettings: polymer.Base) {
     this.appRoot.showNotification(this.appRoot.localize('saving'));
     try {
       await server.setHostnameForAccessKeys(hostname);
@@ -353,7 +353,7 @@ export class ServerManagementApp {
       window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
     }
     if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') &&
-      serverView.supportsAccessKeyDataLimit) {
+        serverView.supportsAccessKeyDataLimit) {
       await serverView.showDataLimitsHelpBubble();
       window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
     }
@@ -373,7 +373,7 @@ export class ServerManagementApp {
   // Compute the suggested data limit based on the server's transfer capacity and number of access
   // keys.
   private static async computeDefaultAccessKeyDataLimit(
-    server: server.Server, accessKeys?: server.AccessKey[]): Promise<server.DataLimit> {
+      server: server.Server, accessKeys?: server.AccessKey[]): Promise<server.DataLimit> {
     try {
       // Assume non-managed servers have a data transfer capacity of 1TB.
       let serverTransferCapacity: server.DataAmount = {terabytes: 1};

--- a/src/server_manager/web_app/server_management_app.ts
+++ b/src/server_manager/web_app/server_management_app.ts
@@ -1,0 +1,419 @@
+// Copyright 2018 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as semver from 'semver';
+
+import * as errors from '../infrastructure/errors';
+import * as server from '../model/server';
+import {Server} from '../model/server';
+import * as digitalocean_server from './digitalocean_server';
+
+import {DisplayServer} from './display_server';
+import {AppRoot} from './ui_components/app-root';
+import {DisplayAccessKey, DisplayDataAmount, ServerView} from './ui_components/outline-server-view';
+
+const CHANGE_KEYS_PORT_VERSION = '1.0.0';
+const DATA_LIMITS_VERSION = '1.1.0';
+const CHANGE_HOSTNAME_VERSION = '1.2.0';
+
+// Date by which the data limits feature experiment will be permanently added or removed.
+export const DATA_LIMITS_AVAILABILITY_DATE = new Date('2020-06-02');
+const MAX_ACCESS_KEY_DATA_LIMIT_BYTES = 50 * (10 ** 9);  // 50GB
+
+export class ServerManagementApp {
+  constructor(private appRoot: AppRoot) {}
+
+  // Show the server management screen. Assumes the server is healthy.
+  public async showServer(server: server.Server, selectedDisplayServer: DisplayServer) {
+    this.appRoot.selectedServer = selectedDisplayServer;
+
+    // Show view and initialize fields from selectedServer.
+    const view = this.appRoot.getServerView(selectedDisplayServer.id);
+    view.isServerReachable = true;
+    view.serverId = server.getServerId();
+    view.serverName = server.getName();
+    view.serverHostname = server.getHostnameForAccessKeys();
+    view.serverManagementApiUrl = server.getManagementApiUrl();
+    view.serverPortForNewAccessKeys = server.getPortForNewAccessKeys();
+    view.serverCreationDate =
+      ServerManagementApp.localizeDate(server.getCreatedDate(), this.appRoot.language);
+    view.serverVersion = server.getVersion();
+    view.dataLimitsAvailabilityDate =
+      ServerManagementApp.localizeDate(DATA_LIMITS_AVAILABILITY_DATE, this.appRoot.language);
+    view.accessKeyDataLimit =
+      ServerManagementApp.dataLimitToDisplayDataAmount(server.getAccessKeyDataLimit());
+    view.isAccessKeyDataLimitEnabled = !!view.accessKeyDataLimit;
+
+    const version = server.getVersion();
+    if (version) {
+      view.isAccessKeyPortEditable = semver.gte(version, CHANGE_KEYS_PORT_VERSION);
+      view.supportsAccessKeyDataLimit = semver.gte(version, DATA_LIMITS_VERSION);
+      view.isHostnameEditable = semver.gte(version, CHANGE_HOSTNAME_VERSION);
+    }
+
+    if (ServerManagementApp.isManagedServer(server)) {
+      view.isServerManaged = true;
+      const host = server.getHost();
+      view.monthlyCost = host.getMonthlyCost().usd;
+      view.monthlyOutboundTransferBytes =
+        host.getMonthlyOutboundTransferLimit().terabytes * (10 ** 12);
+      view.serverLocation = this.getLocalizedCityName(host.getRegionId());
+    } else {
+      view.isServerManaged = false;
+    }
+
+    view.metricsEnabled = server.getMetricsEnabled();
+    this.appRoot.showServerView();
+    this.showMetricsOptInWhenNeeded(server, view);
+
+    // Load "My Connection" and other access keys.
+    try {
+      const serverAccessKeys = await server.listAccessKeys();
+      view.accessKeyRows = serverAccessKeys.map(this.convertToUiAccessKey.bind(this));
+      if (!view.accessKeyDataLimit) {
+        view.accessKeyDataLimit = ServerManagementApp.dataLimitToDisplayDataAmount(
+          await ServerManagementApp.computeDefaultAccessKeyDataLimit(server, serverAccessKeys));
+      }
+      // Show help bubbles once the page has rendered.
+      setTimeout(() => {
+        ServerManagementApp.showHelpBubblesOnce(view);
+      }, 250);
+    } catch (error) {
+      console.error(`Failed to load access keys: ${error}`);
+      this.appRoot.showError(this.appRoot.localize('error-keys-get'));
+    }
+
+    this.showTransferStats(server, view);
+  }
+
+  public async renameServer(server: Server, newName: string) {
+    const view = this.appRoot.getServerView(this.appRoot.selectedServer.id);
+    try {
+      await server.setName(newName);
+      view.serverName = newName;
+    } catch (error) {
+      console.error(`Failed to rename server: ${error}`);
+      this.appRoot.showError(this.appRoot.localize('error-server-rename'));
+      const oldName = server.getName();
+      view.serverName = oldName;
+      // tslint:disable-next-line:no-any
+      (view.$.serverSettings as any).serverName = oldName;
+    }
+  }
+
+  public async setMetricsEnabled(server: Server, metricsEnabled: boolean) {
+    try {
+      await server.setMetricsEnabled(metricsEnabled);
+      this.appRoot.showNotification(this.appRoot.localize('saved'));
+      // Change metricsEnabled property on polymer element to update display.
+      this.appRoot.getServerView(this.appRoot.selectedServer.id).metricsEnabled = metricsEnabled;
+    } catch (error) {
+      console.error(`Failed to set metrics enabled: ${error}`);
+      this.appRoot.showError(this.appRoot.localize('error-metrics'));
+    }
+  }
+
+  private showMetricsOptInWhenNeeded(server: server.Server, serverView: ServerView) {
+    const showMetricsOptInOnce = () => {
+      // FIXME: Add sanity check back in
+      // // Sanity check to make sure the running server is still displayed, i.e.
+      // // it hasn't been deleted.
+      // if (this.selectedServer !== server) {
+      //   return;
+      // }
+
+      // Show the metrics opt in prompt if the server has not already opted in,
+      // and if they haven't seen the prompt yet according to localStorage.
+      const storageKey = server.getServerId() + '-prompted-for-metrics';
+      if (!server.getMetricsEnabled() && !localStorage.getItem(storageKey)) {
+        this.appRoot.showMetricsDialogForNewServer();
+        localStorage.setItem(storageKey, 'true');
+      }
+    };
+
+    // Calculate milliseconds passed since server creation.
+    const createdDate = server.getCreatedDate();
+    const now = new Date();
+    const msSinceCreation = now.getTime() - createdDate.getTime();
+
+    // Show metrics opt-in once ONE_DAY_IN_MS has passed since server creation.
+    const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+    if (msSinceCreation >= ONE_DAY_IN_MS) {
+      showMetricsOptInOnce();
+    } else {
+      setTimeout(showMetricsOptInOnce, ONE_DAY_IN_MS - msSinceCreation);
+    }
+  }
+
+  private async refreshTransferStats(server: server.Server, serverView: ServerView) {
+    try {
+      const stats = await server.getDataUsage();
+      let totalBytes = 0;
+      // tslint:disable-next-line:forin
+      for (const accessKeyId in stats.bytesTransferredByUserId) {
+        totalBytes += stats.bytesTransferredByUserId[accessKeyId];
+      }
+      serverView.setServerTransferredData(totalBytes);
+
+      const accessKeyDataLimit = server.getAccessKeyDataLimit();
+      if (accessKeyDataLimit) {
+        // Make access key data usage relative to the data limit.
+        totalBytes = accessKeyDataLimit.bytes;
+      }
+
+      // Update all the displayed access keys, even if usage didn't change, in case the data limit
+      // did.
+      for (const accessKey of serverView.accessKeyRows) {
+        const accessKeyId = accessKey.id;
+        const transferredBytes = stats.bytesTransferredByUserId[accessKeyId] || 0;
+        let relativeTraffic =
+          totalBytes ? 100 * transferredBytes / totalBytes : (accessKeyDataLimit ? 100 : 0);
+        if (relativeTraffic > 100) {
+          // Can happen when a data limit is set on an access key that already exceeds it.
+          relativeTraffic = 100;
+        }
+        serverView.updateAccessKeyRow(accessKeyId, {transferredBytes, relativeTraffic});
+      }
+    } catch (e) {
+      // Since failures are invisible to users we generally want exceptions here to bubble
+      // up and trigger a Sentry report. The exception is network errors, about which we can't
+      // do much (note: ShadowboxServer generates a breadcrumb for failures regardless which
+      // will show up when someone explicitly submits feedback).
+      if (e instanceof errors.ServerApiError && e.isNetworkError()) {
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private showTransferStats(server: server.Server, serverView: ServerView) {
+    this.refreshTransferStats(server, serverView);
+    // Get transfer stats once per minute for as long as server is selected.
+    const statsRefreshRateMs = 60 * 1000;
+    const intervalId = setInterval(() => {
+      // FIXME: Add check back in
+      // if (this.selectedServer !== server) {
+      //   // Server is no longer running, stop interval
+      //   clearInterval(intervalId);
+      //   return;
+      // }
+      this.refreshTransferStats(server, serverView);
+    }, statsRefreshRateMs);
+  }
+
+  // Converts the access key from the remote service format to the
+  // format used by outline-server-view.
+  private convertToUiAccessKey(remoteAccessKey: server.AccessKey): DisplayAccessKey {
+    return {
+      id: remoteAccessKey.id,
+      placeholderName: `${this.appRoot.localize('key', 'keyId', remoteAccessKey.id)}`,
+      name: remoteAccessKey.name,
+      accessUrl: remoteAccessKey.accessUrl,
+      transferredBytes: 0,
+      relativeTraffic: 0
+    };
+  }
+
+  public addAccessKey(server: Server) {
+    server.addAccessKey()
+      .then((serverAccessKey: server.AccessKey) => {
+        const uiAccessKey = this.convertToUiAccessKey(serverAccessKey);
+        this.appRoot.getServerView(this.appRoot.selectedServer.id).addAccessKey(uiAccessKey);
+        this.appRoot.showNotification(this.appRoot.localize('notification-key-added'));
+      })
+      .catch((error) => {
+        console.error(`Failed to add access key: ${error}`);
+        this.appRoot.showError(this.appRoot.localize('error-key-add'));
+      });
+  }
+
+  public renameAccessKey(
+    server: Server, accessKeyId: string, newName: string, entry: polymer.Base) {
+    server.renameAccessKey(accessKeyId, newName)
+      .then(() => {
+        entry.commitName();
+      })
+      .catch((error) => {
+        console.error(`Failed to rename access key: ${error}`);
+        this.appRoot.showError(this.appRoot.localize('error-key-rename'));
+        entry.revertName();
+      });
+  }
+
+  public removeAccessKey(server: Server, accessKeyId: string) {
+    server.removeAccessKey(accessKeyId)
+      .then(() => {
+        this.appRoot.getServerView(this.appRoot.selectedServer.id).removeAccessKey(accessKeyId);
+        this.appRoot.showNotification(this.appRoot.localize('notification-key-removed'));
+      })
+      .catch((error) => {
+        console.error(`Failed to remove access key: ${error}`);
+        this.appRoot.showError(this.appRoot.localize('error-key-remove'));
+      });
+  }
+
+  public async setAccessKeyDataLimit(server: Server, limit: server.DataLimit) {
+    if (!limit) {
+      return false;
+    }
+    const previousLimit = server.getAccessKeyDataLimit();
+    if (previousLimit && limit.bytes === previousLimit.bytes) {
+      return false;
+    }
+    const serverView = this.appRoot.getServerView(this.appRoot.selectedServer.id);
+    try {
+      await server.setAccessKeyDataLimit(limit);
+      this.appRoot.showNotification(this.appRoot.localize('saved'));
+      serverView.accessKeyDataLimit = ServerManagementApp.dataLimitToDisplayDataAmount(limit);
+      this.refreshTransferStats(server, serverView);
+      return true;
+    } catch (error) {
+      console.error(`Failed to set access key data limit: ${error}`);
+      this.appRoot.showError(this.appRoot.localize('error-set-data-limit'));
+      serverView.accessKeyDataLimit = ServerManagementApp.dataLimitToDisplayDataAmount(
+        previousLimit || await ServerManagementApp.computeDefaultAccessKeyDataLimit(server));
+      serverView.isAccessKeyDataLimitEnabled = !!previousLimit;
+    }
+  }
+
+  public async removeAccessKeyDataLimit(server: Server) {
+    const serverView = this.appRoot.getServerView(this.appRoot.selectedServer.id);
+    try {
+      await server.removeAccessKeyDataLimit();
+      this.appRoot.showNotification(this.appRoot.localize('saved'));
+      this.refreshTransferStats(server, serverView);
+    } catch (error) {
+      console.error(`Failed to remove access key data limit: ${error}`);
+      this.appRoot.showError(this.appRoot.localize('error-remove-data-limit'));
+      serverView.isAccessKeyDataLimitEnabled = true;
+    }
+  }
+
+  public async setHostnameForAccessKeys(
+    server: Server, hostname: string, serverSettings: polymer.Base) {
+    this.appRoot.showNotification(this.appRoot.localize('saving'));
+    try {
+      await server.setHostnameForAccessKeys(hostname);
+      this.appRoot.showNotification(this.appRoot.localize('saved'));
+      serverSettings.enterSavedState();
+    } catch (error) {
+      this.appRoot.showError(this.appRoot.localize('error-not-saved'));
+      if (error.isNetworkError()) {
+        serverSettings.enterErrorState(this.appRoot.localize('error-network'));
+        return;
+      }
+      const message = error.response.status === 400 ? 'error-hostname-invalid' : 'error-unexpected';
+      serverSettings.enterErrorState(this.appRoot.localize(message));
+    }
+  }
+
+  public async setPortForNewAccessKeys(server: Server, port: number, serverSettings: polymer.Base) {
+    this.appRoot.showNotification(this.appRoot.localize('saving'));
+    try {
+      await server.setPortForNewAccessKeys(port);
+      this.appRoot.showNotification(this.appRoot.localize('saved'));
+      serverSettings.enterSavedState();
+    } catch (error) {
+      this.appRoot.showError(this.appRoot.localize('error-not-saved'));
+      if (error.isNetworkError()) {
+        serverSettings.enterErrorState(this.appRoot.localize('error-network'));
+        return;
+      }
+      const code = error.response.status;
+      if (code === 409) {
+        serverSettings.enterErrorState(this.appRoot.localize('error-keys-port-in-use'));
+        return;
+      }
+      serverSettings.enterErrorState(this.appRoot.localize('error-unexpected'));
+    }
+  }
+
+  private static localizeDate(date: Date, language: string): string {
+    return date.toLocaleString(language, {year: 'numeric', month: 'long', day: 'numeric'});
+  }
+
+  private static async showHelpBubblesOnce(serverView: ServerView) {
+    if (!window.localStorage.getItem('addAccessKeyHelpBubble-dismissed')) {
+      await serverView.showAddAccessKeyHelpBubble();
+      window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
+    }
+    if (!window.localStorage.getItem('getConnectedHelpBubble-dismissed')) {
+      await serverView.showGetConnectedHelpBubble();
+      window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
+    }
+    if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') &&
+      serverView.supportsAccessKeyDataLimit) {
+      await serverView.showDataLimitsHelpBubble();
+      window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
+    }
+  }
+
+  private static dataLimitToDisplayDataAmount(limit: server.DataLimit): DisplayDataAmount|null {
+    if (!limit) {
+      return null;
+    }
+    const bytes = limit.bytes;
+    if (bytes >= 10 ** 9) {
+      return {value: Math.floor(bytes / (10 ** 9)), unit: 'GB'};
+    }
+    return {value: Math.floor(bytes / (10 ** 6)), unit: 'MB'};
+  }
+
+  // Compute the suggested data limit based on the server's transfer capacity and number of access
+  // keys.
+  private static async computeDefaultAccessKeyDataLimit(
+    server: server.Server, accessKeys?: server.AccessKey[]): Promise<server.DataLimit> {
+    try {
+      // Assume non-managed servers have a data transfer capacity of 1TB.
+      let serverTransferCapacity: server.DataAmount = {terabytes: 1};
+      if (ServerManagementApp.isManagedServer(server)) {
+        serverTransferCapacity = server.getHost().getMonthlyOutboundTransferLimit();
+      }
+      if (!accessKeys) {
+        accessKeys = await server.listAccessKeys();
+      }
+      let dataLimitBytes = serverTransferCapacity.terabytes * (10 ** 12) / (accessKeys.length || 1);
+      if (dataLimitBytes > MAX_ACCESS_KEY_DATA_LIMIT_BYTES) {
+        dataLimitBytes = MAX_ACCESS_KEY_DATA_LIMIT_BYTES;
+      }
+      return {bytes: dataLimitBytes};
+    } catch (e) {
+      console.error(`Failed to compute default access key data limit: ${e}`);
+      return {bytes: MAX_ACCESS_KEY_DATA_LIMIT_BYTES};
+    }
+  }
+
+  // TODO: Reconcile with copy in app.ts
+  private getLocalizedCityName(regionId: server.RegionId) {
+    const cityId = digitalocean_server.GetCityId(regionId);
+    return this.appRoot.localize(`city-${cityId}`);
+  }
+
+  // TODO: Reconcile with copy in app.ts
+  private static isManagedServer(testServer: server.Server): testServer is server.ManagedServer {
+    return !!(testServer as server.ManagedServer).getHost;
+  }
+
+  public static displayDataAmountToDataLimit(dataAmount: DisplayDataAmount): server.DataLimit|null {
+    if (!dataAmount) {
+      return null;
+    }
+    if (dataAmount.unit === 'GB') {
+      return {bytes: dataAmount.value * (10 ** 9)};
+    } else if (dataAmount.unit === 'MB') {
+      return {bytes: dataAmount.value * (10 ** 6)};
+    }
+    return {bytes: dataAmount.value};
+  }
+}

--- a/src/server_manager/web_app/ui_components/outline-server-settings.js
+++ b/src/server_manager/web_app/ui_components/outline-server-settings.js
@@ -299,7 +299,10 @@ Polymer({
     }
     // Fire signal if name has changed.
     if (newName !== this.initialName) {
-      this.fire('ServerRenameRequested', {newName});
+      this.fire('ServerRenameRequested', {
+        newName,
+        displayServer: this._makeDisplayServer()
+      });
     }
   },
 
@@ -327,7 +330,9 @@ Polymer({
     if (isDataLimitEnabled) {
       this._requestSetAccessKeyDataLimit();
     } else {
-      this.fire('RemoveAccessKeyDataLimitRequested');
+      this.fire('RemoveAccessKeyDataLimitRequested', {
+        displayServer: this._makeDisplayServer()
+      });
     }
   },
 
@@ -346,7 +351,10 @@ Polymer({
     }
     const value = Number(this.$.accessKeyDataLimitInput.value);
     const unit = this.$.accessKeyDataLimitUnits.selected;
-    this.fire('SetAccessKeyDataLimitRequested', {limit: {value, unit}});
+    this.fire('SetAccessKeyDataLimitRequested', {
+      limit: {value, unit},
+      displayServer: this._makeDisplayServer()
+    });
   },
 
   _computeDataLimitsEnabledName: function(isAccessKeyDataLimitEnabled) {
@@ -361,5 +369,13 @@ Polymer({
     const port = Number(value);
     const valid = !Number.isNaN(port) && port >= 1 && port <= 65535 && Number.isInteger(port);
     return valid ? '' : this.localize('error-keys-port-bad-input');
+  },
+
+  _makeDisplayServer() {
+    return  {
+      id: this.serverManagementApiUrl,
+      name: this.serverName,
+      isManaged: this.isServerManaged
+    };
   }
 });

--- a/src/server_manager/web_app/ui_components/outline-server-settings.js
+++ b/src/server_manager/web_app/ui_components/outline-server-settings.js
@@ -299,10 +299,7 @@ Polymer({
     }
     // Fire signal if name has changed.
     if (newName !== this.initialName) {
-      this.fire('ServerRenameRequested', {
-        newName,
-        displayServer: this._makeDisplayServer()
-      });
+      this.fire('ServerRenameRequested', {newName, displayServer: this._makeDisplayServer()});
     }
   },
 
@@ -330,9 +327,7 @@ Polymer({
     if (isDataLimitEnabled) {
       this._requestSetAccessKeyDataLimit();
     } else {
-      this.fire('RemoveAccessKeyDataLimitRequested', {
-        displayServer: this._makeDisplayServer()
-      });
+      this.fire('RemoveAccessKeyDataLimitRequested', {displayServer: this._makeDisplayServer()});
     }
   },
 
@@ -351,10 +346,9 @@ Polymer({
     }
     const value = Number(this.$.accessKeyDataLimitInput.value);
     const unit = this.$.accessKeyDataLimitUnits.selected;
-    this.fire('SetAccessKeyDataLimitRequested', {
-      limit: {value, unit},
-      displayServer: this._makeDisplayServer()
-    });
+    this.fire(
+        'SetAccessKeyDataLimitRequested',
+        {limit: {value, unit}, displayServer: this._makeDisplayServer()});
   },
 
   _computeDataLimitsEnabledName: function(isAccessKeyDataLimitEnabled) {
@@ -372,7 +366,7 @@ Polymer({
   },
 
   _makeDisplayServer() {
-    return  {
+    return {
       id: this.serverManagementApiUrl,
       name: this.serverName,
       isManaged: this.isServerManaged

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -698,8 +698,17 @@ export class ServerView extends DirMixin(PolymerElement) {
   }
 
   _handleAddAccessKeyPressed() {
-    this.dispatchEvent(makePublicEvent('AddAccessKeyRequested'));
+    const detail = { displayServer: this._makeDisplayServer() };
+    this.dispatchEvent(makePublicEvent('AddAccessKeyRequested', detail));
     this.$.addAccessKeyHelpBubble.hide();
+  }
+
+  _makeDisplayServer() {
+    return  {
+      id: this.serverManagementApiUrl,
+      name: this.serverName,
+      isManaged: this.isServerManaged
+    };
   }
 
   _handleNameInputKeyDown(event) {
@@ -724,6 +733,7 @@ export class ServerView extends DirMixin(PolymerElement) {
     this.dispatchEvent(makePublicEvent('RenameAccessKeyRequested', {
       accessKeyId: accessKey.id,
       newName: displayName,
+      displayServer: this._makeDisplayServer(),
       entry: {
         commitName: () => {
           accessKey.name = displayName;
@@ -760,7 +770,10 @@ export class ServerView extends DirMixin(PolymerElement) {
 
   _handleRemoveAccessKeyPressed(e) {
     const accessKey = e.model.item;
-    this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {accessKeyId: accessKey.id}));
+    this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {
+      accessKeyId: accessKey.id,
+      displayServer: this._makeDisplayServer()
+    }));
   }
 
   setServerTransferredData(totalBytes) {

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -698,13 +698,13 @@ export class ServerView extends DirMixin(PolymerElement) {
   }
 
   _handleAddAccessKeyPressed() {
-    const detail = { displayServer: this._makeDisplayServer() };
+    const detail = {displayServer: this._makeDisplayServer()};
     this.dispatchEvent(makePublicEvent('AddAccessKeyRequested', detail));
     this.$.addAccessKeyHelpBubble.hide();
   }
 
   _makeDisplayServer() {
-    return  {
+    return {
       id: this.serverManagementApiUrl,
       name: this.serverName,
       isManaged: this.isServerManaged
@@ -770,10 +770,9 @@ export class ServerView extends DirMixin(PolymerElement) {
 
   _handleRemoveAccessKeyPressed(e) {
     const accessKey = e.model.item;
-    this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {
-      accessKeyId: accessKey.id,
-      displayServer: this._makeDisplayServer()
-    }));
+    this.dispatchEvent(makePublicEvent(
+        'RemoveAccessKeyRequested',
+        {accessKeyId: accessKey.id, displayServer: this._makeDisplayServer()}));
   }
 
   setServerTransferredData(totalBytes) {


### PR DESCRIPTION
**Refactor to prep for adding more "magic" cloud providers**

This is a first pass to separate the cloud provisioning logic from server management logic into their own (logical) _apps_. These are two disparate flows that can likely be isolated to make the manager architecture cleaner.

I'm thinking that we should draw from domain driven design and define the [bounded context](https://martinfowler.com/bliki/BoundedContext.html) for each app. This would give us a vocabulary that makes sense for the separate flows.

**What this might look like:**
Server Management App server with the following concepts:
* Server information (name, id, version)
* Stats (data transferred)
* Management URL
* Access keys
* Experiments (like data limits)

Server Provisioning App:
* Managed vs Manual servers
* Shadowbox server
* DigitalOcean provisioning logic (which could later be it's own app/module)

I feel like we already implicitly have this, but we could benefit from making it more formal.

This becomes a little tricky (at least for me) when trying to separate the UI logic. We rely on state to keep track of things like _"which server is selected"_ and _"which server is being provisioned"_. So for example, when we fire events like _AddAccessKeyRequested_ or _ServerRenameRequested_, we check which server is currently selected to know which one to update.

My concern with this pattern is that we use this state in both server management and server provisioning flows, so I can't easily tell if it's safe to update that value. In fact, we have a few "sanity check" conditional statements just to make sure we're in the proper state.

I took a stab at factoring out the server management UI by moving it into a separate class and refactoring some of the method level logic. I think what I have below gives a rough idea of what this separation could look like with a few caveats:
* I removed two sanity checks because they depended on state that the new server management app no longer has access to.
* Event bindings still not entirely separated so they're still in _app.ts_