### PR TITLE
Use more accurate language for trusting certificates

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -222,9 +222,9 @@ function main() {
     }
   });
 
-  // Handle cert whitelisting requests from the renderer process.
+  // Handle request to trust the certificate from the renderer process.
   const trustedFingerprints = new Set<string>();
-  ipcMain.on('whitelist-certificate', (event: IpcEvent, fingerprint: string) => {
+  ipcMain.on('trust-certificate', (event: IpcEvent, fingerprint: string) => {
     trustedFingerprints.add(`sha256/${fingerprint}`);
     event.returnValue = true;
   });

--- a/src/server_manager/electron_app/preload.ts
+++ b/src/server_manager/electron_app/preload.ts
@@ -47,8 +47,8 @@ if (sentryDsn) {
 }
 
 // tslint:disable-next-line:no-any
-(window as any).whitelistCertificate = (fingerprint: string) => {
-  return ipcRenderer.sendSync('whitelist-certificate', fingerprint);
+(window as any).trustCertificate = (fingerprint: string) => {
+  return ipcRenderer.sendSync('trust-certificate', fingerprint);
 };
 
 // tslint:disable-next-line:no-any

--- a/src/server_manager/types/preload.d.ts
+++ b/src/server_manager/types/preload.d.ts
@@ -14,7 +14,7 @@
 
 // Functions made available to the renderer process via preload.ts.
 
-declare function whitelistCertificate(fingerprint: string): boolean;
+declare function trustCertificate(fingerprint: string): boolean;
 declare function openImage(basename: string): void;
 declare function onUpdateDownloaded(callback: () => void): void;
 

--- a/src/server_manager/web_app/browser_main.ts
+++ b/src/server_manager/web_app/browser_main.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // tslint:disable-next-line:no-any
-(window as any).whitelistCertificate = (fingerprint: string) => {
-  console.log(`Requested whitelisting of certificate with fingerprint ${fingerprint}`);
+(window as any).trustCertificate = (fingerprint: string) => {
+  console.log(`Requested to trust certificate with fingerprint ${fingerprint}`);
 };
 
 // tslint:disable-next-line:no-any

--- a/src/server_manager/web_app/digitalocean_server.ts
+++ b/src/server_manager/web_app/digitalocean_server.ts
@@ -189,7 +189,7 @@ class DigitaloceanServer extends ShadowboxServer implements server.ManagedServer
       const certificateFingerprint = this.getCertificateFingerprint();
       const apiAddress = this.getManagementApiAddress();
       // Loaded both the cert and url without exceptions, they can be set.
-      whitelistCertificate(certificateFingerprint);
+      trustCertificate(certificateFingerprint);
       this.setManagementApiUrl(apiAddress);
       return true;
     } catch (e) {

--- a/src/server_manager/web_app/manual_server.ts
+++ b/src/server_manager/web_app/manual_server.ts
@@ -26,10 +26,10 @@ class ManualServer extends ShadowboxServer implements server.ManualServer {
     // Electron requires that this be decoded from hex (to unprintable binary),
     // then encoded as base64.
     try {
-      whitelistCertificate(btoa(hexToString(manualServerConfig.certSha256)));
+      trustCertificate(btoa(hexToString(manualServerConfig.certSha256)));
     } catch (e) {
-      // Error whitelisting certificate, may be due to bad user input.
-      console.error('Error whitelisting certificate');
+      // Error trusting certificate, may be due to bad user input.
+      console.error('Error trusting certificate');
     }
   }
 


### PR DESCRIPTION
Use "trust certificate" instead of "whitelist certificate". "Trust" has the right semantics. 

Certificates don't have colors, so putting them in a list of white certificates doesn't make sense, unless we rely on a racist assumption that "white is good/trusted" and "black is bad/not trusted".