### PR TITLE
Clarify Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 stages:
   - name: "Server Daily Release"
     if: type = cron
-  - name: build and unit test
+  - name: Test
     if: type != cron
   - name: "Server Integration Test"
     if: type != cron
@@ -49,7 +49,7 @@ jobs:
     # command failed. However, since each stage incurs a significantly start-up
     # cost, we combine test and build commands for all components into one fast
     # stage.
-    - stage: build and unit test
+    - stage: Test
       script:
         - yarn do metrics_server/build
         - yarn do sentry_webhook/build
@@ -60,7 +60,8 @@ jobs:
         - yarn do server_manager/web_app/build
         - yarn do server_manager/web_app/test
 
-    - stage: "Server Integration Test"
+    - stage: Test
+      name: "Server Integration Test"
       sudo: required
       services: docker
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ stages:
     if: type = cron
   - name: Test
     if: type != cron
-  - name: "Server Integration Test"
-    if: type != cron
   - name: "deploy"
     if: tag =~ ^server-
   - name: "Manager Release"
@@ -50,6 +48,7 @@ jobs:
     # cost, we combine test and build commands for all components into one fast
     # stage.
     - stage: Test
+      name: Unit Tests
       script:
         - yarn do metrics_server/build
         - yarn do sentry_webhook/build
@@ -61,7 +60,7 @@ jobs:
         - yarn do server_manager/web_app/test
 
     - stage: Test
-      name: "Server Integration Test"
+      name: Server Integration Test
       sudo: required
       services: docker
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
     - stage: Test
       name: Unit Tests
       script:
+        - yarn lint
         - yarn do metrics_server/build
         - yarn do sentry_webhook/build
         - yarn do shadowbox/server/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ before_install:
     fi;
 
 stages:
-  - name: tag
+  - name: "Server Daily Release"
     if: type = cron
   - name: build and unit test
     if: type != cron
-  - name: integration test
+  - name: "Server Integration Test"
     if: type != cron
-  - name: deploy
-    if: tag =~ ^daily
-  - name: release
+  - name: "deploy"
+    if: tag =~ ^server-
+  - name: "Manager Release"
     if: tag =~ ^v[0-9]
 
 # Stages with the same name define multiple jobs which run in parallel.
@@ -39,9 +39,9 @@ stages:
 # doing, we add a descriptive environment variable.
 jobs:
   include:
-    - stage: tag
+    - stage: "Server Daily Release"
       script:
-        - RELEASE_NAME=daily-$(date -I)
+        - RELEASE_NAME=server-$(date -I)
         - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
 
     # Ideally, we would split this stage in some way, e.g. by component or by
@@ -60,7 +60,7 @@ jobs:
         - yarn do server_manager/web_app/build
         - yarn do server_manager/web_app/test
 
-    - stage: integration test
+    - stage: "Server Integration Test"
       sudo: required
       services: docker
       script:
@@ -118,7 +118,7 @@ jobs:
 
     # Note that because we cannot currently sign Windows binaries on Travis,
     # these must be manually built and uploaded to the releases page.
-    - stage: release
+    - stage: "Manager Release"
       env:
         - DESC=linux manager
       addons:
@@ -127,7 +127,7 @@ jobs:
           - rpm
       script: yarn do server_manager/electron_app/release_linux
 
-    - stage: release
+    - stage: "Manager Release"
       os: osx
       # electron-builder requires macOS >=10.13.6 for signing to work.
       osx_image: xcode10.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
           curl -L https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m) > docker-compose
           chmod +x docker-compose
           sudo mv docker-compose /usr/local/bin
-        - yarn do shadowbox/docker/build; cd src/shadowbox/integration_test; ./test.sh
+        - yarn do shadowbox/docker/build && cd src/shadowbox/integration_test && ./test.sh
 
     - stage: deploy
       name: Server Docker Image

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
           curl -L https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m) > docker-compose
           chmod +x docker-compose
           sudo mv docker-compose /usr/local/bin
