### PR TITLE
Seems to Fix a problem of "mkdir permission denied"

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -197,7 +197,7 @@ function get_random_port {
 
 function create_persisted_state_dir() {
   readonly STATE_DIR="$SHADOWBOX_DIR/persisted-state"
-  mkdir -p --mode=770 "${STATE_DIR}"
+  mkdir -p -m 770 "${STATE_DIR}"
   chmod g+s "${STATE_DIR}"
 }
 


### PR DESCRIPTION
Try run this script on Debian 10, gives error "mkdir: cannot create directory ‘/opt/outline’: Permission denied".
This seems to fix that issue.
`--mode` just does not seems to appear in man page. Maybe this works on another distro but I think `-m` might be more compatiable.