### PR TITLE
Outline Region Picker refactor

### DIFF
--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -20,13 +20,13 @@ import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as errors from '../infrastructure/errors';
 import {sleep} from '../infrastructure/sleep';
 import * as server from '../model/server';
-import {Location} from './ui_components/outline-region-picker-step';
 
 import {TokenManager} from './digitalocean_oauth';
 import * as digitalocean_server from './digitalocean_server';
 import {DisplayServer, DisplayServerRepository, makeDisplayServer} from './display_server';
 import {parseManualServerConfig} from './management_urls';
 import {AppRoot} from './ui_components/app-root.js';
+import {Location} from './ui_components/outline-region-picker-step';
 import {DisplayAccessKey, DisplayDataAmount, ServerView} from './ui_components/outline-server-view.js';
 
 // The Outline DigitalOcean team's referral code:

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -1258,10 +1258,9 @@ export class App {
 
   private createLocationModel(cityId: string, regionIds: string[]): Location {
     return {
-      id: cityId,
+      id: regionIds[0],
       name: this.appRoot.localize(`city-${cityId}`),
       flag: DIGITALOCEAN_FLAG_MAPPING[cityId] || '',
-      locationId: regionIds[0],
       available: regionIds.length > 0,
     };
   }

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -20,15 +20,14 @@ import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as errors from '../infrastructure/errors';
 import {sleep} from '../infrastructure/sleep';
 import * as server from '../model/server';
+import {RegionId} from '../model/server';
 
 import {TokenManager} from './digitalocean_oauth';
 import * as digitalocean_server from './digitalocean_server';
 import {DisplayServer, DisplayServerRepository, makeDisplayServer} from './display_server';
 import {parseManualServerConfig} from './management_urls';
-
 import {AppRoot} from './ui_components/app-root.js';
 import {DisplayAccessKey, DisplayDataAmount, ServerView} from './ui_components/outline-server-view.js';
-import {RegionId} from "../model/server";
 
 // The Outline DigitalOcean team's referral code:
 //   https://www.digitalocean.com/help/referral-program/

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -20,7 +20,7 @@ import * as digitalocean_api from '../cloud/digitalocean_api';
 import * as errors from '../infrastructure/errors';
 import {sleep} from '../infrastructure/sleep';
 import * as server from '../model/server';
-import {RegionId} from '../model/server';
+import {Location} from './ui_components/outline-region-picker-step';
 
 import {TokenManager} from './digitalocean_oauth';
 import * as digitalocean_server from './digitalocean_server';
@@ -37,6 +37,19 @@ const CHANGE_KEYS_PORT_VERSION = '1.0.0';
 const DATA_LIMITS_VERSION = '1.1.0';
 const CHANGE_HOSTNAME_VERSION = '1.2.0';
 const MAX_ACCESS_KEY_DATA_LIMIT_BYTES = 50 * (10 ** 9);  // 50GB
+
+// DigitalOcean mapping of regions to flags
+const FLAG_IMAGE_DIR = 'images/flags';
+const DIGITALOCEAN_FLAG_MAPPING: {[cityId: string]: string} = {
+  ams: `${FLAG_IMAGE_DIR}/netherlands.png`,
+  sgp: `${FLAG_IMAGE_DIR}/singapore.png`,
+  blr: `${FLAG_IMAGE_DIR}/india.png`,
+  fra: `${FLAG_IMAGE_DIR}/germany.png`,
+  lon: `${FLAG_IMAGE_DIR}/uk.png`,
+  sfo: `${FLAG_IMAGE_DIR}/us.png`,
+  tor: `${FLAG_IMAGE_DIR}/canada.png`,
+  nyc: `${FLAG_IMAGE_DIR}/us.png`,
+};
 
 function dataLimitToDisplayDataAmount(limit: server.DataLimit): DisplayDataAmount|null {
   if (!limit) {
@@ -724,42 +737,16 @@ export class App {
         })
         .then(
             (map) => {
-              // // Change from a list of regions per location to just one region per location.
-              // // Where there are multiple working regions in one location, arbitrarily use the
-              // // first.
-              // const availableRegionIds: {[cityId: string]: server.RegionId} = {};
-              // for (const cityId in map) {
-              //   if (map[cityId].length > 0) {
-              //     availableRegionIds[cityId] = map[cityId][0];
-              //   }
-              // }
-              // regionPicker.availableRegionIds = availableRegionIds;
-
-              const FLAG_IMAGE_DIR = 'images/flags';
-              const flagByCityId: {[cityId: string]: string} = {
-                ams: `${FLAG_IMAGE_DIR}/netherlands.png`,
-                sgp: `${FLAG_IMAGE_DIR}/singapore.png`,
-                blr: `${FLAG_IMAGE_DIR}/india.png`,
-                fra: `${FLAG_IMAGE_DIR}/germany.png`,
-                lon: `${FLAG_IMAGE_DIR}/uk.png`,
-                sfo: `${FLAG_IMAGE_DIR}/us.png`,
-                tor: `${FLAG_IMAGE_DIR}/canada.png`,
-                nyc: `${FLAG_IMAGE_DIR}/us.png`,
-              };
-
-              console.log(JSON.stringify(map));
-              const locations: Array<{}> = [];
+              const locations: Location[] = [];
               Object.entries(map).forEach(([cityId, regionIds]) => {
                 locations.push({
                   id: cityId,
                   name: this.appRoot.localize(`city-${cityId}`),
-                  flag: flagByCityId[cityId] || '',
+                  flag: DIGITALOCEAN_FLAG_MAPPING[cityId] || '',
                   locationId: regionIds[0],
                   available: regionIds.length > 0,
                 });
               });
-
-              console.log(JSON.stringify(locations));
               regionPicker.locations = locations;
             },
             (e) => {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -737,15 +737,8 @@ export class App {
         })
         .then(
             (map) => {
-              const locations: Location[] = [];
-              Object.entries(map).forEach(([cityId, regionIds]) => {
-                locations.push({
-                  id: cityId,
-                  name: this.appRoot.localize(`city-${cityId}`),
-                  flag: DIGITALOCEAN_FLAG_MAPPING[cityId] || '',
-                  locationId: regionIds[0],
-                  available: regionIds.length > 0,
-                });
+              const locations = Object.entries(map).map(([cityId, regionIds]) => {
+                return this.createLocationModel(cityId, regionIds);
               });
               regionPicker.locations = locations;
             },
@@ -1261,5 +1254,15 @@ export class App {
     this.appRoot.setLanguage(languageCode, languageDir);
     document.documentElement.setAttribute('dir', languageDir);
     window.localStorage.setItem('overrideLanguage', languageCode);
+  }
+
+  private createLocationModel(cityId: string, regionIds: string[]): Location {
+    return {
+      id: cityId,
+      name: this.appRoot.localize(`city-${cityId}`),
+      flag: DIGITALOCEAN_FLAG_MAPPING[cityId] || '',
+      locationId: regionIds[0],
+      available: regionIds.length > 0,
+    };
   }
 }

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -28,6 +28,7 @@ import {parseManualServerConfig} from './management_urls';
 
 import {AppRoot} from './ui_components/app-root.js';
 import {DisplayAccessKey, DisplayDataAmount, ServerView} from './ui_components/outline-server-view.js';
+import {RegionId} from "../model/server";
 
 // The Outline DigitalOcean team's referral code:
 //   https://www.digitalocean.com/help/referral-program/
@@ -724,16 +725,43 @@ export class App {
         })
         .then(
             (map) => {
-              // Change from a list of regions per location to just one region per location.
-              // Where there are multiple working regions in one location, arbitrarily use the
-              // first.
-              const availableRegionIds: {[cityId: string]: server.RegionId} = {};
-              for (const cityId in map) {
-                if (map[cityId].length > 0) {
-                  availableRegionIds[cityId] = map[cityId][0];
-                }
-              }
-              regionPicker.availableRegionIds = availableRegionIds;
+              // // Change from a list of regions per location to just one region per location.
+              // // Where there are multiple working regions in one location, arbitrarily use the
+              // // first.
+              // const availableRegionIds: {[cityId: string]: server.RegionId} = {};
+              // for (const cityId in map) {
+              //   if (map[cityId].length > 0) {
+              //     availableRegionIds[cityId] = map[cityId][0];
+              //   }
+              // }
+              // regionPicker.availableRegionIds = availableRegionIds;
+
+              const FLAG_IMAGE_DIR = 'images/flags';
+              const flagByCityId: {[cityId: string]: string} = {
+                ams: `${FLAG_IMAGE_DIR}/netherlands.png`,
+                sgp: `${FLAG_IMAGE_DIR}/singapore.png`,
+                blr: `${FLAG_IMAGE_DIR}/india.png`,
+                fra: `${FLAG_IMAGE_DIR}/germany.png`,
+                lon: `${FLAG_IMAGE_DIR}/uk.png`,
+                sfo: `${FLAG_IMAGE_DIR}/us.png`,
+                tor: `${FLAG_IMAGE_DIR}/canada.png`,
+                nyc: `${FLAG_IMAGE_DIR}/us.png`,
+              };
+
+              console.log(JSON.stringify(map));
+              const locations: Array<{}> = [];
+              Object.entries(map).forEach(([cityId, regionIds]) => {
+                locations.push({
+                  id: cityId,
+                  name: this.appRoot.localize(`city-${cityId}`),
+                  flag: flagByCityId[cityId] || '',
+                  locationId: regionIds[0],
+                  available: regionIds.length > 0,
+                });
+              });
+
+              console.log(JSON.stringify(locations));
+              regionPicker.locations = locations;
             },
             (e) => {
               console.error(`Failed to get list of available regions: ${e}`);

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -1258,7 +1258,7 @@ export class App {
 
   private createLocationModel(cityId: string, regionIds: string[]): Location {
     return {
-      id: regionIds[0],
+      id: regionIds.length > 0 ? regionIds[0] : null,
       name: this.appRoot.localize(`city-${cityId}`),
       flag: DIGITALOCEAN_FLAG_MAPPING[cityId] || '',
       available: regionIds.length > 0,

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -35,7 +35,7 @@ import './outline-intro-step.js';
 import './outline-language-picker.js';
 import './outline-manual-server-entry.js';
 import './outline-modal-dialog.js';
-import './outline-region-picker-step.js';
+import './outline-region-picker-step';
 import './outline-server-progress-step.js';
 import './outline-tos-view.js';
 

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -590,7 +590,7 @@ export class AppRoot extends mixinBehaviors
 
   getAndShowRegionPicker() {
     this.currentPage = 'regionPicker';
-    this.$.regionPicker.init();
+    this.$.regionPicker.reset();
     return this.$.regionPicker;
   }
 

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -629,7 +629,7 @@ export class AppRoot extends mixinBehaviors
 
   handleRegionSelected(/** @type {Event} */ e) {
     this.fire('SetUpServerRequested', {
-      regionId: this.$.regionPicker.getSelectedRegionId(),
+      regionId: e.detail.selectedRegionId,
     });
   }
 

--- a/src/server_manager/web_app/ui_components/cloud-install-styles.js
+++ b/src/server_manager/web_app/ui_components/cloud-install-styles.js
@@ -18,7 +18,7 @@ import {html} from '@polymer/polymer/lib/utils/html-tag.js';
 
 // Polymer style module to share styles between steps
 // https://polymer-library.polymer-project.org/3.0/docs/devguide/style-shadow-dom#share-styles-between-elements
-const styleElement = document.createElement('dom-module');
+export const styleElement = document.createElement('dom-module');
 styleElement.appendChild(html`
 <style>
   :host {

--- a/src/server_manager/web_app/ui_components/cloud-install-styles.js
+++ b/src/server_manager/web_app/ui_components/cloud-install-styles.js
@@ -15,10 +15,11 @@
 */
 
 import {html} from '@polymer/polymer/lib/utils/html-tag.js';
+import {unsafeCSS} from 'lit-element';
 
 // Polymer style module to share styles between steps
 // https://polymer-library.polymer-project.org/3.0/docs/devguide/style-shadow-dom#share-styles-between-elements
-export const styleElement = document.createElement('dom-module');
+const styleElement = document.createElement('dom-module');
 styleElement.appendChild(html`
 <style>
   :host {
@@ -240,5 +241,8 @@ styleElement.appendChild(html`
     transform: scaleX(-1);
   }
 </style>`);
-
 styleElement.register('cloud-install-styles');
+
+// Shared styles for LitElement components
+const commonStyleCss = styleElement.querySelector('template').content.textContent;
+export const COMMON_STYLES = unsafeCSS(commonStyleCss);

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.js
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.js
@@ -168,8 +168,13 @@ export class OutlineRegionPicker extends PolymerElement {
   }
 
   _handleCreateServerTap() {
-    const selectedLocation = this.locations.find(location => location.id === this.selectedLocationId);
-    const params = {bubbles: true, composed: true, detail: {selectedRegionId: selectedLocation.locationId}};
+    const selectedLocation =
+        this.locations.find(location => location.id === this.selectedLocationId);
+    const params = {
+      bubbles: true,
+      composed: true,
+      detail: {selectedRegionId: selectedLocation.locationId}
+    };
     const customEvent = new CustomEvent('RegionSelected', params);
     this.dispatchEvent(customEvent);
   }

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -18,8 +18,10 @@ import '@polymer/paper-progress/paper-progress';
 import '@polymer/iron-icon/iron-icon';
 import '@polymer/iron-icons/iron-icons';
 import './outline-step-view';
-import {styleElement} from './cloud-install-styles';
+
 import {css, customElement, html, LitElement, property} from 'lit-element';
+
+import {styleElement} from './cloud-install-styles';
 
 export interface Location {
   id: string;
@@ -110,22 +112,28 @@ export class OutlineRegionPicker extends LitElement {
       <span slot="step-title">${this.localize('region-title')}</span>
       <span slot="step-description">${this.localize('region-description')}</span>
       <span slot="step-action">
-        <paper-button id="createServerButton" @tap="${this._handleCreateServerTap}" ?disabled="${!this._isCreateButtonEnabled(this.isServerBeingCreated, this.selectedLocationId)}">
+        <paper-button id="createServerButton" @tap="${this._handleCreateServerTap}" ?disabled="${
+        !this._isCreateButtonEnabled(this.isServerBeingCreated, this.selectedLocationId)}">
           ${this.localize('region-setup')}
         </paper-button>
       </span>
       <div class="card-content" id="cityContainer">
         ${this.locations.map(item => {
-          return html`
-          <input type="radio" id="card-${item.id}" name="${item.id}" ?disabled="${!item.available}" .checked="${this._isLocationSelected(this.selectedLocationId, item.id)}" @tap="${this._locationSelected}">
+      return html`
+          <input type="radio" id="card-${item.id}" name="${item.id}" ?disabled="${
+          !item.available}" .checked="${
+          this._isLocationSelected(
+              this.selectedLocationId, item.id)}" @tap="${this._locationSelected}">
           <label for="card-${item.id}" class="city-button">
-            <iron-icon icon="check-circle" ?hidden="${!this._isLocationSelected(this.selectedLocationId, item.id)}"></iron-icon>
+            <iron-icon icon="check-circle" ?hidden="${
+          !this._isLocationSelected(this.selectedLocationId, item.id)}"></iron-icon>
             <img class="flag" src="${item.flag}">
             <div class="city-name">${item.name}</div>
           </label>`;
-        })}
+    })}
       </div>
-      <paper-progress .hidden="${!this.isServerBeingCreated}" indeterminate="" class="slow"></paper-progress>
+      <paper-progress .hidden="${
+        !this.isServerBeingCreated}" indeterminate="" class="slow"></paper-progress>
     </outline-step-view>
     `;
   }

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -113,7 +113,7 @@ export class OutlineRegionPicker extends LitElement {
       <span slot="step-description">${this.localize('region-description')}</span>
       <span slot="step-action">
         <paper-button id="createServerButton" @tap="${this._handleCreateServerTap}" ?disabled="${
-        !this._isCreateButtonEnabled(this.isServerBeingCreated, this.selectedLocationId)}">
+    !this._isCreateButtonEnabled(this.isServerBeingCreated, this.selectedLocationId)}">
           ${this.localize('region-setup')}
         </paper-button>
       </span>
@@ -121,19 +121,19 @@ export class OutlineRegionPicker extends LitElement {
         ${this.locations.map(item => {
       return html`
           <input type="radio" id="card-${item.id}" name="${item.id}" ?disabled="${
-          !item.available}" .checked="${
-          this._isLocationSelected(
-              this.selectedLocationId, item.id)}" @tap="${this._locationSelected}">
+      !item.available}" .checked="${
+          this._isLocationSelected(this.selectedLocationId,
+                                   item.id)}" @tap="${this._locationSelected}">
           <label for="card-${item.id}" class="city-button">
             <iron-icon icon="check-circle" ?hidden="${
-          !this._isLocationSelected(this.selectedLocationId, item.id)}"></iron-icon>
+      !this._isLocationSelected(this.selectedLocationId, item.id)}"></iron-icon>
             <img class="flag" src="${item.flag}">
             <div class="city-name">${item.name}</div>
           </label>`;
     })}
       </div>
       <paper-progress .hidden="${
-        !this.isServerBeingCreated}" indeterminate="" class="slow"></paper-progress>
+    !this.isServerBeingCreated}" indeterminate="" class="slow"></paper-progress>
     </outline-step-view>
     `;
   }

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -118,7 +118,7 @@ export class OutlineRegionPicker extends LitElement {
       <div class="card-content" id="cityContainer">
         ${this.locations.map(item => {
           return html`
-          <input type="radio" id="card-${item.id}" name="${item.id}" ?disabled="${!item.available}" .checked="${this.selectedLocationId === item.id}" @tap="${this._locationSelected}">
+          <input type="radio" id="card-${item.id}" name="city" value="${item.id}" ?disabled="${!item.available}" .checked="${this.selectedLocationId === item.id}" @change="${this._locationSelected}">
           <label for="card-${item.id}" class="city-button">
             ${this.selectedLocationId === item.id ? html`<iron-icon icon="check-circle"></iron-icon>` : ''}
             <img class="flag" src="${item.flag}">
@@ -142,17 +142,15 @@ export class OutlineRegionPicker extends LitElement {
 
   _locationSelected(event: Event): void {
     const inputEl = event.target as HTMLInputElement;
-    this.selectedLocationId = inputEl.name;
+    this.selectedLocationId = inputEl.value;
   }
 
   _handleCreateServerTap(): void {
     this.isServerBeingCreated = true;
-    const selectedLocation =
-        this.locations.find(location => location.id === this.selectedLocationId);
     const params = {
       bubbles: true,
       composed: true,
-      detail: {selectedRegionId: selectedLocation.id}
+      detail: {selectedRegionId: this.selectedLocationId}
     };
     const customEvent = new CustomEvent('RegionSelected', params);
     this.dispatchEvent(customEvent);

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -112,28 +112,22 @@ export class OutlineRegionPicker extends LitElement {
       <span slot="step-title">${this.localize('region-title')}</span>
       <span slot="step-description">${this.localize('region-description')}</span>
       <span slot="step-action">
-        <paper-button id="createServerButton" @tap="${this._handleCreateServerTap}" ?disabled="${
-    !this._isCreateButtonEnabled(this.isServerBeingCreated, this.selectedLocationId)}">
+        <paper-button id="createServerButton" @tap="${this._handleCreateServerTap}" ?disabled="${!this._isCreateButtonEnabled(this.isServerBeingCreated, this.selectedLocationId)}">
           ${this.localize('region-setup')}
         </paper-button>
       </span>
       <div class="card-content" id="cityContainer">
         ${this.locations.map(item => {
-      return html`
-          <input type="radio" id="card-${item.id}" name="${item.id}" ?disabled="${
-      !item.available}" .checked="${
-          this._isLocationSelected(this.selectedLocationId,
-                                   item.id)}" @tap="${this._locationSelected}">
+          return html`
+          <input type="radio" id="card-${item.id}" name="${item.id}" ?disabled="${!item.available}" .checked="${this._isLocationSelected(this.selectedLocationId, item.id)}" @tap="${this._locationSelected}">
           <label for="card-${item.id}" class="city-button">
-            <iron-icon icon="check-circle" ?hidden="${
-      !this._isLocationSelected(this.selectedLocationId, item.id)}"></iron-icon>
+            <iron-icon icon="check-circle" ?hidden="${!this._isLocationSelected(this.selectedLocationId, item.id)}"></iron-icon>
             <img class="flag" src="${item.flag}">
             <div class="city-name">${item.name}</div>
           </label>`;
-    })}
+        })}
       </div>
-      <paper-progress .hidden="${
-    !this.isServerBeingCreated}" indeterminate="" class="slow"></paper-progress>
+      <paper-progress .hidden="${!this.isServerBeingCreated}" indeterminate="" class="slow"></paper-progress>
     </outline-step-view>
     `;
   }

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -21,7 +21,7 @@ import './outline-step-view';
 
 import {css, customElement, html, LitElement, property, unsafeCSS} from 'lit-element';
 
-import {styleElement} from './cloud-install-styles';
+import {COMMON_STYLES} from './cloud-install-styles';
 
 export interface Location {
   id: string;
@@ -38,9 +38,8 @@ export class OutlineRegionPicker extends LitElement {
   @property({type: Function}) localize: Function;
 
   static get styles() {
-    const styles = styleElement.querySelector('template').content.textContent;
     return css`
-      ${unsafeCSS(styles)}
+      ${COMMON_STYLES}
       input[type="radio"] {
         display: none;
       }

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -38,8 +38,7 @@ export class OutlineRegionPicker extends LitElement {
   @property({type: Function}) localize: Function;
 
   static get styles() {
-    return css`
-      ${COMMON_STYLES}
+    return [COMMON_STYLES, css`
       input[type="radio"] {
         display: none;
       }
@@ -101,7 +100,7 @@ export class OutlineRegionPicker extends LitElement {
         right: 0;
         margin: 6px;
       }
-    `;
+    `];
   }
 
   render() {

--- a/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
+++ b/src/server_manager/web_app/ui_components/outline-region-picker-step.ts
@@ -58,7 +58,6 @@ export class OutlineRegionPicker extends LitElement {
         min-width: calc(25% - 24px);
         position: relative;
         margin: 4px;
-        padding-top: 24px;
         text-align: center;
         border: 1px solid;
         border-color: rgba(0, 0, 0, 0);
@@ -93,12 +92,14 @@ export class OutlineRegionPicker extends LitElement {
         flex-flow: wrap;
         padding-top: 24px;
       }
+      .card-header {
+        height: 24px;
+        display: flex;
+        justify-content: flex-end;
+      }
       iron-icon {
         color: var(--primary-green);
-        position: absolute;
-        top: 0;
-        right: 0;
-        margin: 6px;
+        padding: 6px 6px 0px 6px;
       }
     `];
   }
@@ -118,7 +119,9 @@ export class OutlineRegionPicker extends LitElement {
           return html`
           <input type="radio" id="card-${item.id}" name="city" value="${item.id}" ?disabled="${!item.available}" .checked="${this.selectedLocationId === item.id}" @change="${this._locationSelected}">
           <label for="card-${item.id}" class="city-button">
-            ${this.selectedLocationId === item.id ? html`<iron-icon icon="check-circle"></iron-icon>` : ''}
+            <div class="card-header">
+              ${this.selectedLocationId === item.id ? html`<iron-icon icon="check-circle"></iron-icon>` : ''}
+            </div>
             <img class="flag" src="${item.flag}">
             <div class="city-name">${item.name}</div>
           </label>`;


### PR DESCRIPTION
To get ready for multiple cloud "magic" experiences, this updates the region picker with the following:
* Creates a separate view model for the region picker
* Extracts hardcoded list of DigitalOcean regions/flags
* Removes getSelectedRegionId() as per OpenWC [best practices](https://open-wc.org/developing/best-practices.html#upwards-data)
* Adds [workaround](https://github.com/Polymer/lit-element/issues/100) to include cloud-install-styles
* Small cleanups (e.g. binding to checked property)

Caveats: 
* There's a slight performance regression. The updated region picker lags for ~0.5 seconds before showing the available regions.
* The RTL plugin doesn't run on the LitElement CSS. I updated the region picker css to be bi-directional.

**Original**
<img width="300" alt="original" src="https://user-images.githubusercontent.com/1009390/89314677-f2a2d080-d647-11ea-8a1d-0096d27f3ff9.png">

**Updated (ltr/rtl)**
<img width="300" alt="updated-ltr" src="https://user-images.githubusercontent.com/1009390/89314683-f59dc100-d647-11ea-906b-413d77855d48.png"><img width="300" alt="updated-rtl" src="https://user-images.githubusercontent.com/1009390/89314688-f8001b00-d647-11ea-84c0-1dc696417ad4.png">