-        - yarn do shadowbox/integration_test/run
+        - yarn do shadowbox/docker/build; cd src/shadowbox/integration_test; ./test.sh
 
     - stage: deploy
       name: Server Docker Image

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ stages:
     if: tag =~ ^v[0-9]
 
 # Stages with the same name define multiple jobs which run in parallel.
-# To make it more apparent in the Travis UI exactly what each job is
-# doing, we add a descriptive environment variable.
 jobs:
   include:
     - stage: "Server Daily Release"
@@ -73,8 +71,7 @@ jobs:
         - yarn do shadowbox/integration_test/run
 
     - stage: deploy
-      env:
-        - DESC=shadowbox docker image
+      name: Server Docker Image
       sudo: required
       services: docker
       script:
@@ -86,8 +83,7 @@ jobs:
         - docker push quay.io/outline/shadowbox:daily
 
     - stage: deploy
-      env:
-        - DESC=linux manager
+      name: Manager Linux
       addons:
         apt:
           packages:
@@ -96,8 +92,7 @@ jobs:
 
     # https://www.electron.build/multi-platform-build
     - stage: deploy
-      env:
-        - DESC=windows manager
+      name: Manager Windows
       sudo: required
       services: docker
       script:
@@ -111,16 +106,14 @@ jobs:
             /bin/bash -c "yarn do server_manager/electron_app/package_only_windows" || travis_terminate $?
 
     - stage: deploy
-      env:
-        - DESC=macos manager
+      name: Manager macOS
       os: osx
       script: yarn do server_manager/electron_app/package_macos
 
     # Note that because we cannot currently sign Windows binaries on Travis,
     # these must be manually built and uploaded to the releases page.
     - stage: "Manager Release"
-      env:
-        - DESC=linux manager
+      name: Manager Linux
       addons:
         apt:
           packages:
@@ -131,8 +124,7 @@ jobs:
       os: osx
       # electron-builder requires macOS >=10.13.6 for signing to work.
       osx_image: xcode10.1
-      env:
-        - DESC=macos manager
+      name: Manager macOS
       script:
         - openssl aes-256-cbc -K $encrypted_61a49da75942_key -iv $encrypted_61a49da75942_iv -in macos-signing-certificate.p12.enc -out macos-signing-certificate.p12 -d
         - export CSC_LINK=$(pwd)/macos-signing-certificate.p12

