### PR TITLE
Fix for bad/expired DigitalOcean access token issue

### DIFF
--- a/src/server_manager/cloud/digitalocean_api.ts
+++ b/src/server_manager/cloud/digitalocean_api.ts
@@ -220,6 +220,8 @@ class RestApiSession implements DigitalOceanSession {
           // this.response may be empty.
           const responseObj = (xhr.response ? JSON.parse(xhr.response) : {});
           resolve(responseObj);
+        } else if (xhr.status === 401) {
+          reject(new XhrError());
         } else {
           // this.response is a JSON object, whose message is an error string.
           const responseJson = JSON.parse(xhr.response);

--- a/src/server_manager/cloud/digitalocean_api.ts
+++ b/src/server_manager/cloud/digitalocean_api.ts
@@ -221,6 +221,7 @@ class RestApiSession implements DigitalOceanSession {
           const responseObj = (xhr.response ? JSON.parse(xhr.response) : {});
           resolve(responseObj);
         } else if (xhr.status === 401) {
+          console.error('DigitalOcean request failed with Unauthorized error');
           reject(new XhrError());
         } else {
           // this.response is a JSON object, whose message is an error string.


### PR DESCRIPTION
The app is swallowing unauthorized errors (e.g. bad token/expired token) bypassing the connectivity dialog flow. This leaves the user in an unrecoverable state in which they cannot log out or re-login.

This PR catches the 401 error and treats it as a connectivity error, allowing the user to retry or logout.