### PR TITLE
Clean up some code

### DIFF
--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -568,11 +568,12 @@ export class App {
       await this.syncServerToDisplay(server);
       await this.showServerManagement(server, displayServer);
     } else {
-      this.showServerUnreachable(server, displayServer);
+      await this.showServerUnreachable(server, displayServer);
     }
   }
 
-  private showServerUnreachable(server: server.Server, displayServer: DisplayServer) {
+  private async showServerUnreachable(server: server.Server, displayServer: DisplayServer):
+      Promise<void> {
     // Display the unreachable server state within the server view.
     const serverView = this.appRoot.getServerView(displayServer.id) as ServerView;
     serverView.isServerReachable = false;


### PR DESCRIPTION
Some cleanup:
- Converts Promise code to async
- Renames `showServer()` to `showServerManagement()` and `showServerIfHealthy()` to `showServer()`

Borrows from https://github.com/Jigsaw-Code/outline-server/pull/783
More clean up to come, including small product changes. I wanna get rid of `serverBeingCreated`.

/cc @alalamav 