### PR TITLE
Adds key sharing help bubble

### DIFF
--- a/src/server_manager/messages/en.json
+++ b/src/server_manager/messages/en.json
@@ -165,6 +165,8 @@
   "server-help-connection-description": "Click here to install the Outline client app, using your personal access key to your Outline server.",
   "server-help-connection-ok": "Okay, got it!",
   "server-help-connection-title": "You are not connected yet!",
+  "server-help-key-sharing-title": "Share access",
+  "server-help-key-sharing-description": "Click here to give someone access to your server.",
   "server-keys": "Keys",
   "server-name": "Outline Server {serverLocation}",
   "server-remove": "Remove server",

--- a/src/server_manager/messages/master_messages.json
+++ b/src/server_manager/messages/master_messages.json
@@ -789,6 +789,14 @@
     "message": "You are not connected yet!",
     "description": "This string appears within a help bubble as a header. The help bubble provides information about connecting to the server."
   },
+  "server_help_key_sharing_title": {
+    "message": "Share access",
+    "description": "This string appears within a help bubble as a header. The help bubble provides information about sharing an access key."
+  },
+  "server_help_key_sharing_description": {
+    "message": "Click here to give someone access to your server.",
+    "description": "This string appears within a help bubble as a header. The help bubble provides information about sharing an access key."
+  },
   "server_keys": {
     "message": "Keys",
     "description": "This string appears within the server view as the unit of a card that displays the number of server access keys."

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -89,19 +89,9 @@ async function computeDefaultAccessKeyDataLimit(
 }
 
 async function showHelpBubblesOnce(serverView: ServerView) {
-  if (!window.localStorage.getItem('addAccessKeyHelpBubble-dismissed')) {
-    await serverView.showAddAccessKeyHelpBubble();
-    window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
-  }
-  if (!window.localStorage.getItem('getConnectedHelpBubble-dismissed')) {
-    await serverView.showGetConnectedHelpBubble();
-    window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
-  }
-  if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') &&
-      serverView.supportsAccessKeyDataLimit) {
-    await serverView.showDataLimitsHelpBubble();
-    window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
-  }
+  await serverView.showAddAccessKeyHelpBubble();
+  await serverView.showGetConnectedHelpBubble();
+  await serverView.showDataLimitsHelpBubble();
 }
 
 function isManagedServer(testServer: server.Server): testServer is server.ManagedServer {

--- a/src/server_manager/web_app/ui_components/outline-help-bubble.js
+++ b/src/server_manager/web_app/ui_components/outline-help-bubble.js
@@ -135,15 +135,6 @@ export class HelpBubble extends mixinBehaviors
     return 'outline-help-bubble';
   }
 
-  static get properties() {
-    return {isActive: {type: Boolean, computed: '_computeIsActive()'}};
-  }
-
-  constructor() {
-    super();
-    this.active = false;
-  }
-
   ready() {
     super.ready();
     // Prevent help bubble from overlapping with it's positionTarget.
@@ -182,7 +173,7 @@ export class HelpBubble extends mixinBehaviors
     this.fire('outline-help-bubble-dismissed');
   }
 
-  _computeIsActive() {
+  isDisplayed() {
     return !this.hasAttribute('hidden');
   }
 }

--- a/src/server_manager/web_app/ui_components/outline-help-bubble.js
+++ b/src/server_manager/web_app/ui_components/outline-help-bubble.js
@@ -13,13 +13,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-import '@polymer/polymer/polymer-legacy.js';
+import '@polymer/paper-button/paper-button.js';
+import './cloud-install-styles.js';
 
 import {IronFitBehavior} from '@polymer/iron-fit-behavior/iron-fit-behavior.js';
