### PR TITLE
Document the non-experimental API endpoint for the default data limit

### DIFF
--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -79,6 +79,35 @@ paths:
           description: The requested port wasn't an integer from 1 through 65535, or the request had no port parameter.
         '409':
           description: The requested port was already in use by another service.
+          
+  /server/access-key-data-limit:
+    put:
+      description: Sets a data transfer limit for all access keys
+      tags:
+        - Access Key
+        - Limit
+      requestBody:
+        required: true
+        content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataLimit"
+              examples:
+                '0':
+                  value: "{limit: {bytes: 10000}}"
+      responses:
+        '204':
+          description: Access key data limit set successfully
+        '400':
+          description: Invalid data limit
+    delete:
+      description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
+      tags:
+        - Access Key
+        - Limit
+      responses:
+        '204':
+          description: Access key limit deleted successfully.
 
   /name:
     put:
@@ -339,35 +368,7 @@ paths:
       responses:
         '204':
           description: Access key limit deleted successfully.
-  /access-key-data-limit:
-    put:
-      description: Sets a data transfer limit for all access keys
-      tags:
-        - Access Key
-        - Limit
-      requestBody:
-        required: true
-        content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DataLimit"
-              examples:
-                '0':
-                  value: "{limit: {bytes: 10000}}"
-      responses:
-        '204':
-          description: Access key data limit set successfully
-        '400':
-          description: Invalid data limit
-    delete:
-      description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
-      tags:
-        - Access Key
-        - Limit
-      responses:
-        '204':
-          description: Access key limit deleted successfully.
-
+ 
 components:
   schemas:
     Server:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -311,7 +311,8 @@ paths:
           description: Invalid request
   /experimental/access-key-data-limit:
     put:
-      description: Sets a data transfer limit for all access keys
+      deprecated: true
+      description: (Deprecated) Sets a data transfer limit for all access keys
       tags:
         - Access Key
         - Limit
@@ -330,7 +331,8 @@ paths:
         '400':
           description: Invalid data limit
     delete:
-      description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
+      deprecated: true
+      description: (Deprecated) Removes the access key data limit, lifting data transfer restrictions on all access keys.
       tags:
         - Access Key
         - Limit

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -310,35 +310,40 @@ paths:
         '400':
           description: Invalid request
   /experimental/access-key-data-limit:
-    put:
-      description: Sets a data transfer limit for all access keys
-      tags:
-        - Access Key
-        - Limit
-      requestBody:
-        required: true
-        content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DataLimit"
-              examples:
-                '0':
-                  value: "{limit: {bytes: 10000}}"
-      responses:
-        '204':
-          description: Access key data limit set successfully
-        '400':
-          description: Invalid data limit
-    delete:
-      description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
-      tags:
-        - Access Key
-        - Limit
-      responses:
-        '204':
-          description: Access key limit deleted successfully.
+    $ref: "#/components/resources/DefaultDataLimit"
+  /access-key-data-limit:
+    $ref: "#/components/resources/DefaultDataLimit"
 
 components:
+  resources:
+    DefaultDataLimit:
+      put:
+        description: Sets a data transfer limit for all access keys
+        tags:
+          - Access Key
+          - Limit
+        requestBody:
+          required: true
+          content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/DataLimit"
+                examples:
+                  '0':
+                    value: "{limit: {bytes: 10000}}"
+        responses:
+          '204':
+            description: Access key data limit set successfully
+          '400':
+            description: Invalid data limit
+      delete:
+        description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
+        tags:
+          - Access Key
+          - Limit
+        responses:
+          '204':
+            description: Access key limit deleted successfully.
   schemas:
     Server:
       properties:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -310,40 +310,63 @@ paths:
         '400':
           description: Invalid request
   /experimental/access-key-data-limit:
-    $ref: "#/components/resources/DefaultDataLimit"
+    put:
+      description: Sets a data transfer limit for all access keys
+      tags:
+        - Access Key
+        - Limit
+      requestBody:
+        required: true
+        content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataLimit"
+              examples:
+                '0':
+                  value: "{limit: {bytes: 10000}}"
+      responses:
+        '204':
+          description: Access key data limit set successfully
+        '400':
+          description: Invalid data limit
+    delete:
+      description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
+      tags:
+        - Access Key
+        - Limit
+      responses:
+        '204':
+          description: Access key limit deleted successfully.
   /access-key-data-limit:
-    $ref: "#/components/resources/DefaultDataLimit"
+    put:
+      description: Sets a data transfer limit for all access keys
+      tags:
+        - Access Key
+        - Limit
+      requestBody:
+        required: true
+        content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataLimit"
+              examples:
+                '0':
+                  value: "{limit: {bytes: 10000}}"
+      responses:
+        '204':
+          description: Access key data limit set successfully
+        '400':
+          description: Invalid data limit
+    delete:
+      description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
+      tags:
+        - Access Key
+        - Limit
+      responses:
+        '204':
+          description: Access key limit deleted successfully.
 
 components:
-  resources:
-    DefaultDataLimit:
-      put:
-        description: Sets a data transfer limit for all access keys
-        tags:
-          - Access Key
-          - Limit
-        requestBody:
-          required: true
-          content:
-              application/json:
-                schema:
-                  $ref: "#/components/schemas/DataLimit"
-                examples:
-                  '0':
-                    value: "{limit: {bytes: 10000}}"
-        responses:
-          '204':
-            description: Access key data limit set successfully
-          '400':
-            description: Invalid data limit
-      delete:
-        description: Removes the access key data limit, lifting data transfer restrictions on all access keys.
-        tags:
-          - Access Key
-          - Limit
-        responses:
-          '204':
-            description: Access key limit deleted successfully.
   schemas:
     Server:
       properties:


### PR DESCRIPTION
It came up in https://github.com/Jigsaw-Code/outline-server/issues/786 that we're still only documenting the experimental data limits endpoint on reDoc.  This PR deprecates the `experimental/access-key-data-limit` API endpoints and adds the correct ones to the documentation.

See https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/Jigsaw-Code/outline-server/cohenjon-default-limit-api/src/shadowbox/server/api.yml#tag/Limit/paths/~1server~1access-key-data-limit/put