--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
   },
   "scripts": {
     "clean": "rm -rf src/*/node_modules/ build/ node_modules/ src/server_manager/install_scripts/do_install_script.ts",
-    "do": "bash ./scripts/do_action.sh"
+    "do": "bash ./scripts/do_action.sh",
+    "lint": "tslint 'src/**/*.ts' -e '**/node_modules/**'"
   },
   "workspaces": [
     "src/*"
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "yarn tslint --fix 'src/**/*.ts' -e '**/node_modules/**' && yarn git-clang-format && yarn pretty-quick --staged --pattern '**/*.html'"
+      "pre-commit": "yarn run lint && yarn git-clang-format && yarn pretty-quick --staged --pattern '**/*.html'"
     }
   }
 }

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -64,7 +64,7 @@ function ss_arguments_for_user() {
 
 # Runs curl on the client container.
 function client_curl() {
-  docker exec $CLIENT_CONTAINER curl --silent --show-error --connect-timeout 5 "$@"
+  docker exec $CLIENT_CONTAINER curl --silent --show-error --connect-timeout 5 --retry 5 "$@"
 }
 
 function fail() {

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -74,9 +74,9 @@ function fail() {
 
 function cleanup() {
   status=$?
-  if (($DEBUG != 0)); then
+  if ((DEBUG != 1)); then
     docker-compose --project-name=integrationtest down
-    rm -r ${TMP_STATE_DIR}
+    rm -rf ${TMP_STATE_DIR} || echo "Failed to cleanup files at ${TMP_STATE_DIR}"
   fi
   return $status
 }
@@ -84,13 +84,13 @@ function cleanup() {
 # Start a subprocess for trap
 (
   set -eu
-  (($DEBUG != 0)) && set -x
-
-  # Make the certificate
-  source ../scripts/make_test_certificate.sh /tmp
+  ((DEBUG == 1)) && set -x
 
   # Ensure proper shut down on exit if not in debug mode
   trap "cleanup" EXIT
+
+  # Make the certificate
+  source ../scripts/make_test_certificate.sh /tmp
 
   # Sets everything up
   export SB_API_PREFIX=TestApiPrefix
@@ -105,11 +105,11 @@ function cleanup() {
 
   # Verify that the client cannot access or even resolve the target
   # Exit code 28 for "Connection timed out".
-  docker exec $CLIENT_CONTAINER curl --silent --connect-timeout 1 $TARGET_IP > /dev/null && \
+  docker exec $CLIENT_CONTAINER curl --silent --connect-timeout 5 $TARGET_IP > /dev/null && \
     fail "Client should not have access to target IP" || (($? == 28))
 
   # Exit code 6 for "Could not resolve host".
-  docker exec $CLIENT_CONTAINER curl --silent --connect-timeout 1 http://target > /dev/null && \
+  docker exec $CLIENT_CONTAINER curl --silent --connect-timeout 5 http://target > /dev/null && \
     fail "Client should not have access to target host" || (($? == 6))
 
   # Wait for shadowbox to come up.
@@ -148,7 +148,7 @@ function cleanup() {
   # Verify we can't access the URL anymore after the key is deleted
   client_curl --insecure -X DELETE ${SB_API_URL}/access-keys/0 > /dev/null
   # Exit code 56 is "Connection reset by peer".
-  client_curl -x socks5h://localhost:$LOCAL_SOCKS_PORT --connect-timeout 1 $INTERNET_TARGET_URL &> /dev/null \
+  client_curl -x socks5h://localhost:$LOCAL_SOCKS_PORT --connect-timeout 5 $INTERNET_TARGET_URL &> /dev/null \
     && fail "Deleted access key is still active" || (($? == 56))
 
   # Verify that we can change the port for new access keys

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -64,7 +64,7 @@ function ss_arguments_for_user() {
 
 # Runs curl on the client container.
 function client_curl() {
-  docker exec $CLIENT_CONTAINER curl --silent --show-error "$@"
+  docker exec $CLIENT_CONTAINER curl --silent --show-error --connect-timeout 5 "$@"
 }
 
 function fail() {
@@ -148,7 +148,7 @@ function cleanup() {
   # Verify we can't access the URL anymore after the key is deleted
   client_curl --insecure -X DELETE ${SB_API_URL}/access-keys/0 > /dev/null
   # Exit code 56 is "Connection reset by peer".
-  client_curl -x socks5h://localhost:$LOCAL_SOCKS_PORT --connect-timeout 5 $INTERNET_TARGET_URL &> /dev/null \
+  client_curl -x socks5h://localhost:$LOCAL_SOCKS_PORT $INTERNET_TARGET_URL &> /dev/null \
     && fail "Deleted access key is still active" || (($? == 56))
 
   # Verify that we can change the port for new access keys

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -130,7 +130,7 @@ function cleanup() {
   # Start Shadowsocks client and wait for it to be ready
   declare -r LOCAL_SOCKS_PORT=5555
   docker exec -d $CLIENT_CONTAINER \
-    /go/bin/go-shadowsocks2 $SS_USER_ARGUMENTS -socks :$LOCAL_SOCKS_PORT -verbose \
+    /go/bin/go-shadowsocks2 $SS_USER_ARGUMENTS -socks localhost:$LOCAL_SOCKS_PORT -verbose \
     || fail "Could not start shadowsocks client"
   while ! docker exec $CLIENT_CONTAINER nc -z localhost $LOCAL_SOCKS_PORT; do
     sleep 0.1


### PR DESCRIPTION
A few tweaks to Travis:

- Use `server-` tags instead of `daily-`. This clarifies it's the server, and I want to use that for releases (e.g. `server-v1.2.3`).
- Clarify stage names
- Merge unit and integration tests into a single Test stage to run in parallel
- Use job names instead of env var

This also fixes the docker cleanup and the flakiness of the integration test

cc: @mpmcroy 