### PR TITLE
Moves the "server progress view" to the "create server" flow

### DIFF
--- a/src/server_manager/web_app/app.spec.ts
+++ b/src/server_manager/web_app/app.spec.ts
@@ -18,7 +18,7 @@ import * as digitalocean_api from '../cloud/digitalocean_api';
 import {sleep} from '../infrastructure/sleep';
 import * as server from '../model/server';
 
-import {App, localServerId} from './app';
+import {App, LAST_DISPLAYED_SERVER_STORAGE_KEY, localServerId} from './app';
 import {TokenManager} from './digitalocean_oauth';
 import {AppRoot} from './ui_components/app-root.js';
 
@@ -121,7 +121,7 @@ describe('App', () => {
     await app.start();
     await app.createDigitalOceanServer('fakeRegion');
     expect(appRoot.currentPage).toEqual('serverView');
-    expect(appRoot.getServerView(appRoot.selectedServerId).currentPage).toEqual('progressView');
+    expect(appRoot.getServerView(appRoot.selectedServerId).selectedPage).toEqual('progressView');
   });
 
   it('shows progress screen when starting with DigitalOcean servers still being created',
@@ -133,10 +133,11 @@ describe('App', () => {
        // Manually create the server since the DO repository server factory function is synchronous.
        const server = await managedSeverRepository.createServer();
        const app = createTestApp(appRoot, tokenManager, null, managedSeverRepository);
-       app.setLastDisplayedServer(server);
+       // Sets last displayed server.
+       localStorage.setItem(LAST_DISPLAYED_SERVER_STORAGE_KEY, localServerId(server));
        await app.start();
        expect(appRoot.currentPage).toEqual('serverView');
-       expect(appRoot.getServerView(appRoot.selectedServerId).currentPage).toEqual('progressView');
+       expect(appRoot.getServerView(appRoot.selectedServerId).selectedPage).toEqual('progressView');
      });
 });
 

--- a/src/server_manager/web_app/app.spec.ts
+++ b/src/server_manager/web_app/app.spec.ts
@@ -18,7 +18,7 @@ import * as digitalocean_api from '../cloud/digitalocean_api';
 import {sleep} from '../infrastructure/sleep';
 import * as server from '../model/server';
 
-import {App} from './app';
+import {App, localServerId} from './app';
 import {TokenManager} from './digitalocean_oauth';
 import {AppRoot} from './ui_components/app-root.js';
 
@@ -32,7 +32,7 @@ const TOKEN_WITH_ONE_SERVER = 'one-server-token';
 // tslint:disable-next-line:no-any
 (global as any).bringToFront = () => {};
 
-// Inject app-root element into DOM once before the test suite runs.
+// Inject app-root element into DOM once before each test.
 beforeEach(() => {
   document.body.innerHTML = "<app-root id='appRoot' language='en'></app-root>";
 });
