### PR TITLE
Changes the text on the DO account connectivity dialog 'cancel' button to 'disconnect'

### DIFF
--- a/src/server_manager/cloud/digitalocean_api.ts
+++ b/src/server_manager/cloud/digitalocean_api.ts
@@ -220,6 +220,8 @@ class RestApiSession implements DigitalOceanSession {
           // this.response may be empty.
           const responseObj = (xhr.response ? JSON.parse(xhr.response) : {});
           resolve(responseObj);
+        } else if (xhr.status === 401) {
+          reject(new XhrError());
         } else {
           // this.response is a JSON object, whose message is an error string.
           const responseJson = JSON.parse(xhr.response);

--- a/src/server_manager/cloud/digitalocean_api.ts
+++ b/src/server_manager/cloud/digitalocean_api.ts
@@ -221,6 +221,7 @@ class RestApiSession implements DigitalOceanSession {
           const responseObj = (xhr.response ? JSON.parse(xhr.response) : {});
           resolve(responseObj);
         } else if (xhr.status === 401) {
+          console.error('DigitalOcean request failed with Unauthorized error');
           reject(new XhrError());
         } else {
           // this.response is a JSON object, whose message is an error string.

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -694,7 +694,7 @@ export class AppRoot extends mixinBehaviors
   showConnectivityDialog(cb) {
     const dialogTitle = this.localize('error-connectivity-title');
     const dialogText = this.localize('error-connectivity');
-    this.showModalDialog(dialogTitle, dialogText, [this.localize('cancel'), this.localize('retry')])
+    this.showModalDialog(dialogTitle, dialogText, [this.localize('digitalocean-disconnect'), this.localize('retry')])
         .then(clickedButtonIndex => {
           cb(clickedButtonIndex === 1);  // pass true if user clicked retry
         });


### PR DESCRIPTION
The DigitalOcean account connectivity dialog, which pops up when the app encounters CORS and network errors, has two buttons:
* **CANCEL** - closes the dialog and disconnects the users DigitalOcean account
* **RETRY** - retries the DigitalOcean network request

This PR renames the **CANCEL** button to **DISCONNECT** to make it clear to the user that their DigitalOcean account will be disconnected (_since this is happening without the user knowing_).

Original vs Updated screenshots

<img width="400" alt="Screen Shot 2020-10-07 at 12 42 11 PM" src="https://user-images.githubusercontent.com/1009390/95361319-96a03680-089a-11eb-89ac-dae45a890ba0.png"><img width="400" alt="Screen Shot 2020-10-07 at 12 40 03 PM" src="https://user-images.githubusercontent.com/1009390/95361342-9d2eae00-089a-11eb-9268-ccd5124c51f3.png">
