### PR TITLE
Sets flex-grow on access key name element

### DIFF
--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -286,6 +286,7 @@ export class ServerView extends DirMixin(PolymerElement) {
         display: flex;
         flex-direction: column;
         font-weight: 500;
+        flex: 1;
       }
       input.access-key-name {
         font-family: inherit;


### PR DESCRIPTION
Sets flex-grow on access key name element to take up available space

<img width="912" alt="Screen Shot 2020-06-15 at 6 34 50 PM" src="https://user-images.githubusercontent.com/1009390/84712567-ef883f80-af36-11ea-9ad6-e9e2a1301157.png">