@@ -120,7 +120,8 @@ describe('App', () => {
     const app = createTestApp(appRoot, tokenManager);
     await app.start();
     await app.createDigitalOceanServer('fakeRegion');
-    expect(appRoot.currentPage).toEqual('serverProgressStep');
+    expect(appRoot.currentPage).toEqual('serverView');
+    expect(appRoot.getServerView(appRoot.selectedServerId).currentPage).toEqual('progressView');
   });
 
   it('shows progress screen when starting with DigitalOcean servers still being created',
@@ -132,10 +133,10 @@ describe('App', () => {
        // Manually create the server since the DO repository server factory function is synchronous.
        const server = await managedSeverRepository.createServer();
        const app = createTestApp(appRoot, tokenManager, null, managedSeverRepository);
-       // Sets last diplayed server.
-       await app.showServer(server);
+       app.setLastDisplayedServer(server);
        await app.start();
-       expect(appRoot.currentPage).toEqual('serverProgressStep');
+       expect(appRoot.currentPage).toEqual('serverView');
+       expect(appRoot.getServerView(appRoot.selectedServerId).currentPage).toEqual('progressView');
      });
 });
 

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -657,19 +657,17 @@ export class App {
     this.selectedServer = server;
     this.appRoot.selectedServerId = serverId;
     localStorage.setItem(LAST_DISPLAYED_SERVER_STORAGE_KEY, serverId);
-
-    if (isManagedServer(server)) {
-      if (!(server as server.ManagedServer).isInstallCompleted()) {
-        this.appRoot.showProgress(this.makeDisplayName(server), true);
-        return;
-      }
-    }
     await this.updateServerView(server);
     this.appRoot.showServerView();
   }
 
   private async updateServerView(server: server.Server): Promise<void> {
-    if (await server.isHealthy()) {
+    if (isManagedServer(server)) {
+      if (!(server as server.ManagedServer).isInstallCompleted()) {
+        const view = this.appRoot.getServerView(localServerId(server));
+        view.currentPage = 'progressView';
+      }
+    } else if (await server.isHealthy()) {
       this.setServerManagementView(server);
     } else {
       this.setServerUnreachableView(server);
@@ -680,7 +678,8 @@ export class App {
   private setServerManagementView(server: server.Server): void {
     // Show view and initialize fields from selectedServer.
     const view = this.appRoot.getServerView(localServerId(server));
-    view.isServerReachable = true;
+    view.currentPage = 'managementView';
+    // view.isServerReachable = true;
     view.serverId = server.getServerId();
     view.serverName = server.getName();
     view.serverHostname = server.getHostnameForAccessKeys();
@@ -739,7 +738,8 @@ export class App {
   private setServerUnreachableView(server: server.Server): void {
     // Display the unreachable server state within the server view.
     const serverView = this.appRoot.getServerView(localServerId(server)) as ServerView;
-    serverView.isServerReachable = false;
+    serverView.currentPage = 'unreachableView';
+    // serverView.isServerReachable = false;
     serverView.isServerManaged = isManagedServer(server);
     serverView.serverName =
         this.makeDisplayName(server);  // Don't get the name from the remote server.

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -662,9 +662,8 @@ export class App {
   }
 
   private async updateServerView(server: server.Server): Promise<void> {
-    if (isManagedServer(server) &&
-        !(server as server.ManagedServer).isInstallCompleted()) {
-      await sleep(1000); // TODO: Wait for view to be initialized.
+    if (isManagedServer(server) && !(server as server.ManagedServer).isInstallCompleted()) {
+      await sleep(1000);  // TODO: Wait for view to be initialized.
       const view = this.appRoot.getServerView(localServerId(server));
       view.selectPage('progressView');
     } else if (await server.isHealthy()) {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -400,13 +400,12 @@ export class App {
     return name;
   }
 
-  private async addServer(server: server.Server): Promise<void> {
+  private addServer(server: server.Server): void {
     console.log('Loading server', server);
     const serverId = localServerId(server);
     this.idServerMap.set(serverId, server);
     const serverEntry = this.makeServerListEntry(server);
     this.appRoot.serverList = this.appRoot.serverList.concat([serverEntry]);
-    await this.appRoot.notifyPath('serverList');
 
     // Once the server is added to the list, do the rest asynchronously.
     setTimeout(async () => {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -423,6 +423,7 @@ export class App {
           this.appRoot.showError(this.appRoot.localize('error-server-creation'));
         }
       }
+      await this.updateServerView(server);
       // This has to run after updateServerView because it depends on the isHealthy() call.
       // TODO(fortuna): Better handle state changes.
       this.updateServerEntry(server);

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -362,7 +362,7 @@ export class App {
       }
       const servers = await this.digitalOceanRepository.listServers();
       for (const server of servers) {
-        await this.addServer(server);
+        this.addServer(server);
       }
       return servers;
     } catch (error) {
@@ -375,7 +375,7 @@ export class App {
 
   private async loadManualServers() {
     for (const server of await this.manualServerRepository.listServers()) {
-      await this.addServer(server);
+      this.addServer(server);
     }
   }
 
@@ -631,7 +631,7 @@ export class App {
       const server = await this.digitalOceanRetry(() => {
         return this.digitalOceanRepository.createServer(regionId, serverName);
       });
-      await this.addServer(server);
+      this.addServer(server);
       await this.showServer(server);
     } catch (error) {
       console.error('Error from createDigitalOceanServer', error);
@@ -976,7 +976,7 @@ export class App {
     }
     const manualServer = await this.manualServerRepository.addServer(serverConfig);
     if (await manualServer.isHealthy()) {
-      await this.addServer(manualServer);
+      this.addServer(manualServer);
       await this.showServer(manualServer);
     } else {
       // Remove inaccessible manual server from local storage if it was just created.

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -662,11 +662,11 @@ export class App {
   }
 
   private async updateServerView(server: server.Server): Promise<void> {
-    if (isManagedServer(server)) {
-      if (!(server as server.ManagedServer).isInstallCompleted()) {
-        const view = this.appRoot.getServerView(localServerId(server));
-        view.currentPage = 'progressView';
-      }
+    if (isManagedServer(server) &&
+        !(server as server.ManagedServer).isInstallCompleted()) {
+      await sleep(1000); // TODO: Wait for view to be initialized.
+      const view = this.appRoot.getServerView(localServerId(server));
+      view.selectPage('progressView');
     } else if (await server.isHealthy()) {
       this.setServerManagementView(server);
     } else {
@@ -678,8 +678,7 @@ export class App {
   private setServerManagementView(server: server.Server): void {
     // Show view and initialize fields from selectedServer.
     const view = this.appRoot.getServerView(localServerId(server));
-    view.currentPage = 'managementView';
-    // view.isServerReachable = true;
+    view.selectPage('managementView');
     view.serverId = server.getServerId();
     view.serverName = server.getName();
     view.serverHostname = server.getHostnameForAccessKeys();
@@ -738,8 +737,7 @@ export class App {
   private setServerUnreachableView(server: server.Server): void {
     // Display the unreachable server state within the server view.
     const serverView = this.appRoot.getServerView(localServerId(server)) as ServerView;
-    serverView.currentPage = 'unreachableView';
-    // serverView.isServerReachable = false;
+    serverView.selectPage('unreachableView');
     serverView.isServerManaged = isManagedServer(server);
     serverView.serverName =
         this.makeDisplayName(server);  // Don't get the name from the remote server.

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -74,7 +74,7 @@ function displayDataAmountToDataLimit(dataAmount: DisplayDataAmount): server.Dat
   return {bytes: dataAmount.value};
 }
 
-function localServerId(server: server.Server): string {
+export function localServerId(server: server.Server): string {
   if (isManagedServer(server)) {
     return (server as server.ManagedServer).getHost().getHostId();
   } else {
@@ -653,12 +653,15 @@ export class App {
   }
 
   public async showServer(server: server.Server): Promise<void> {
-    const serverId = localServerId(server);
     this.selectedServer = server;
-    this.appRoot.selectedServerId = serverId;
-    localStorage.setItem(LAST_DISPLAYED_SERVER_STORAGE_KEY, serverId);
+    this.appRoot.selectedServerId = localServerId(server);
+    this.setLastDisplayedServer(server);
     await this.updateServerView(server);
     this.appRoot.showServerView();
+  }
+
+  setLastDisplayedServer(server: server.Server) {
+    localStorage.setItem(LAST_DISPLAYED_SERVER_STORAGE_KEY, localServerId(server));
   }
 
   private async updateServerView(server: server.Server): Promise<void> {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -411,6 +411,7 @@ export class App {
     setTimeout(async () => {
       // Wait for server config to load, then update the server view and list.
       if (isManagedServer(server) && !server.isInstallCompleted()) {
+        await this.updateServerView(server);
         try {
           await (server as server.ManagedServer).waitOnInstall();
         } catch (error) {
@@ -422,7 +423,6 @@ export class App {
           this.appRoot.showError(this.appRoot.localize('error-server-creation'));
         }
       }
-      await this.updateServerView(server);
       // This has to run after updateServerView because it depends on the isHealthy() call.
       // TODO(fortuna): Better handle state changes.
       this.updateServerEntry(server);

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -36,7 +36,7 @@ import './outline-language-picker.js';
 import './outline-manual-server-entry.js';
 import './outline-modal-dialog.js';
 import './outline-region-picker-step';
-import './outline-server-progress-step.js';
+// import './outline-server-progress-step.js';
 import './outline-tos-view.js';
 
 import {AppLocalizeBehavior} from '@polymer/app-localize-behavior/app-localize-behavior.js';
@@ -417,7 +417,7 @@ export class AppRoot extends mixinBehaviors
               <outline-do-oauth-step id="digitalOceanOauth" localize="[[localize]]"></outline-do-oauth-step>
               <outline-manual-server-entry id="manualEntry" localize="[[localize]]"></outline-manual-server-entry>
               <outline-region-picker-step id="regionPicker" localize="[[localize]]"></outline-region-picker-step>
-              <outline-server-progress-step id="serverProgressStep" localize="[[localize]]"></outline-server-progress-step>
+<!--              <outline-server-progress-step id="serverProgressStep" localize="[[localize]]"></outline-server-progress-step>-->
               <div id="serverView">
                 <template is="dom-repeat" items="{{serverList}}" as="server">
                   <outline-server-view id="serverView-{{_base64Encode(server.id)}}" localize="[[localize]]" hidden\$="{{!_isServerSelected(selectedServerId, server)}}"></outline-server-view>
@@ -605,19 +605,19 @@ export class AppRoot extends mixinBehaviors
     return this.$.manualEntry;
   }
 
-  /**
-   * @param {string} serverName
-   * @param {boolean} showCancelButton
-   */
-  showProgress(serverName, showCancelButton) {
-    this.currentPage = 'serverProgressStep';
-    this.$.serverProgressStep.serverName = serverName;
-    this.$.serverProgressStep.showCancelButton = showCancelButton;
-    this.$.serverProgressStep.start();
-  }
+  // /**
+  //  * @param {string} serverName
+  //  * @param {boolean} showCancelButton
+  //  */
+  // showProgress(serverName, showCancelButton) {
+  //   this.currentPage = 'serverProgressStep';
+  //   this.$.serverProgressStep.serverName = serverName;
+  //   this.$.serverProgressStep.showCancelButton = showCancelButton;
+  //   this.$.serverProgressStep.start();
+  // }
 
   showServerView() {
-    this.$.serverProgressStep.stop();
+    // this.$.serverProgressStep.stop();
     this.currentPage = 'serverView';
   }
 

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -616,6 +616,8 @@ export class AppRoot extends mixinBehaviors
     if (!displayServerId) {
       return null;
     }
+    // Render to ensure that the server view has been added to the DOM.
+    this.$.serverView.querySelector('dom-repeat').render();
     const selectedServerId = this._base64Encode(displayServerId);
     return this.$.serverView.querySelector(`#serverView-${selectedServerId}`);
   }

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -36,7 +36,6 @@ import './outline-language-picker.js';
 import './outline-manual-server-entry.js';
 import './outline-modal-dialog.js';
 import './outline-region-picker-step';
-// import './outline-server-progress-step.js';
 import './outline-tos-view.js';
 
 import {AppLocalizeBehavior} from '@polymer/app-localize-behavior/app-localize-behavior.js';
@@ -417,7 +416,6 @@ export class AppRoot extends mixinBehaviors
               <outline-do-oauth-step id="digitalOceanOauth" localize="[[localize]]"></outline-do-oauth-step>
               <outline-manual-server-entry id="manualEntry" localize="[[localize]]"></outline-manual-server-entry>
               <outline-region-picker-step id="regionPicker" localize="[[localize]]"></outline-region-picker-step>
-<!--              <outline-server-progress-step id="serverProgressStep" localize="[[localize]]"></outline-server-progress-step>-->
               <div id="serverView">
                 <template is="dom-repeat" items="{{serverList}}" as="server">
                   <outline-server-view id="serverView-{{_base64Encode(server.id)}}" localize="[[localize]]" hidden\$="{{!_isServerSelected(selectedServerId, server)}}"></outline-server-view>
@@ -605,19 +603,7 @@ export class AppRoot extends mixinBehaviors
     return this.$.manualEntry;
   }
 
-  // /**
-  //  * @param {string} serverName
-  //  * @param {boolean} showCancelButton
-  //  */
-  // showProgress(serverName, showCancelButton) {
-  //   this.currentPage = 'serverProgressStep';
-  //   this.$.serverProgressStep.serverName = serverName;
-  //   this.$.serverProgressStep.showCancelButton = showCancelButton;
-  //   this.$.serverProgressStep.start();
-  // }
-
   showServerView() {
-    // this.$.serverProgressStep.stop();
     this.currentPage = 'serverView';
   }
 

--- a/src/server_manager/web_app/ui_components/outline-server-progress-step.js
+++ b/src/server_manager/web_app/ui_components/outline-server-progress-step.js
@@ -86,7 +86,7 @@ Polymer({
     localize: Function,
   },
 
-  start: function() {
+  startAnimation: function() {
     if (this.updateIntervalId) {
       this.stop();
     }
@@ -107,7 +107,7 @@ Polymer({
     }, updateInterval * 1000);
   },
 
-  stop: function() {
+  stopAnimation: function() {
     if (!this.updateIntervalId) {
       return;
     }

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -401,174 +401,10 @@ export class ServerView extends DirMixin(PolymerElement) {
     </style>
 
     <div class="container">
-      <iron-pages id="pages" attr-for-selected="id" selected="{{currentPage}}">
-        <outline-server-progress-step id="progressView" localize="[[localize]]"></outline-server-progress-step>
-        <div id="unreachableView">
-          <div class="server-header">
-            <div class="server-name">
-              <h3>[[serverName]]</h3>
-            </div>
-          </div>
-          <div class="card-section unreachable-server"">
-            <img class="server-img" src="images/server-unreachable.png">
-            <h3>[[localize('server-unreachable')]]</h3>
-            <p></p>
-            <div>[[localize('server-unreachable-description')]]</div>
-            <span hidden\$="{{isServerManaged}}">[[localize('server-unreachable-managed-description')]]</span>
-            <span hidden\$="{{!isServerManaged}}">[[localize('server-unreachable-manual-description')]]</span>
-            <div class="button-container">
-              <paper-button on-tap="removeServer" hidden\$="{{isServerManaged}}">[[localize('server-remove')]]</paper-button>
-              <paper-button on-tap="destroyServer" hidden\$="{{!isServerManaged}}">[[localize('server-destroy')]]</paper-button>
-              <paper-button on-tap="retryDisplayingServer" class="try-again-btn">[[localize('retry')]]</paper-button>
-            </div>
-          </div>
-        </div>
-        <div id="managementView">
-          <div class="server-header">
-            <div class="server-name">
-              <h3>[[serverName]]</h3>
-              <paper-menu-button horizontal-align="right" class="overflow-menu flex-1" close-on-activate="" no-animations="" dynamic-align="" no-overlap="">
-                <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
-                <paper-listbox slot="dropdown-content">
-                  <paper-item hidden\$="[[!isServerManaged]]" on-tap="destroyServer">
-                    <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-destroy')]]
-                  </paper-item>
-                  <paper-item hidden\$="[[isServerManaged]]" on-tap="removeServer">
-                    <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-remove')]]
-                  </paper-item>
-                </paper-listbox>
-              </paper-menu-button>
-            </div>
-            <div class="server-location">[[serverLocation]]</div>
-          </div>
-          <div class="tabs-container">
-            <div class="tabs-spacer"></div>
-            <paper-tabs selected="{{selectedTab}}" attr-for-selected="name" noink="">
-              <paper-tab name="connections">[[localize('server-connections')]]</paper-tab>
-              <paper-tab name="settings" id="settingsTab">[[localize('server-settings')]]</paper-tab>
-            </paper-tabs>
-          </div> 
-          <iron-pages selected="{{selectedTab}}" attr-for-selected="name">
-            <div name="connections">
-              <div class="stats-container">
-                <div class="stats-card transfer-stats card-section">
-                  <iron-icon icon="icons:swap-horiz"></iron-icon>
-                  <div class="stats">
-                    <h3>[[_getFormattedTransferredValue(totalInboundBytes, '0')]]</h3>
-                    <p>[[_getFormattedTransferredUnit(totalInboundBytes, 'B')]]</p>
-                  </div>
-                  <p>[[localize('server-data-transfer')]]</p>
-                </div>
-                <div hidden\$="[[!isServerManaged]]" class="stats-card card-section">
-                  <div>
-                    <img class="digital-ocean-icon" src="images/do_white_logo.svg">
-                  </div>
-                  <div class="stats">
-                    <h3>[[managedServerUtilzationPercentage]]</h3>
-                    <p>/[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]</p>
-                  </div>
-                  <p>[[localize('server-data-used')]]</p>
-                </div>
-                <div class="stats-card card-section">
-                  <iron-icon icon="outline-iconset:key"></iron-icon>
-                  <div class="stats">
-                    <h3>[[accessKeyRows.length]]</h3>
-                    <p>[[localize('server-keys')]]</p>
-                  </div>
-                  <p>[[localize('server-access')]]</p>
-                </div>
-              </div>
-    
-              <div class="access-key-list card-section">
-                <!-- header row -->
-                <div class="access-key-row header-row">
-                  <outline-sort-span class="access-key-container"
-                      direction="[[_computeColumnDirection('name', accessKeySortBy, accessKeySortDirection)]]"
-                      on-tap="_setSortByOrToggleDirection" data-sort-by="name">
-                    [[localize('server-access-keys')]]
-                  </outline-sort-span>
-                  <outline-sort-span class="measurement-container"
-                      direction="[[_computeColumnDirection('usage', accessKeySortBy, accessKeySortDirection)]]"
-                      on-tap="_setSortByOrToggleDirection" data-sort-by="usage">
-                    [[localize('server-usage')]]
-                  </outline-sort-span>
-                  <span class="flex-1 header-row-spacer"></span>
-                </div>
-                <!-- admin row -->
-                <div class="access-key-row" id="managerRow">
-                  <span class="access-key-container">
-                    <img class="manager-access-key-icon access-key-icon" src="images/manager-key-avatar.svg">
-                    <div class="access-key-name">
-                      <div>[[localize('server-my-access-key')]]</div>
-                      <div id="manager-access-key-description">[[localize('server-connect-devices')]]</div>
-                    </div>
-                  </span>
-                  <span class="measurement-container">
-                    <span class="measurement">[[_formatBytesTransferred(myConnection.transferredBytes, "...")]]</span>
-                    <paper-progress value="[[myConnection.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
-                    <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
-                      [[_getDataLimitsUsageString(myConnection)]]
-                    </paper-tooltip>
-                  </span>
-                  <span class="actions">
-                    <span class="flex-1">
-                      <paper-icon-button icon="outline-iconset:devices" class="connect-button" on-tap="_handleConnectPressed"></paper-icon-button>
-                    </span>
-                    <span class="overflow-menu flex-1"></span>
-                  </span>
-                </div>
-                <div id="accessKeysContainer">
-                  <!-- rows for each access key -->
-                  <template is="dom-repeat" items="{{accessKeyRows}}" filter="isRegularConnection" sort="{{_sortAccessKeys(accessKeySortBy, accessKeySortDirection)}}" observe="name transferredBytes">
-                    <!-- TODO(alalama): why is observe not responding to rename? -->
-                    <div class="access-key-row">
-                      <span class="access-key-container">
-                        <img class="access-key-icon" src="images/key-avatar.svg">
-                        <input type="text" class="access-key-name" id\$="access-key-[[item.id]]" placeholder="{{item.placeholderName}}" value="[[item.name]]" on-blur="_handleNameInputBlur" on-keydown="_handleNameInputKeyDown">
-                      </span>
-                      <span class="measurement-container">
-                        <span class="measurement">[[_formatBytesTransferred(item.transferredBytes, "...")]]</span>
-                        <paper-progress value="[[item.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
-                        <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
-                          [[_getDataLimitsUsageString(item)]]
-                        </paper-tooltip>
-                      </span>
-                      <span class="actions">
-                        <span class="flex-1">
-                          <paper-icon-button icon="outline-iconset:share" class="share-button" on-tap="_handleShareCodePressed"></paper-icon-button>
-                        </span>
-                        <span class="flex-1">
-                          <paper-menu-button horizontal-align="right" class="overflow-menu" close-on-activate="" no-animations="" no-overlap="" dynamic-align="">
-                            <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
-                            <paper-listbox slot="dropdown-content">
-                              <paper-item on-tap="_handleRenameAccessKeyPressed">
-                                <iron-icon icon="icons:create"></iron-icon>[[localize('server-access-key-rename')]]
-                              </paper-item>
-                              <paper-item on-tap="_handleRemoveAccessKeyPressed">
-                                <iron-icon icon="icons:delete"></iron-icon>[[localize('remove')]]
-                              </paper-item>
-                            </paper-listbox>
-                          </paper-menu-button>
-                        </span>
-                      </span>
-                    </div>
-                  </template>
-                </div>
-                <!-- add key button -->
-                <div class="access-key-row" id="addAccessKeyRow">
-                  <span class="access-key-container">
-                    <paper-icon-button icon="icons:add" on-tap="_handleAddAccessKeyPressed" id="addAccessKeyButton" class="access-key-icon"></paper-icon-button>
-                    <div class="add-new-key" on-tap="_handleAddAccessKeyPressed">[[localize('server-access-key-new')]]</div>
-                  </span>
-                </div>
-              </div>
-            </div>
-            <div name="settings">
-              <outline-server-settings id="serverSettings" server-id="[[serverId]]" server-hostname="[[serverHostname]]" server-name="[[serverName]]" server-version="[[serverVersion]]" is-hostname-editable="[[isHostnameEditable]]" server-management-api-url="[[serverManagementApiUrl]]" server-port-for-new-access-keys="[[serverPortForNewAccessKeys]]" is-access-key-port-editable="[[isAccessKeyPortEditable]]" access-key-data-limit="{{accessKeyDataLimit}}" is-access-key-data-limit-enabled="{{isAccessKeyDataLimitEnabled}}" supports-access-key-data-limit="[[supportsAccessKeyDataLimit]]" show-feature-metrics-disclaimer="[[showFeatureMetricsDisclaimer]]" server-creation-date="[[serverCreationDate]]" server-monthly-cost="[[monthlyCost]]" server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]" is-server-managed="[[isServerManaged]]" server-location="[[serverLocation]]" metrics-enabled="[[metricsEnabled]]" localize="[[localize]]">
-              </outline-server-settings>
-            </div>
-          </iron-pages>
-        </div>
+      <iron-pages id="pages" attr-for-selected="id" selected="[[selectedPage]]" on-selected-changed="_selectedPageChanged">
+        <outline-server-progress-step id="progressView" server-name="[[serverName]]" localize="[[localize]]"></outline-server-progress-step>
+        <div id="unreachableView">${this.unreachableViewTemplate}</div>
+        <div id="managementView">${this.managementViewTemplate}</div>
       </iron-pages>
     </div>
 
@@ -576,23 +412,193 @@ export class ServerView extends DirMixin(PolymerElement) {
       <img src="images/connect-tip-2x.png">
       <h3>[[localize('server-help-connection-title')]]</h3>
       <p>[[localize('server-help-connection-description')]]</p>
-      <paper-button on-tap="closeGetConnectedHelpBubble">[[localize('server-help-connection-ok')]]</paper-button>
+      <paper-button on-tap="_closeGetConnectedHelpBubble">[[localize('server-help-connection-ok')]]</paper-button>
     </outline-help-bubble>
     <outline-help-bubble id="addAccessKeyHelpBubble" vertical-align="bottom" horizontal-align="left">
       <img src="images/key-tip-2x.png">
       <h3>[[localize('server-help-access-key-title')]]</h3>
       <p>[[localize('server-help-access-key-description')]]</p>
-      <paper-button on-tap="closeAddAccessKeyHelpBubble">[[localize('server-help-access-key-next')]]</paper-button>
+      <paper-button on-tap="_closeAddAccessKeyHelpBubble">[[localize('server-help-access-key-next')]]</paper-button>
     </outline-help-bubble>
     <outline-help-bubble id="dataLimitsHelpBubble" vertical-align="top" horizontal-align="right">
       <h3>[[localize('data-limits-dialog-title')]]</h3>
       <p>[[localize('data-limits-dialog-text')]]</p>
-      <paper-button on-tap="closeDataLimitsHelpBubble">[[localize('ok')]]</paper-button>
+      <paper-button on-tap="_closeDataLimitsHelpBubble">[[localize('ok')]]</paper-button>
     </outline-help-bubble>
     `;
     }
 
-    static get is() {
+  static get unreachableViewTemplate() {
+    return html`
+      <div class="server-header">
+        <div class="server-name">
+          <h3>[[serverName]]</h3>
+        </div>
+      </div>
+      <div class="card-section unreachable-server"">
+        <img class="server-img" src="images/server-unreachable.png">
+        <h3>[[localize('server-unreachable')]]</h3>
+        <p></p>
+        <div>[[localize('server-unreachable-description')]]</div>
+        <span hidden\$="{{isServerManaged}}">[[localize('server-unreachable-managed-description')]]</span>
+        <span hidden\$="{{!isServerManaged}}">[[localize('server-unreachable-manual-description')]]</span>
+        <div class="button-container">
+          <paper-button on-tap="removeServer" hidden\$="{{isServerManaged}}">[[localize('server-remove')]]</paper-button>
+          <paper-button on-tap="destroyServer" hidden\$="{{!isServerManaged}}">[[localize('server-destroy')]]</paper-button>
+          <paper-button on-tap="retryDisplayingServer" class="try-again-btn">[[localize('retry')]]</paper-button>
+        </div>
+      </div>`;
+  }
+
+  static get managementViewTemplate() {
+    return html`
+      <div class="server-header">
+        <div class="server-name">
+          <h3>[[serverName]]</h3>
+          <paper-menu-button horizontal-align="right" class="overflow-menu flex-1" close-on-activate="" no-animations="" dynamic-align="" no-overlap="">
+            <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
+            <paper-listbox slot="dropdown-content">
+              <paper-item hidden\$="[[!isServerManaged]]" on-tap="destroyServer">
+                <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-destroy')]]
+              </paper-item>
+              <paper-item hidden\$="[[isServerManaged]]" on-tap="removeServer">
+                <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-remove')]]
+              </paper-item>
+            </paper-listbox>
+          </paper-menu-button>
+        </div>
+        <div class="server-location">[[serverLocation]]</div>
+      </div>
+      <div class="tabs-container">
+        <div class="tabs-spacer"></div>
+        <paper-tabs selected="{{selectedTab}}" attr-for-selected="name" noink="">
+          <paper-tab name="connections">[[localize('server-connections')]]</paper-tab>
+          <paper-tab name="settings" id="settingsTab">[[localize('server-settings')]]</paper-tab>
+        </paper-tabs>
+      </div> 
+      <iron-pages selected="[[selectedTab]]" attr-for-selected="name" on-selected-changed="_selectedTabChanged">
+        <div name="connections">
+          <div class="stats-container">
+            <div class="stats-card transfer-stats card-section">
+              <iron-icon icon="icons:swap-horiz"></iron-icon>
+              <div class="stats">
+                <h3>[[_getFormattedTransferredValue(totalInboundBytes, '0')]]</h3>
+                <p>[[_getFormattedTransferredUnit(totalInboundBytes, 'B')]]</p>
+              </div>
+              <p>[[localize('server-data-transfer')]]</p>
+            </div>
+            <div hidden\$="[[!isServerManaged]]" class="stats-card card-section">
+              <div>
+                <img class="digital-ocean-icon" src="images/do_white_logo.svg">
+              </div>
+              <div class="stats">
+                <h3>[[managedServerUtilzationPercentage]]</h3>
+                <p>/[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]</p>
+              </div>
+              <p>[[localize('server-data-used')]]</p>
+            </div>
+            <div class="stats-card card-section">
+              <iron-icon icon="outline-iconset:key"></iron-icon>
+              <div class="stats">
+                <h3>[[accessKeyRows.length]]</h3>
+                <p>[[localize('server-keys')]]</p>
+              </div>
+              <p>[[localize('server-access')]]</p>
+            </div>
+          </div>
+
+          <div class="access-key-list card-section">
+            <!-- header row -->
+            <div class="access-key-row header-row">
+              <outline-sort-span class="access-key-container"
+                  direction="[[_computeColumnDirection('name', accessKeySortBy, accessKeySortDirection)]]"
+                  on-tap="_setSortByOrToggleDirection" data-sort-by="name">
+                [[localize('server-access-keys')]]
+              </outline-sort-span>
+              <outline-sort-span class="measurement-container"
+                  direction="[[_computeColumnDirection('usage', accessKeySortBy, accessKeySortDirection)]]"
+                  on-tap="_setSortByOrToggleDirection" data-sort-by="usage">
+                [[localize('server-usage')]]
+              </outline-sort-span>
+              <span class="flex-1 header-row-spacer"></span>
+            </div>
+            <!-- admin row -->
+            <div class="access-key-row" id="managerRow">
+              <span class="access-key-container">
+                <img class="manager-access-key-icon access-key-icon" src="images/manager-key-avatar.svg">
+                <div class="access-key-name">
+                  <div>[[localize('server-my-access-key')]]</div>
+                  <div id="manager-access-key-description">[[localize('server-connect-devices')]]</div>
+                </div>
+              </span>
+              <span class="measurement-container">
+                <span class="measurement">[[_formatBytesTransferred(myConnection.transferredBytes, "...")]]</span>
+                <paper-progress value="[[myConnection.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
+                <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
+                  [[_getDataLimitsUsageString(myConnection)]]
+                </paper-tooltip>
+              </span>
+              <span class="actions">
+                <span class="flex-1">
+                  <paper-icon-button icon="outline-iconset:devices" class="connect-button" on-tap="_handleConnectPressed"></paper-icon-button>
+                </span>
+                <span class="overflow-menu flex-1"></span>
+              </span>
+            </div>
+            <div id="accessKeysContainer">
+              <!-- rows for each access key -->
+              <template is="dom-repeat" items="{{accessKeyRows}}" filter="isRegularConnection" sort="{{_sortAccessKeys(accessKeySortBy, accessKeySortDirection)}}" observe="name transferredBytes">
+                <!-- TODO(alalama): why is observe not responding to rename? -->
+                <div class="access-key-row">
+                  <span class="access-key-container">
+                    <img class="access-key-icon" src="images/key-avatar.svg">
+                    <input type="text" class="access-key-name" id\$="access-key-[[item.id]]" placeholder="{{item.placeholderName}}" value="[[item.name]]" on-blur="_handleNameInputBlur" on-keydown="_handleNameInputKeyDown">
+                  </span>
+                  <span class="measurement-container">
+                    <span class="measurement">[[_formatBytesTransferred(item.transferredBytes, "...")]]</span>
+                    <paper-progress value="[[item.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
+                    <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
+                      [[_getDataLimitsUsageString(item)]]
+                    </paper-tooltip>
+                  </span>
+                  <span class="actions">
+                    <span class="flex-1">
+                      <paper-icon-button icon="outline-iconset:share" class="share-button" on-tap="_handleShareCodePressed"></paper-icon-button>
+                    </span>
+                    <span class="flex-1">
+                      <paper-menu-button horizontal-align="right" class="overflow-menu" close-on-activate="" no-animations="" no-overlap="" dynamic-align="">
+                        <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
+                        <paper-listbox slot="dropdown-content">
+                          <paper-item on-tap="_handleRenameAccessKeyPressed">
+                            <iron-icon icon="icons:create"></iron-icon>[[localize('server-access-key-rename')]]
+                          </paper-item>
+                          <paper-item on-tap="_handleRemoveAccessKeyPressed">
+                            <iron-icon icon="icons:delete"></iron-icon>[[localize('remove')]]
+                          </paper-item>
+                        </paper-listbox>
+                      </paper-menu-button>
+                    </span>
+                  </span>
+                </div>
+              </template>
+            </div>
+            <!-- add key button -->
+            <div class="access-key-row" id="addAccessKeyRow">
+              <span class="access-key-container">
+                <paper-icon-button icon="icons:add" on-tap="_handleAddAccessKeyPressed" id="addAccessKeyButton" class="access-key-icon"></paper-icon-button>
+                <div class="add-new-key" on-tap="_handleAddAccessKeyPressed">[[localize('server-access-key-new')]]</div>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div name="settings">
+          <outline-server-settings id="serverSettings" server-id="[[serverId]]" server-hostname="[[serverHostname]]" server-name="[[serverName]]" server-version="[[serverVersion]]" is-hostname-editable="[[isHostnameEditable]]" server-management-api-url="[[serverManagementApiUrl]]" server-port-for-new-access-keys="[[serverPortForNewAccessKeys]]" is-access-key-port-editable="[[isAccessKeyPortEditable]]" access-key-data-limit="{{accessKeyDataLimit}}" is-access-key-data-limit-enabled="{{isAccessKeyDataLimitEnabled}}" supports-access-key-data-limit="[[supportsAccessKeyDataLimit]]" show-feature-metrics-disclaimer="[[showFeatureMetricsDisclaimer]]" server-creation-date="[[serverCreationDate]]" server-monthly-cost="[[monthlyCost]]" server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]" is-server-managed="[[isServerManaged]]" server-location="[[serverLocation]]" metrics-enabled="[[metricsEnabled]]" localize="[[localize]]">
+          </outline-server-settings>
+        </div>
+      </iron-pages>`;
+  }
+
+  static get is() {
       return 'outline-server-view';
     }
 
@@ -630,7 +636,7 @@ export class ServerView extends DirMixin(PolymerElement) {
         accessKeySortBy: {type: String},
         accessKeySortDirection: {type: Number},
         localize: {type: Function, readonly: true},
-        currentPage: {type: String, readonly: true},
+        selectedPage: {type: String},
         selectedTab: {type: String},
       };
     }
@@ -639,7 +645,6 @@ export class ServerView extends DirMixin(PolymerElement) {
       return [
         '_accessKeysAddedOrRemoved(accessKeyRows.splices)',
         '_myConnectionChanged(myConnection)',
-        '_selectedTabChanged(selectedTab)',
       ];
     }
 
@@ -696,15 +701,9 @@ export class ServerView extends DirMixin(PolymerElement) {
       this.accessKeySortDirection = 1;
       /** @type {(msgId: string, ...params: string[]) => string} */
       this.localize = null;
-      this.currentPage = '';
+      /** @type {'progressView'|'unreachableView'|'managementView'} */
+      this.selectedPage = 'managementView';
       this.selectedTab = 'connections';
-    }
-
-    selectPage(page) {
-      if (page !== 'progressView') {
-        this.$.progressView.stop();
-      }
-      this.currentPage = page;
     }
 
     /**
@@ -727,6 +726,53 @@ export class ServerView extends DirMixin(PolymerElement) {
         return;
       }
     }
+  }
+
+  setServerTransferredData(totalBytes) {
+    this.totalInboundBytes = totalBytes;
+  }
+
+  updateAccessKeyRow(accessKeyId, fields) {
+    let newAccessKeyRow;
+    if (accessKeyId === MY_CONNECTION_USER_ID) {
+      newAccessKeyRow = Object.assign({}, this.get('myConnection'), fields);
+      this.set('myConnection', newAccessKeyRow);
+    }
+    for (let ui in this.accessKeyRows) {
+      if (this.accessKeyRows[ui].id === accessKeyId) {
+        newAccessKeyRow = Object.assign({}, this.get(['accessKeyRows', ui]), fields);
+        this.set(['accessKeyRows', ui], newAccessKeyRow);
+        return;
+      }
+    }
+  }
+
+  // Help bubbles should be shown after this outline-server-view
+  // is on the screen (e.g. selected in iron-pages). If help bubbles
+  // are initialized before this point, setPosition will not work and
+  // they will appear in the top left of the view.
+  showGetConnectedHelpBubble() {
+    return this._showHelpBubble('getConnectedHelpBubble', 'managerRow');
+  }
+
+  showAddAccessKeyHelpBubble() {
+    return this._showHelpBubble('addAccessKeyHelpBubble', 'addAccessKeyRow', 'down', 'left');
+  }
+
+  showDataLimitsHelpBubble() {
+    return this._showHelpBubble('dataLimitsHelpBubble', 'settingsTab', 'up', 'right');
+  }
+
+  _closeAddAccessKeyHelpBubble() {
+    this.$.addAccessKeyHelpBubble.hide();
+  }
+
+  _closeGetConnectedHelpBubble() {
+    this.$.getConnectedHelpBubble.hide();
+  }
+
+  _closeDataLimitsHelpBubble() {
+    this.$.dataLimitsHelpBubble.hide();
   }
 
   _handleAddAccessKeyPressed() {
@@ -801,25 +847,6 @@ export class ServerView extends DirMixin(PolymerElement) {
     this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {accessKeyId: accessKey.id}));
   }
 
-  setServerTransferredData(totalBytes) {
-    this.totalInboundBytes = totalBytes;
-  }
-
-  updateAccessKeyRow(accessKeyId, fields) {
-    let newAccessKeyRow;
-    if (accessKeyId === MY_CONNECTION_USER_ID) {
-      newAccessKeyRow = Object.assign({}, this.get('myConnection'), fields);
-      this.set('myConnection', newAccessKeyRow);
-    }
-    for (let ui in this.accessKeyRows) {
-      if (this.accessKeyRows[ui].id === accessKeyId) {
-        newAccessKeyRow = Object.assign({}, this.get(['accessKeyRows', ui]), fields);
-        this.set(['accessKeyRows', ui], newAccessKeyRow);
-        return;
-      }
-    }
-  }
-
   _formatBytesTransferred(numBytes, emptyValue = '') {
     if (!numBytes) {
       // numBytes may not be set for manual servers, or may be 0 for
@@ -889,41 +916,21 @@ export class ServerView extends DirMixin(PolymerElement) {
     }
   }
 
-  _selectedTabChanged(selectedTab) {
-    if (this.selectedTab === 'settings') {
-      this.closeAddAccessKeyHelpBubble();
-      this.closeGetConnectedHelpBubble();
-      this.closeDataLimitsHelpBubble();
-      this.$.serverSettings.setServerName(this.serverName);
+  _selectedPageChanged() {
+    if (this.selectedPage === 'progressView') {
+      this.$.progressView.startAnimation();
+    } else {
+      this.$.progressView.stopAnimation();
     }
   }
 
-  // Help bubbles should be shown after this outline-server-view
-  // is on the screen (e.g. selected in iron-pages). If help bubbles
-  // are initialized before this point, setPosition will not work and
-  // they will appear in the top left of the view.
-  showGetConnectedHelpBubble() {
-    return this._showHelpBubble('getConnectedHelpBubble', 'managerRow');
-  }
-
-  showAddAccessKeyHelpBubble() {
-    return this._showHelpBubble('addAccessKeyHelpBubble', 'addAccessKeyRow', 'down', 'left');
-  }
-
-  showDataLimitsHelpBubble() {
-    return this._showHelpBubble('dataLimitsHelpBubble', 'settingsTab', 'up', 'right');
-  }
-
-  closeAddAccessKeyHelpBubble() {
-    this.$.addAccessKeyHelpBubble.hide();
-  }
-
-  closeGetConnectedHelpBubble() {
-    this.$.getConnectedHelpBubble.hide();
-  }
-
-  closeDataLimitsHelpBubble() {
-    this.$.dataLimitsHelpBubble.hide();
+  _selectedTabChanged() {
+    if (this.selectedTab === 'settings') {
+      this._closeAddAccessKeyHelpBubble();
+      this._closeGetConnectedHelpBubble();
+      this._closeDataLimitsHelpBubble();
+      this.$.serverSettings.setServerName(this.serverName);
+    }
   }
 
   _showHelpBubble(

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -29,6 +29,7 @@ import './cloud-install-styles.js';
 import './outline-iconset.js';
 import './outline-help-bubble.js';
 import './outline-metrics-option-dialog.js';
+import './outline-server-progress-step.js';
 import './outline-server-settings.js';
 import './outline-share-dialog.js';
 import './outline-sort-span.js';
@@ -400,164 +401,173 @@ export class ServerView extends DirMixin(PolymerElement) {
     </style>
 
     <div class="container">
-      <div class="server-header">
-        <div class="server-name">
-          <h3>[[serverName]]</h3>
-          <paper-menu-button horizontal-align="right" class="overflow-menu flex-1" hidden\$="{{!isServerReachable}}" close-on-activate="" no-animations="" dynamic-align="" no-overlap="">
-            <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
-            <paper-listbox slot="dropdown-content">
-              <paper-item hidden\$="[[!isServerManaged]]" on-tap="destroyServer">
-                <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-destroy')]]
-              </paper-item>
-              <paper-item hidden\$="[[isServerManaged]]" on-tap="removeServer">
-                <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-remove')]]
-              </paper-item>
-            </paper-listbox>
-          </paper-menu-button>
-        </div>
-        <div class="server-location" hidden\$="{{!isServerReachable}}">[[serverLocation]]</div>
-      </div>
-      <div class="tabs-container" hidden\$="{{!isServerReachable}}">
-        <div class="tabs-spacer"></div>
-        <paper-tabs selected="{{selectedTab}}" attr-for-selected="name" noink="">
-          <paper-tab name="connections">[[localize('server-connections')]]</paper-tab>
-          <paper-tab name="settings" id="settingsTab">[[localize('server-settings')]]</paper-tab>
-        </paper-tabs>
-      </div>
-
-      <!-- Unreachable server display -->
-      <div class="card-section unreachable-server" hidden\$="{{isServerReachable}}">
-        <img class="server-img" src="images/server-unreachable.png">
-        <h3>[[localize('server-unreachable')]]</h3>
-        <p></p>
-        <div>[[localize('server-unreachable-description')]]</div>
-        <span hidden\$="{{isServerManaged}}">[[localize('server-unreachable-managed-description')]]</span>
-        <span hidden\$="{{!isServerManaged}}">[[localize('server-unreachable-manual-description')]]</span>
-        <div class="button-container">
-          <paper-button on-tap="removeServer" hidden\$="{{isServerManaged}}">[[localize('server-remove')]]</paper-button>
-          <paper-button on-tap="destroyServer" hidden\$="{{!isServerManaged}}">[[localize('server-destroy')]]</paper-button>
-          <paper-button on-tap="retryDisplayingServer" class="try-again-btn">[[localize('retry')]]</paper-button>
-        </div>
-      </div>
-
-      <iron-pages selected="{{selectedTab}}" attr-for-selected="name" hidden\$="{{!isServerReachable}}">
-        <div name="connections">
-          <div class="stats-container">
-            <div class="stats-card transfer-stats card-section">
-              <iron-icon icon="icons:swap-horiz"></iron-icon>
-              <div class="stats">
-                <h3>[[_getFormattedTransferredValue(totalInboundBytes, '0')]]</h3>
-                <p>[[_getFormattedTransferredUnit(totalInboundBytes, 'B')]]</p>
-              </div>
-              <p>[[localize('server-data-transfer')]]</p>
-            </div>
-            <div hidden\$="[[!isServerManaged]]" class="stats-card card-section">
-              <div>
-                <img class="digital-ocean-icon" src="images/do_white_logo.svg">
-              </div>
-              <div class="stats">
-                <h3>[[managedServerUtilzationPercentage]]</h3>
-                <p>/[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]</p>
-              </div>
-              <p>[[localize('server-data-used')]]</p>
-            </div>
-            <div class="stats-card card-section">
-              <iron-icon icon="outline-iconset:key"></iron-icon>
-              <div class="stats">
-                <h3>[[accessKeyRows.length]]</h3>
-                <p>[[localize('server-keys')]]</p>
-              </div>
-              <p>[[localize('server-access')]]</p>
+      <iron-pages id="pages" attr-for-selected="id" selected="{{currentPage}}">
+        <outline-server-progress-step id="progressView" localize="[[localize]]"></outline-server-progress-step>
+        <div id="unreachableView">
+          <div class="server-header">
+            <div class="server-name">
+              <h3>[[serverName]]</h3>
             </div>
           </div>
-
-          <div class="access-key-list card-section">
-            <!-- header row -->
-            <div class="access-key-row header-row">
-              <outline-sort-span class="access-key-container"
-                  direction="[[_computeColumnDirection('name', accessKeySortBy, accessKeySortDirection)]]"
-                  on-tap="_setSortByOrToggleDirection" data-sort-by="name">
-                [[localize('server-access-keys')]]
-              </outline-sort-span>
-              <outline-sort-span class="measurement-container"
-                  direction="[[_computeColumnDirection('usage', accessKeySortBy, accessKeySortDirection)]]"
-                  on-tap="_setSortByOrToggleDirection" data-sort-by="usage">
-                [[localize('server-usage')]]
-              </outline-sort-span>
-              <span class="flex-1 header-row-spacer"></span>
+          <div class="card-section unreachable-server"">
+            <img class="server-img" src="images/server-unreachable.png">
+            <h3>[[localize('server-unreachable')]]</h3>
+            <p></p>
+            <div>[[localize('server-unreachable-description')]]</div>
+            <span hidden\$="{{isServerManaged}}">[[localize('server-unreachable-managed-description')]]</span>
+            <span hidden\$="{{!isServerManaged}}">[[localize('server-unreachable-manual-description')]]</span>
+            <div class="button-container">
+              <paper-button on-tap="removeServer" hidden\$="{{isServerManaged}}">[[localize('server-remove')]]</paper-button>
+              <paper-button on-tap="destroyServer" hidden\$="{{!isServerManaged}}">[[localize('server-destroy')]]</paper-button>
+              <paper-button on-tap="retryDisplayingServer" class="try-again-btn">[[localize('retry')]]</paper-button>
             </div>
-            <!-- admin row -->
-            <div class="access-key-row" id="managerRow">
-              <span class="access-key-container">
-                <img class="manager-access-key-icon access-key-icon" src="images/manager-key-avatar.svg">
-                <div class="access-key-name">
-                  <div>[[localize('server-my-access-key')]]</div>
-                  <div id="manager-access-key-description">[[localize('server-connect-devices')]]</div>
+          </div>
+        </div>
+        <div id="managementView">
+          <div class="server-header">
+            <div class="server-name">
+              <h3>[[serverName]]</h3>
+              <paper-menu-button horizontal-align="right" class="overflow-menu flex-1" close-on-activate="" no-animations="" dynamic-align="" no-overlap="">
+                <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
+                <paper-listbox slot="dropdown-content">
+                  <paper-item hidden\$="[[!isServerManaged]]" on-tap="destroyServer">
+                    <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-destroy')]]
+                  </paper-item>
+                  <paper-item hidden\$="[[isServerManaged]]" on-tap="removeServer">
+                    <iron-icon icon="icons:remove-circle-outline"></iron-icon>[[localize('server-remove')]]
+                  </paper-item>
+                </paper-listbox>
+              </paper-menu-button>
+            </div>
+            <div class="server-location">[[serverLocation]]</div>
+          </div>
+          <div class="tabs-container">
+            <div class="tabs-spacer"></div>
+            <paper-tabs selected="{{selectedTab}}" attr-for-selected="name" noink="">
+              <paper-tab name="connections">[[localize('server-connections')]]</paper-tab>
+              <paper-tab name="settings" id="settingsTab">[[localize('server-settings')]]</paper-tab>
+            </paper-tabs>
+          </div> 
+          <iron-pages selected="{{selectedTab}}" attr-for-selected="name">
+            <div name="connections">
+              <div class="stats-container">
+                <div class="stats-card transfer-stats card-section">
+                  <iron-icon icon="icons:swap-horiz"></iron-icon>
+                  <div class="stats">
+                    <h3>[[_getFormattedTransferredValue(totalInboundBytes, '0')]]</h3>
+                    <p>[[_getFormattedTransferredUnit(totalInboundBytes, 'B')]]</p>
+                  </div>
+                  <p>[[localize('server-data-transfer')]]</p>
                 </div>
-              </span>
-              <span class="measurement-container">
-                <span class="measurement">[[_formatBytesTransferred(myConnection.transferredBytes, "...")]]</span>
-                <paper-progress value="[[myConnection.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
-                <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
-                  [[_getDataLimitsUsageString(myConnection)]]
-                </paper-tooltip>
-              </span>
-              <span class="actions">
-                <span class="flex-1">
-                  <paper-icon-button icon="outline-iconset:devices" class="connect-button" on-tap="_handleConnectPressed"></paper-icon-button>
-                </span>
-                <span class="overflow-menu flex-1"></span>
-              </span>
-            </div>
-            <div id="accessKeysContainer">
-              <!-- rows for each access key -->
-              <template is="dom-repeat" items="{{accessKeyRows}}" filter="isRegularConnection" sort="{{_sortAccessKeys(accessKeySortBy, accessKeySortDirection)}}" observe="name transferredBytes">
-                <!-- TODO(alalama): why is observe not responding to rename? -->
-                <div class="access-key-row">
+                <div hidden\$="[[!isServerManaged]]" class="stats-card card-section">
+                  <div>
+                    <img class="digital-ocean-icon" src="images/do_white_logo.svg">
+                  </div>
+                  <div class="stats">
+                    <h3>[[managedServerUtilzationPercentage]]</h3>
+                    <p>/[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]</p>
+                  </div>
+                  <p>[[localize('server-data-used')]]</p>
+                </div>
+                <div class="stats-card card-section">
+                  <iron-icon icon="outline-iconset:key"></iron-icon>
+                  <div class="stats">
+                    <h3>[[accessKeyRows.length]]</h3>
+                    <p>[[localize('server-keys')]]</p>
+                  </div>
+                  <p>[[localize('server-access')]]</p>
+                </div>
+              </div>
+    
+              <div class="access-key-list card-section">
+                <!-- header row -->
+                <div class="access-key-row header-row">
+                  <outline-sort-span class="access-key-container"
+                      direction="[[_computeColumnDirection('name', accessKeySortBy, accessKeySortDirection)]]"
+                      on-tap="_setSortByOrToggleDirection" data-sort-by="name">
+                    [[localize('server-access-keys')]]
+                  </outline-sort-span>
+                  <outline-sort-span class="measurement-container"
+                      direction="[[_computeColumnDirection('usage', accessKeySortBy, accessKeySortDirection)]]"
+                      on-tap="_setSortByOrToggleDirection" data-sort-by="usage">
+                    [[localize('server-usage')]]
+                  </outline-sort-span>
+                  <span class="flex-1 header-row-spacer"></span>
+                </div>
+                <!-- admin row -->
+                <div class="access-key-row" id="managerRow">
                   <span class="access-key-container">
-                    <img class="access-key-icon" src="images/key-avatar.svg">
-                    <input type="text" class="access-key-name" id\$="access-key-[[item.id]]" placeholder="{{item.placeholderName}}" value="[[item.name]]" on-blur="_handleNameInputBlur" on-keydown="_handleNameInputKeyDown">
+                    <img class="manager-access-key-icon access-key-icon" src="images/manager-key-avatar.svg">
+                    <div class="access-key-name">
+                      <div>[[localize('server-my-access-key')]]</div>
+                      <div id="manager-access-key-description">[[localize('server-connect-devices')]]</div>
+                    </div>
                   </span>
                   <span class="measurement-container">
-                    <span class="measurement">[[_formatBytesTransferred(item.transferredBytes, "...")]]</span>
-                    <paper-progress value="[[item.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
+                    <span class="measurement">[[_formatBytesTransferred(myConnection.transferredBytes, "...")]]</span>
+                    <paper-progress value="[[myConnection.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
                     <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
-                      [[_getDataLimitsUsageString(item)]]
+                      [[_getDataLimitsUsageString(myConnection)]]
                     </paper-tooltip>
                   </span>
                   <span class="actions">
                     <span class="flex-1">
-                      <paper-icon-button icon="outline-iconset:share" class="share-button" on-tap="_handleShareCodePressed"></paper-icon-button>
+                      <paper-icon-button icon="outline-iconset:devices" class="connect-button" on-tap="_handleConnectPressed"></paper-icon-button>
                     </span>
-                    <span class="flex-1">
-                      <paper-menu-button horizontal-align="right" class="overflow-menu" close-on-activate="" no-animations="" no-overlap="" dynamic-align="">
-                        <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
-                        <paper-listbox slot="dropdown-content">
-                          <paper-item on-tap="_handleRenameAccessKeyPressed">
-                            <iron-icon icon="icons:create"></iron-icon>[[localize('server-access-key-rename')]]
-                          </paper-item>
-                          <paper-item on-tap="_handleRemoveAccessKeyPressed">
-                            <iron-icon icon="icons:delete"></iron-icon>[[localize('remove')]]
-                          </paper-item>
-                        </paper-listbox>
-                      </paper-menu-button>
-                    </span>
+                    <span class="overflow-menu flex-1"></span>
                   </span>
                 </div>
-              </template>
+                <div id="accessKeysContainer">
+                  <!-- rows for each access key -->
+                  <template is="dom-repeat" items="{{accessKeyRows}}" filter="isRegularConnection" sort="{{_sortAccessKeys(accessKeySortBy, accessKeySortDirection)}}" observe="name transferredBytes">
+                    <!-- TODO(alalama): why is observe not responding to rename? -->
+                    <div class="access-key-row">
+                      <span class="access-key-container">
+                        <img class="access-key-icon" src="images/key-avatar.svg">
+                        <input type="text" class="access-key-name" id\$="access-key-[[item.id]]" placeholder="{{item.placeholderName}}" value="[[item.name]]" on-blur="_handleNameInputBlur" on-keydown="_handleNameInputKeyDown">
+                      </span>
+                      <span class="measurement-container">
+                        <span class="measurement">[[_formatBytesTransferred(item.transferredBytes, "...")]]</span>
+                        <paper-progress value="[[item.relativeTraffic]]" class\$="[[_computePaperProgressClass(isAccessKeyDataLimitEnabled)]]"></paper-progress>
+                        <paper-tooltip animation-delay="0" offset="0" position="top" hidden\$="[[!isAccessKeyDataLimitEnabled]]">
+                          [[_getDataLimitsUsageString(item)]]
+                        </paper-tooltip>
+                      </span>
+                      <span class="actions">
+                        <span class="flex-1">
+                          <paper-icon-button icon="outline-iconset:share" class="share-button" on-tap="_handleShareCodePressed"></paper-icon-button>
+                        </span>
+                        <span class="flex-1">
+                          <paper-menu-button horizontal-align="right" class="overflow-menu" close-on-activate="" no-animations="" no-overlap="" dynamic-align="">
+                            <paper-icon-button icon="more-vert" slot="dropdown-trigger"></paper-icon-button>
+                            <paper-listbox slot="dropdown-content">
+                              <paper-item on-tap="_handleRenameAccessKeyPressed">
+                                <iron-icon icon="icons:create"></iron-icon>[[localize('server-access-key-rename')]]
+                              </paper-item>
+                              <paper-item on-tap="_handleRemoveAccessKeyPressed">
+                                <iron-icon icon="icons:delete"></iron-icon>[[localize('remove')]]
+                              </paper-item>
+                            </paper-listbox>
+                          </paper-menu-button>
+                        </span>
+                      </span>
+                    </div>
+                  </template>
+                </div>
+                <!-- add key button -->
+                <div class="access-key-row" id="addAccessKeyRow">
+                  <span class="access-key-container">
+                    <paper-icon-button icon="icons:add" on-tap="_handleAddAccessKeyPressed" id="addAccessKeyButton" class="access-key-icon"></paper-icon-button>
+                    <div class="add-new-key" on-tap="_handleAddAccessKeyPressed">[[localize('server-access-key-new')]]</div>
+                  </span>
+                </div>
+              </div>
             </div>
-            <!-- add key button -->
-            <div class="access-key-row" id="addAccessKeyRow">
-              <span class="access-key-container">
-                <paper-icon-button icon="icons:add" on-tap="_handleAddAccessKeyPressed" id="addAccessKeyButton" class="access-key-icon"></paper-icon-button>
-                <div class="add-new-key" on-tap="_handleAddAccessKeyPressed">[[localize('server-access-key-new')]]</div>
-              </span>
+            <div name="settings">
+              <outline-server-settings id="serverSettings" server-id="[[serverId]]" server-hostname="[[serverHostname]]" server-name="[[serverName]]" server-version="[[serverVersion]]" is-hostname-editable="[[isHostnameEditable]]" server-management-api-url="[[serverManagementApiUrl]]" server-port-for-new-access-keys="[[serverPortForNewAccessKeys]]" is-access-key-port-editable="[[isAccessKeyPortEditable]]" access-key-data-limit="{{accessKeyDataLimit}}" is-access-key-data-limit-enabled="{{isAccessKeyDataLimitEnabled}}" supports-access-key-data-limit="[[supportsAccessKeyDataLimit]]" show-feature-metrics-disclaimer="[[showFeatureMetricsDisclaimer]]" server-creation-date="[[serverCreationDate]]" server-monthly-cost="[[monthlyCost]]" server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]" is-server-managed="[[isServerManaged]]" server-location="[[serverLocation]]" metrics-enabled="[[metricsEnabled]]" localize="[[localize]]">
+              </outline-server-settings>
             </div>
-          </div>
-        </div>
-        <div name="settings">
-          <outline-server-settings id="serverSettings" server-id="[[serverId]]" server-hostname="[[serverHostname]]" server-name="[[serverName]]" server-version="[[serverVersion]]" is-hostname-editable="[[isHostnameEditable]]" server-management-api-url="[[serverManagementApiUrl]]" server-port-for-new-access-keys="[[serverPortForNewAccessKeys]]" is-access-key-port-editable="[[isAccessKeyPortEditable]]" access-key-data-limit="{{accessKeyDataLimit}}" is-access-key-data-limit-enabled="{{isAccessKeyDataLimitEnabled}}" supports-access-key-data-limit="[[supportsAccessKeyDataLimit]]" show-feature-metrics-disclaimer="[[showFeatureMetricsDisclaimer]]" server-creation-date="[[serverCreationDate]]" server-monthly-cost="[[monthlyCost]]" server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]" is-server-managed="[[isServerManaged]]" server-location="[[serverLocation]]" metrics-enabled="[[metricsEnabled]]" localize="[[localize]]">
-          </outline-server-settings>
+          </iron-pages>
         </div>
       </iron-pages>
     </div>
@@ -612,7 +622,6 @@ export class ServerView extends DirMixin(PolymerElement) {
         metricsEnabled: Boolean,
         monthlyOutboundTransferBytes: {type: Number},
         monthlyCost: {type: Number},
-        selectedTab: {type: String},
         managedServerUtilzationPercentage: {
           type: Number,
           computed:
@@ -621,6 +630,8 @@ export class ServerView extends DirMixin(PolymerElement) {
         accessKeySortBy: {type: String},
         accessKeySortDirection: {type: Number},
         localize: {type: Function, readonly: true},
+        currentPage: {type: String},
+        selectedTab: {type: String},
       };
     }
 
@@ -677,7 +688,6 @@ export class ServerView extends DirMixin(PolymerElement) {
       //   https://www.polymer-project.org/1.0/docs/devguide/data-binding.html
       this.monthlyOutboundTransferBytes = 0;
       this.monthlyCost = 0;
-      this.selectedTab = 'connections';
       this.accessKeySortBy = 'name';
       /**
        * The direction to sort: 1 == ascending, -1 == descending
@@ -686,6 +696,8 @@ export class ServerView extends DirMixin(PolymerElement) {
       this.accessKeySortDirection = 1;
       /** @type {(msgId: string, ...params: string[]) => string} */
       this.localize = null;
+      this.currentPage = 'unreachableView';
+      this.selectedTab = 'connections';
     }
 
     /**

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -91,8 +91,11 @@ export class ServerView extends DirMixin(PolymerElement) {
       .container {
         display: flex;
         flex-direction: column;
-        padding: 24px;
         color: var(--light-gray);
+      }
+      #managementView,
+      #unreachableView {
+        padding: 24px;
       }
       .tabs-container {
         display: flex;
@@ -428,8 +431,8 @@ export class ServerView extends DirMixin(PolymerElement) {
     `;
     }
 
-  static get unreachableViewTemplate() {
-    return html`
+    static get unreachableViewTemplate() {
+      return html`
       <div class="server-header">
         <div class="server-name">
           <h3>[[serverName]]</h3>
@@ -448,10 +451,10 @@ export class ServerView extends DirMixin(PolymerElement) {
           <paper-button on-tap="retryDisplayingServer" class="try-again-btn">[[localize('retry')]]</paper-button>
         </div>
       </div>`;
-  }
+    }
 
-  static get managementViewTemplate() {
-    return html`
+    static get managementViewTemplate() {
+      return html`
       <div class="server-header">
         <div class="server-name">
           <h3>[[serverName]]</h3>
@@ -596,9 +599,9 @@ export class ServerView extends DirMixin(PolymerElement) {
           </outline-server-settings>
         </div>
       </iron-pages>`;
-  }
+    }
 
-  static get is() {
+    static get is() {
       return 'outline-server-view';
     }
 

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -630,7 +630,7 @@ export class ServerView extends DirMixin(PolymerElement) {
         accessKeySortBy: {type: String},
         accessKeySortDirection: {type: Number},
         localize: {type: Function, readonly: true},
-        currentPage: {type: String},
+        currentPage: {type: String, readonly: true},
         selectedTab: {type: String},
       };
     }
@@ -696,8 +696,15 @@ export class ServerView extends DirMixin(PolymerElement) {
       this.accessKeySortDirection = 1;
       /** @type {(msgId: string, ...params: string[]) => string} */
       this.localize = null;
-      this.currentPage = 'unreachableView';
+      this.currentPage = '';
       this.selectedTab = 'connections';
+    }
+
+    selectPage(page) {
+      if (page !== 'progressView') {
+        this.$.progressView.stop();
+      }
+      this.currentPage = page;
     }
 
     /**


### PR DESCRIPTION
This PR replaces the single `outline-server-progress-step` from `app-root` with individual progress views in `outline-server-view`.

This will make it easier to display server views since `app-root` (and `app.ts`) will no longer need to maintain logic to show/hide the progress view. The progress view can now be considered a state of the server view (progress/unreachable/healthy).

<img width="260" alt="Screen Shot 2021-01-13 at 3 00 07 PM" src="https://user-images.githubusercontent.com/1009390/104504184-12073780-55b0-11eb-8a78-9761c7588a40.png"><img width="260" alt="Screen Shot 2021-01-12 at 10 00 52 AM" src="https://user-images.githubusercontent.com/1009390/104331528-29b1c380-54bd-11eb-8cdc-415da81fb4c3.png"><img width="260" alt="Screen Shot 2021-01-12 at 10 01 15 AM" src="https://user-images.githubusercontent.com/1009390/104331529-2a4a5a00-54bd-11eb-9909-f4cbdda1d57f.png">