-import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
-import {html} from '@polymer/polymer/lib/utils/html-tag.js';
-Polymer({
-  _template: html`
+import {html, PolymerElement} from '@polymer/polymer';
+import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+
+export class HelpBubble extends mixinBehaviors([IronFitBehavior], PolymerElement) {
+  static get template() {
+    return html`
     <style include="cloud-install-styles"></style>
     <style>
       :host {
@@ -124,23 +127,34 @@ Polymer({
     <div class="upArrowWrapper"><div class="upArrow"></div></div>
     <div class="downArrowWrapper"><div class="downArrow"></div></div>
     <div class="helpContent"><slot></slot></div>
-`,
+    `;
+  }
 
-  is: 'outline-help-bubble',
+  static get is() {
+    return 'outline-help-bubble';
+  }
 
-  behaviors: [
-    IronFitBehavior,
-  ],
+  static get properties() {
+    return {
+      isActive: {type: Boolean, computed: '_computeIsActive()'}
+    };
+  }
 
-  ready: function() {
+  constructor() {
+    super();
+    this.active = false;
+  }
+
+  ready() {
+    super.ready();
     // Prevent help bubble from overlapping with it's positionTarget.
     this.setAttribute('no-overlap', true);
 
     // Help bubble should default to hidden until show is called.
     this.setAttribute('hidden', true);
-  },
+  }
 
-  show: function(positionTarget, arrowDirection, leftOrRightOffset) {
+  show(positionTarget, arrowDirection, leftOrRightOffset) {
     this.removeAttribute('hidden');
 
     // Set arrow direction.
@@ -160,12 +174,18 @@ Polymer({
     // Listen to scroll and resize events so the help bubble can reposition if needed.
     window.addEventListener('scroll', this.refit.bind(this));
     window.addEventListener('resize', this.refit.bind(this));
-  },
+  }
 
-  hide: function() {
+  hide() {
     this.setAttribute('hidden', true);
     window.removeEventListener('scroll', this.refit.bind(this));
     window.removeEventListener('resize', this.refit.bind(this));
     this.fire('outline-help-bubble-dismissed');
   }
-});
+
+  _computeIsActive() {
+    return !this.hasAttribute('hidden');
+  }
+}
+
+customElements.define(HelpBubble.is, HelpBubble);

--- a/src/server_manager/web_app/ui_components/outline-help-bubble.js
+++ b/src/server_manager/web_app/ui_components/outline-help-bubble.js
@@ -20,7 +20,8 @@ import {IronFitBehavior} from '@polymer/iron-fit-behavior/iron-fit-behavior.js';
 import {html, PolymerElement} from '@polymer/polymer';
 import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
 
-export class HelpBubble extends mixinBehaviors([IronFitBehavior], PolymerElement) {
+export class HelpBubble extends mixinBehaviors
+([IronFitBehavior], PolymerElement) {
   static get template() {
     return html`
     <style include="cloud-install-styles"></style>
@@ -135,9 +136,7 @@ export class HelpBubble extends mixinBehaviors([IronFitBehavior], PolymerElement
   }
 
   static get properties() {
-    return {
-      isActive: {type: Boolean, computed: '_computeIsActive()'}
-    };
+    return {isActive: {type: Boolean, computed: '_computeIsActive()'}};
   }
 
   constructor() {

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -27,10 +27,10 @@ import '@polymer/paper-tabs/paper-tabs.js';
 import '@polymer/paper-tooltip/paper-tooltip.js';
 import './cloud-install-styles.js';
 import './outline-iconset.js';
-import './outline-help-bubble.js';
 import './outline-metrics-option-dialog.js';
 import './outline-server-settings.js';
 import './outline-share-dialog.js';
+import {HelpBubble} from './outline-help-bubble';
 import {html, PolymerElement} from '@polymer/polymer';
 import {DirMixin} from '@polymer/polymer/lib/mixins/dir-mixin.js';
 
@@ -530,6 +530,12 @@ export class ServerView extends DirMixin(PolymerElement) {
       <p>[[localize('server-help-access-key-description')]]</p>
       <paper-button on-tap="closeAddAccessKeyHelpBubble">[[localize('server-help-access-key-next')]]</paper-button>
     </outline-help-bubble>
+    <outline-help-bubble id="keySharingHelpBubble" vertical-align="bottom" horizontal-align="left">
+      <img src="images/key-tip-2x.png">
+      <h3>Share access</h3>
+      <p>Share this key to give someone access to your server.</p>
+      <paper-button on-tap="closeKeySharingHelpBubble">[[localize('ok')]]</paper-button>
+    </outline-help-bubble>
     <outline-help-bubble id="dataLimitsHelpBubble" vertical-align="top" horizontal-align="right">
       <h3>[[localize('data-limits-dialog-title')]]</h3>
       <p>[[localize('data-limits-dialog-text')]]</p>
@@ -649,7 +655,8 @@ export class ServerView extends DirMixin(PolymerElement) {
 
   _handleAddAccessKeyPressed() {
     this.dispatchEvent(makePublicEvent('AddAccessKeyRequested'));
-    this.$.addAccessKeyHelpBubble.hide();
+    this.closeAddAccessKeyHelpBubble();
+    this.showKeySharingHelpBubble();
   }
 
   _handleNameInputKeyDown(event) {
@@ -777,6 +784,7 @@ export class ServerView extends DirMixin(PolymerElement) {
       this.closeAddAccessKeyHelpBubble();
       this.closeGetConnectedHelpBubble();
       this.closeDataLimitsHelpBubble();
+      this.closeKeySharingHelpBubble();
       this.$.serverSettings.update(this.serverName, this.metricsEnabled);
     }
   }
@@ -785,28 +793,48 @@ export class ServerView extends DirMixin(PolymerElement) {
   // is on the screen (e.g. selected in iron-pages). If help bubbles
   // are initialized before this point, setPosition will not work and
   // they will appear in the top left of the view.
-  showGetConnectedHelpBubble() {
-    return this._showHelpBubble('getConnectedHelpBubble', 'accessKeysContainer', 'down', 'right');
+  showAddAccessKeyHelpBubble() {
+    if (!window.localStorage.getItem('addAccessKeyHelpBubble-dismissed')) {
+      return this._showHelpBubble('addAccessKeyHelpBubble', 'addAccessKeyRow', 'down', 'left');
+    }
   }
 
-  showAddAccessKeyHelpBubble() {
-    return this._showHelpBubble('addAccessKeyHelpBubble', 'addAccessKeyRow', 'down', 'left');
+  showGetConnectedHelpBubble() {
+    if (!window.localStorage.getItem('getConnectedHelpBubble-dismissed')) {
+      return this._showHelpBubble('getConnectedHelpBubble', 'accessKeysContainer', 'down', 'right');
+    }
   }
 
   showDataLimitsHelpBubble() {
-    return this._showHelpBubble('dataLimitsHelpBubble', 'settingsTab', 'up', 'right');
+    if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') && this.supportsAccessKeyDataLimit) {
+      return this._showHelpBubble('dataLimitsHelpBubble', 'settingsTab', 'up', 'right');
+    }
+  }
+
+  showKeySharingHelpBubble() {
+    if (!window.localStorage.getItem('keySharingHelpBubble-dismissed')) {
+      return this._showHelpBubble('keySharingHelpBubble', 'accessKeysContainer', 'down', 'right');
+    }
   }
 
   closeAddAccessKeyHelpBubble() {
     this.$.addAccessKeyHelpBubble.hide();
+    window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
   }
 
   closeGetConnectedHelpBubble() {
     this.$.getConnectedHelpBubble.hide();
+    window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
   }
 
   closeDataLimitsHelpBubble() {
     this.$.dataLimitsHelpBubble.hide();
+    window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
+  }
+
+  closeKeySharingHelpBubble() {
+    this.$.keySharingHelpBubble.hide();
+    window.localStorage.setItem('keySharingHelpBubble-dismissed', 'true');
   }
 
   _showHelpBubble(

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -819,31 +819,31 @@ export class ServerView extends DirMixin(PolymerElement) {
   }
 
   closeAddAccessKeyHelpBubble() {
-    this.$.addAccessKeyHelpBubble.hide();
-    if (this.$.addAccessKeyHelpBubble.isActive) {
+    if (this.$.addAccessKeyHelpBubble.isDisplayed()) {
       window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
     }
+    this.$.addAccessKeyHelpBubble.hide();
   }
 
   closeGetConnectedHelpBubble() {
-    this.$.getConnectedHelpBubble.hide();
-    if (this.$.getConnectedHelpBubble.isActive) {
+    if (this.$.getConnectedHelpBubble.isDisplayed()) {
       window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
     }
+    this.$.getConnectedHelpBubble.hide();
   }
 
   closeDataLimitsHelpBubble() {
-    this.$.dataLimitsHelpBubble.hide();
-    if (this.$.dataLimitsHelpBubble.isActive) {
+    if (this.$.dataLimitsHelpBubble.isDisplayed()) {
       window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
     }
+    this.$.dataLimitsHelpBubble.hide();
   }
 
   closeKeySharingHelpBubble() {
-    this.$.keySharingHelpBubble.hide();
-    if (this.$.keySharingHelpBubble.isActive) {
+    if (this.$.keySharingHelpBubble.isDisplayed()) {
       window.localStorage.setItem('keySharingHelpBubble-dismissed', 'true');
     }
+    this.$.keySharingHelpBubble.hide();
   }
 
   _showHelpBubble(

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -30,13 +30,14 @@ import './outline-iconset.js';
 import './outline-metrics-option-dialog.js';
 import './outline-server-settings.js';
 import './outline-share-dialog.js';
-import {HelpBubble} from './outline-help-bubble';
+
 import {html, PolymerElement} from '@polymer/polymer';
 import {DirMixin} from '@polymer/polymer/lib/mixins/dir-mixin.js';
-
-
 import * as byte_size from 'byte-size';
+
 import {makePublicEvent} from '../../infrastructure/events';
+
+import {HelpBubble} from './outline-help-bubble';
 
 byte_size.defaultOptions({
   units: 'metric',
@@ -806,7 +807,8 @@ export class ServerView extends DirMixin(PolymerElement) {
   }
 
   showDataLimitsHelpBubble() {
-    if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') && this.supportsAccessKeyDataLimit) {
+    if (!window.localStorage.getItem('dataLimitsHelpBubble-dismissed') &&
+        this.supportsAccessKeyDataLimit) {
       return this._showHelpBubble('dataLimitsHelpBubble', 'settingsTab', 'up', 'right');
     }
   }

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -30,14 +30,13 @@ import './outline-iconset.js';
 import './outline-metrics-option-dialog.js';
 import './outline-server-settings.js';
 import './outline-share-dialog.js';
+import './outline-help-bubble.js';
 
 import {html, PolymerElement} from '@polymer/polymer';
 import {DirMixin} from '@polymer/polymer/lib/mixins/dir-mixin.js';
 import * as byte_size from 'byte-size';
 
 import {makePublicEvent} from '../../infrastructure/events';
-
-import {HelpBubble} from './outline-help-bubble';
 
 byte_size.defaultOptions({
   units: 'metric',
@@ -531,10 +530,10 @@ export class ServerView extends DirMixin(PolymerElement) {
       <p>[[localize('server-help-access-key-description')]]</p>
       <paper-button on-tap="closeAddAccessKeyHelpBubble">[[localize('server-help-access-key-next')]]</paper-button>
     </outline-help-bubble>
-    <outline-help-bubble id="keySharingHelpBubble" vertical-align="bottom" horizontal-align="left">
+    <outline-help-bubble id="keySharingHelpBubble" vertical-align="bottom" horizontal-align="right">
       <img src="images/key-tip-2x.png">
-      <h3>Share access</h3>
-      <p>Share this key to give someone access to your server.</p>
+      <h3>[[localize('server-help-key-sharing-title')]]</h3>
+      <p>[[localize('server-help-key-sharing-description')]]</p>
       <paper-button on-tap="closeKeySharingHelpBubble">[[localize('ok')]]</paper-button>
     </outline-help-bubble>
     <outline-help-bubble id="dataLimitsHelpBubble" vertical-align="top" horizontal-align="right">
@@ -821,22 +820,30 @@ export class ServerView extends DirMixin(PolymerElement) {
 
   closeAddAccessKeyHelpBubble() {
     this.$.addAccessKeyHelpBubble.hide();
-    window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
+    if (this.$.addAccessKeyHelpBubble.isActive) {
+      window.localStorage.setItem('addAccessKeyHelpBubble-dismissed', 'true');
+    }
   }
 
   closeGetConnectedHelpBubble() {
     this.$.getConnectedHelpBubble.hide();
-    window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
+    if (this.$.getConnectedHelpBubble.isActive) {
+      window.localStorage.setItem('getConnectedHelpBubble-dismissed', 'true');
+    }
   }
 
   closeDataLimitsHelpBubble() {
     this.$.dataLimitsHelpBubble.hide();
-    window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
+    if (this.$.dataLimitsHelpBubble.isActive) {
+      window.localStorage.setItem('dataLimitsHelpBubble-dismissed', 'true');
+    }
   }
 
   closeKeySharingHelpBubble() {
     this.$.keySharingHelpBubble.hide();
-    window.localStorage.setItem('keySharingHelpBubble-dismissed', 'true');
+    if (this.$.keySharingHelpBubble.isActive) {
+      window.localStorage.setItem('keySharingHelpBubble-dismissed', 'true');
+    }
   }
 
   _showHelpBubble(


### PR DESCRIPTION
Displays a popup after an access key is created.
* Updates the outline-help-bubble to Polymer 3

**TODO: Do we want to merge this with the "Get connected" help bubble if we're removing the admin key special casing?**

<img width="912" alt="Screen Shot 2020-06-15 at 6 53 51 PM" src="https://user-images.githubusercontent.com/1009390/84713705-a2f23380-af39-11ea-97f9-0ba30bff192d.png">
