### PR TITLE
Use the non-deprecated Buffer factory function

### DIFF
--- a/src/server_manager/install_scripts/build_install_script_ts.node.js
+++ b/src/server_manager/install_scripts/build_install_script_ts.node.js
@@ -15,10 +15,9 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 
 const tarballBinary = fs.readFileSync(process.argv[2]);
-const base64Tarball = new Buffer(tarballBinary).toString('base64');
+const base64Tarball = Buffer.from(tarballBinary).toString('base64');
 const scriptText = `
 (base64 --decode | tar --extract --gzip ) <<EOM
 ${base64Tarball}


### PR DESCRIPTION
We don't run into any of the security issues associated with `new Buffer()`, which mostly involve uninitialized memory, but this will hopefully clean up our build output a little bit.

Tested:
  Installed a server