### PR TITLE
Adds 'serverId' to all events that affect the server

### DIFF
--- a/src/server_manager/model/server.ts
+++ b/src/server_manager/model/server.ts
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 export interface Server {
+  // Get the server ID.
+  getId(): string;
+
   // Get the server's name for display.
   getName(): string;
 
@@ -52,8 +55,8 @@ export interface Server {
   // Updates whether metrics are enabled.
   setMetricsEnabled(metricsEnabled: boolean): Promise<void>;
 
-  // Get the server's unique ID, used for metrics reporting.
-  getServerId(): string;
+  // Get metrics reporting ID.
+  getMetricsId(): string;
 
   // Checks if the server is healthy.
   isHealthy(): Promise<boolean>;

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -202,15 +202,13 @@ export class App {
     });
 
     appRoot.addEventListener('ChangePortForNewAccessKeysRequested', (event: CustomEvent) => {
-      // TODO(serverIdPr): Pass serverId in event
       this.setPortForNewAccessKeys(
-          this.appRoot.selectedServerId, event.detail.validatedInput, event.detail.ui);
+          event.detail.serverId, event.detail.validatedInput, event.detail.ui);
     });
 
     appRoot.addEventListener('ChangeHostnameForAccessKeysRequested', (event: CustomEvent) => {
-      // TODO(serverIdPr): Pass serverId in event
       this.setHostnameForAccessKeys(
-          this.appRoot.selectedServerId, event.detail.validatedInput, event.detail.ui);
+          event.detail.serverId, event.detail.validatedInput, event.detail.ui);
     });
 
     // The UI wants us to validate a server management URL.

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -187,11 +187,14 @@ export class App {
     });
 
     appRoot.addEventListener('RenameAccessKeyRequested', (event: CustomEvent) => {
-      this.renameAccessKey(event.detail.serverId, event.detail.accessKeyId, event.detail.newName, event.detail.entry);
+      this.renameAccessKey(
+          event.detail.serverId, event.detail.accessKeyId, event.detail.newName,
+          event.detail.entry);
     });
 
     appRoot.addEventListener('SetAccessKeyDataLimitRequested', (event: CustomEvent) => {
-      this.setAccessKeyDataLimit(event.detail.serverId, displayDataAmountToDataLimit(event.detail.limit));
+      this.setAccessKeyDataLimit(
+          event.detail.serverId, displayDataAmountToDataLimit(event.detail.limit));
     });
 
     appRoot.addEventListener('RemoveAccessKeyDataLimitRequested', (event: CustomEvent) => {
@@ -200,12 +203,14 @@ export class App {
 
     appRoot.addEventListener('ChangePortForNewAccessKeysRequested', (event: CustomEvent) => {
       // TODO(serverIdPr): Pass serverId in event
-      this.setPortForNewAccessKeys(this.appRoot.selectedServerId, event.detail.validatedInput, event.detail.ui);
+      this.setPortForNewAccessKeys(
+          this.appRoot.selectedServerId, event.detail.validatedInput, event.detail.ui);
     });
 
     appRoot.addEventListener('ChangeHostnameForAccessKeysRequested', (event: CustomEvent) => {
       // TODO(serverIdPr): Pass serverId in event
-      this.setHostnameForAccessKeys(this.appRoot.selectedServerId, event.detail.validatedInput, event.detail.ui);
+      this.setHostnameForAccessKeys(
+          this.appRoot.selectedServerId, event.detail.validatedInput, event.detail.ui);
     });
 
     // The UI wants us to validate a server management URL.
@@ -857,7 +862,8 @@ export class App {
         });
   }
 
-  private renameAccessKey(serverId: string, accessKeyId: string, newName: string, entry: polymer.Base) {
+  private renameAccessKey(
+      serverId: string, accessKeyId: string, newName: string, entry: polymer.Base) {
     const server = this.getServerById(serverId);
     server.renameAccessKey(accessKeyId, newName)
         .then(() => {
@@ -911,7 +917,8 @@ export class App {
     }
   }
 
-  private async setHostnameForAccessKeys(serverId: string, hostname: string, serverSettings: polymer.Base) {
+  private async setHostnameForAccessKeys(
+      serverId: string, hostname: string, serverSettings: polymer.Base) {
     this.appRoot.showNotification(this.appRoot.localize('saving'));
     try {
       const server = this.getServerById(serverId);
@@ -929,7 +936,8 @@ export class App {
     }
   }
 
-  private async setPortForNewAccessKeys(serverId: string, port: number, serverSettings: polymer.Base) {
+  private async setPortForNewAccessKeys(
+      serverId: string, port: number, serverSettings: polymer.Base) {
     this.appRoot.showNotification(this.appRoot.localize('saving'));
     try {
       const server = this.getServerById(serverId);

--- a/src/server_manager/web_app/digitalocean_server.ts
+++ b/src/server_manager/web_app/digitalocean_server.ts
@@ -77,6 +77,10 @@ class DigitaloceanServer extends ShadowboxServer implements server.ManagedServer
     this.pollInstallState();
   }
 
+  getId(): string {
+    return this.getHost().getHostId();
+  }
+
   waitOnInstall(): Promise<void> {
     return new Promise((fulfill, reject) => {
       // Poll this.installState for changes.  This can poll quickly as it

--- a/src/server_manager/web_app/manual_server.ts
+++ b/src/server_manager/web_app/manual_server.ts
@@ -33,6 +33,10 @@ class ManualServer extends ShadowboxServer implements server.ManualServer {
     }
   }
 
+  getId(): string {
+    return this.getManagementApiUrl();
+  }
+
   getCertificateFingerprint() {
     return this.manualServerConfig.certSha256;
   }

--- a/src/server_manager/web_app/shadowbox_server.ts
+++ b/src/server_manager/web_app/shadowbox_server.ts
@@ -35,11 +35,13 @@ export interface ServerConfig {
   accessKeyDataLimit?: server.DataLimit;
 }
 
-export class ShadowboxServer implements server.Server {
+export abstract class ShadowboxServer implements server.Server {
   private managementApiAddress: string;
   private serverConfig: ServerConfig;
 
-  constructor() {}
+  protected constructor() {}
+
+  abstract getId(): string;
 
   listAccessKeys(): Promise<server.AccessKey[]> {
     console.info('Listing access keys');
@@ -136,7 +138,7 @@ export class ShadowboxServer implements server.Server {
     });
   }
 
-  getServerId(): string {
+  getMetricsId(): string {
     return this.serverConfig.serverId;
   }
 

--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -418,7 +418,7 @@ export class AppRoot extends mixinBehaviors
               <outline-region-picker-step id="regionPicker" localize="[[localize]]"></outline-region-picker-step>
               <div id="serverView">
                 <template is="dom-repeat" items="{{serverList}}" as="server">
-                  <outline-server-view id="serverView-{{_base64Encode(server.id)}}" localize="[[localize]]" hidden\$="{{!_isServerSelected(selectedServerId, server)}}"></outline-server-view>
+                  <outline-server-view id="serverView-{{_base64Encode(server.id)}}" server-id="[[server.id]]" localize="[[localize]]" hidden\$="{{!_isServerSelected(selectedServerId, server)}}"></outline-server-view>
                 </template>
               </div>
             </iron-pages>
@@ -891,7 +891,7 @@ export class AppRoot extends mixinBehaviors
 
   _showServer(event) {
     const server = event.model.server;
-    this.fire('ShowServerRequested', {displayServerId: server.id});
+    this.fire('ShowServerRequested', {serverId: server.id});
     this.maybeCloseDrawer();
   }
 

--- a/src/server_manager/web_app/ui_components/outline-server-progress-step.js
+++ b/src/server_manager/web_app/ui_components/outline-server-progress-step.js
@@ -80,6 +80,7 @@ Polymer({
   is: 'outline-server-progress-step',
 
   properties: {
+    serverId: String,
     serverName: String,
     showCancelButton: Boolean,
     updateIntervalId: Number,
@@ -116,6 +117,6 @@ Polymer({
   },
 
   handleCancelTapped: function() {
-    this.fire('CancelServerCreationRequested');
+    this.fire('CancelServerCreationRequested', {serverId: this.serverId});
   }
 });

--- a/src/server_manager/web_app/ui_components/outline-server-settings.js
+++ b/src/server_manager/web_app/ui_components/outline-server-settings.js
@@ -190,7 +190,7 @@ Polymer({
             <outline-validated-input editable="[[isHostnameEditable]]" visible="[[serverHostname]]" label="[[localize('settings-server-hostname')]]" max-length="253" value="[[serverHostname]]" event="ChangeHostnameForAccessKeysRequested" localize="[[localize]]"></outline-validated-input>
             <paper-input readonly="" value="[[serverManagementApiUrl]]" label="[[localize('settings-server-api-url')]]" hidden\$="[[!serverManagementApiUrl]]" always-float-label="" maxlength="100"></paper-input>
             <paper-input readonly="" value="[[serverCreationDate]]" label="[[localize('settings-server-creation')]]" hidden\$="[[!serverCreationDate]]" always-float-label="" maxlength="100"></paper-input>
-            <paper-input readonly="" value="[[serverId]]" label="[[localize('settings-server-id')]]" hidden\$="[[!serverId]]" always-float-label="" maxlength="100"></paper-input>
+            <paper-input readonly="" value="[[metricsId]]" label="[[localize('settings-server-id')]]" hidden\$="[[!metricsId]]" always-float-label="" maxlength="100"></paper-input>
             <paper-input readonly="" value="[[serverVersion]]" label="[[localize('settings-server-version')]]" hidden\$="[[!serverVersion]]" always-float-label="" maxlength="100"></paper-input>
           </div>
         </div>
@@ -257,12 +257,13 @@ Polymer({
   is: 'outline-server-settings',
 
   properties: {
+    serverId: {type: String, value: null},
     isServerManaged: Boolean,
     serverName: String,
     metricsEnabled: Boolean,
     // Initialize to null so we can use the hidden attribute, which does not work well with
     // undefined values.
-    serverId: {type: String, value: null},
+    metricsId: {type: String, value: null},
     serverHostname: {type: String, value: null},
     serverManagementApiUrl: {type: String, value: null},
     serverPortForNewAccessKeys: {type: Number, value: null},
@@ -304,7 +305,7 @@ Polymer({
     }
     // Fire signal if name has changed.
     if (newName !== this.initialName) {
-      this.fire('ServerRenameRequested', {newName});
+      this.fire('ServerRenameRequested', {serverId: this.serverId, newName});
     }
   },
 
@@ -326,7 +327,7 @@ Polymer({
     if (isDataLimitEnabled) {
       this._requestSetAccessKeyDataLimit();
     } else {
-      this.fire('RemoveAccessKeyDataLimitRequested');
+      this.fire('RemoveAccessKeyDataLimitRequested', {serverId: this.serverId});
     }
   },
 
@@ -345,7 +346,7 @@ Polymer({
     }
     const value = Number(this.$.accessKeyDataLimitInput.value);
     const unit = this.$.accessKeyDataLimitUnits.selected;
-    this.fire('SetAccessKeyDataLimitRequested', {limit: {value, unit}});
+    this.fire('SetAccessKeyDataLimitRequested', {serverId: this.serverId, limit: {value, unit}});
   },
 
   _computeDataLimitsEnabledName: function(isAccessKeyDataLimitEnabled) {

--- a/src/server_manager/web_app/ui_components/outline-server-settings.js
+++ b/src/server_manager/web_app/ui_components/outline-server-settings.js
@@ -186,8 +186,8 @@ Polymer({
             <!-- TODO: consider making this an outline-validated-input -->
             <paper-input id="serverNameInput" class="server-name" value="{{serverName}}" label="[[localize('settings-server-name')]]" always-float-label="" maxlength="100" on-keydown="_handleNameInputKeyDown" on-blur="_handleNameInputBlur"></paper-input>
             <p class="detail">[[localize('settings-server-rename')]]</p>
-            <outline-validated-input editable="[[isAccessKeyPortEditable]]" visible="[[serverPortForNewAccessKeys]]" label="[[localize('settings-access-key-port')]]" allowed-pattern="[0-9]{1,5}" max-length="5" value="[[serverPortForNewAccessKeys]]" client-side-validator="[[_validatePort]]" event="ChangePortForNewAccessKeysRequested" localize="[[localize]]"></outline-validated-input>
-            <outline-validated-input editable="[[isHostnameEditable]]" visible="[[serverHostname]]" label="[[localize('settings-server-hostname')]]" max-length="253" value="[[serverHostname]]" event="ChangeHostnameForAccessKeysRequested" localize="[[localize]]"></outline-validated-input>
+            <outline-validated-input editable="[[isAccessKeyPortEditable]]" visible="[[serverPortForNewAccessKeys]]" label="[[localize('settings-access-key-port')]]" allowed-pattern="[0-9]{1,5}" max-length="5" value="[[serverPortForNewAccessKeys]]" client-side-validator="[[_validatePort]]" event="AccessKeyPortSaveRequested" localize="[[localize]]"></outline-validated-input>
+            <outline-validated-input editable="[[isHostnameEditable]]" visible="[[serverHostname]]" label="[[localize('settings-server-hostname')]]" max-length="253" value="[[serverHostname]]" event="AccessKeyHostnameSaveRequested" localize="[[localize]]"></outline-validated-input>
             <paper-input readonly="" value="[[serverManagementApiUrl]]" label="[[localize('settings-server-api-url')]]" hidden\$="[[!serverManagementApiUrl]]" always-float-label="" maxlength="100"></paper-input>
             <paper-input readonly="" value="[[serverCreationDate]]" label="[[localize('settings-server-creation')]]" hidden\$="[[!serverCreationDate]]" always-float-label="" maxlength="100"></paper-input>
             <paper-input readonly="" value="[[metricsId]]" label="[[localize('settings-server-id')]]" hidden\$="[[!metricsId]]" always-float-label="" maxlength="100"></paper-input>
@@ -283,9 +283,30 @@ Polymer({
     shouldShowExperiments: {type: Boolean, value: false},
   },
 
+  ready: function() {
+    this.addEventListener('AccessKeyPortSaveRequested', this._handleAccessKeyPortSaveRequested);
+    this.addEventListener('AccessKeyHostnameSaveRequested', this._handleAccessKeyHostnameSaveRequested);
+  },
+
   setServerName: function(name) {
     this.initialName = name;
     this.name = name;
+  },
+
+  _handleAccessKeyPortSaveRequested: function(event) {
+    this.fire('ChangePortForNewAccessKeysRequested', {
+      serverId: this.serverId,
+      validatedInput: event.detail.validatedInput,
+      ui: event.detail.ui,
+    });
+  },
+
+  _handleAccessKeyHostnameSaveRequested: function(event) {
+    this.fire('ChangeHostnameForAccessKeysRequested', {
+      serverId: this.serverId,
+      validatedInput: event.detail.validatedInput,
+      ui: event.detail.ui,
+    });
   },
 
   _handleNameInputKeyDown: function(event) {

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -405,7 +405,7 @@ export class ServerView extends DirMixin(PolymerElement) {
 
     <div class="container">
       <iron-pages id="pages" attr-for-selected="id" selected="[[selectedPage]]" on-selected-changed="_selectedPageChanged">
-        <outline-server-progress-step id="progressView" server-name="[[serverName]]" localize="[[localize]]"></outline-server-progress-step>
+        <outline-server-progress-step id="progressView" server-id="serverId" server-name="[[serverName]]" localize="[[localize]]"></outline-server-progress-step>
         <div id="unreachableView">${this.unreachableViewTemplate}</div>
         <div id="managementView">${this.managementViewTemplate}</div>
       </iron-pages>
@@ -595,7 +595,7 @@ export class ServerView extends DirMixin(PolymerElement) {
           </div>
         </div>
         <div name="settings">
-          <outline-server-settings id="serverSettings" server-id="[[serverId]]" server-hostname="[[serverHostname]]" server-name="[[serverName]]" server-version="[[serverVersion]]" is-hostname-editable="[[isHostnameEditable]]" server-management-api-url="[[serverManagementApiUrl]]" server-port-for-new-access-keys="[[serverPortForNewAccessKeys]]" is-access-key-port-editable="[[isAccessKeyPortEditable]]" access-key-data-limit="{{accessKeyDataLimit}}" is-access-key-data-limit-enabled="{{isAccessKeyDataLimitEnabled}}" supports-access-key-data-limit="[[supportsAccessKeyDataLimit]]" show-feature-metrics-disclaimer="[[showFeatureMetricsDisclaimer]]" server-creation-date="[[serverCreationDate]]" server-monthly-cost="[[monthlyCost]]" server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]" is-server-managed="[[isServerManaged]]" server-location="[[serverLocation]]" metrics-enabled="[[metricsEnabled]]" localize="[[localize]]">
+          <outline-server-settings id="serverSettings" server-id="[[serverId]]" metrics-id="[[metricsId]]" server-hostname="[[serverHostname]]" server-name="[[serverName]]" server-version="[[serverVersion]]" is-hostname-editable="[[isHostnameEditable]]" server-management-api-url="[[serverManagementApiUrl]]" server-port-for-new-access-keys="[[serverPortForNewAccessKeys]]" is-access-key-port-editable="[[isAccessKeyPortEditable]]" access-key-data-limit="{{accessKeyDataLimit}}" is-access-key-data-limit-enabled="{{isAccessKeyDataLimitEnabled}}" supports-access-key-data-limit="[[supportsAccessKeyDataLimit]]" show-feature-metrics-disclaimer="[[showFeatureMetricsDisclaimer]]" server-creation-date="[[serverCreationDate]]" server-monthly-cost="[[monthlyCost]]" server-monthly-transfer-limit="[[_formatBytesTransferred(monthlyOutboundTransferBytes)]]" is-server-managed="[[isServerManaged]]" server-location="[[serverLocation]]" metrics-enabled="[[metricsEnabled]]" localize="[[localize]]">
           </outline-server-settings>
         </div>
       </iron-pages>`;
@@ -628,6 +628,7 @@ export class ServerView extends DirMixin(PolymerElement) {
         totalInboundBytes: Number,
         accessKeyRows: {type: Array},
         hasNonAdminAccessKeys: Boolean,
+        metricsId: String,
         metricsEnabled: Boolean,
         monthlyOutboundTransferBytes: {type: Number},
         monthlyCost: {type: Number},
@@ -687,6 +688,7 @@ export class ServerView extends DirMixin(PolymerElement) {
       /** @type {DisplayAccessKey[]} */
       this.accessKeyRows = [];
       this.hasNonAdminAccessKeys = false;
+      this.metricsId = '';
       this.metricsEnabled = false;
       // Initialize monthlyOutboundTransferBytes and monthlyCost to 0, so they can
       // be bound to hidden attributes.  Initializing to undefined does not
@@ -779,7 +781,7 @@ export class ServerView extends DirMixin(PolymerElement) {
   }
 
   _handleAddAccessKeyPressed() {
-    this.dispatchEvent(makePublicEvent('AddAccessKeyRequested'));
+    this.dispatchEvent(makePublicEvent('AddAccessKeyRequested', {serverId: this.serverId}));
     this.$.addAccessKeyHelpBubble.hide();
   }
 
@@ -803,6 +805,7 @@ export class ServerView extends DirMixin(PolymerElement) {
     }
     input.disabled = true;
     this.dispatchEvent(makePublicEvent('RenameAccessKeyRequested', {
+      serverId: this.serverId,
       accessKeyId: accessKey.id,
       newName: displayName,
       entry: {
@@ -847,7 +850,7 @@ export class ServerView extends DirMixin(PolymerElement) {
 
   _handleRemoveAccessKeyPressed(e) {
     const accessKey = e.model.item;
-    this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {accessKeyId: accessKey.id}));
+    this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {serverId: this.serverId, accessKeyId: accessKey.id}));
   }
 
   _formatBytesTransferred(numBytes, emptyValue = '') {
@@ -987,11 +990,11 @@ export class ServerView extends DirMixin(PolymerElement) {
   }
 
   destroyServer() {
-    this.dispatchEvent(makePublicEvent('DeleteServerRequested'));
+    this.dispatchEvent(makePublicEvent('DeleteServerRequested', {serverId: this.serverId}));
   }
 
   removeServer() {
-    this.dispatchEvent(makePublicEvent('ForgetServerRequested'));
+    this.dispatchEvent(makePublicEvent('ForgetServerRequested', {serverId: this.serverId}));
   }
 
   _computePaperProgressClass(isAccessKeyDataLimitEnabled) {

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -850,7 +850,8 @@ export class ServerView extends DirMixin(PolymerElement) {
 
   _handleRemoveAccessKeyPressed(e) {
     const accessKey = e.model.item;
-    this.dispatchEvent(makePublicEvent('RemoveAccessKeyRequested', {serverId: this.serverId, accessKeyId: accessKey.id}));
+    this.dispatchEvent(makePublicEvent(
+        'RemoveAccessKeyRequested', {serverId: this.serverId, accessKeyId: accessKey.id}));
   }
 
   _formatBytesTransferred(numBytes, emptyValue = '') {


### PR DESCRIPTION
This updates the events that affect the server to include the server ID. This allows us to get rid of selected server local state in `app.ts` (`selectedServer`).

## Open questions
* The `ShadowboxServer`/`DigitalOceanServer`/`ManualServer` hierarchy is a little confusing now that ShadowboxServer is abstract.
* Determine what we should name the [managed/manual] server ID (what we're calling localServerId atm) vs the shadowbox Server ID