### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,6 @@ name: Build and Test
 
 on: push
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   manager:
     name: Build and Test Manager
@@ -13,7 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO run on Windows as well
+        os: [ubuntu-latest, macos-latest]
       # Don't cancel jobs on other platforms if one fails
       fail-fast: false
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+      # Don't cancel jobs on other platforms if one fails
+      fail-fast: false
 
-    
-    # Ideally we would run all the build steps in parallel.  We may be able to drastically reduce
-    # job startup overhead by caching the master branch and running 'git pull' as opposed to a full
-    # clone on every CI run.
+    shell: bash
+      
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1
@@ -55,9 +55,6 @@ jobs:
 
     runs-on: ubuntu-latest
     
-    # Ideally we would run all the build steps in parallel.  We may be able to drastically reduce
-    # job startup overhead by caching the master branch and running 'git pull' as opposed to a full
-    # clone on every CI run.
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO run on Windows as well
-        os: [ubuntu-latest, macos-latest]
+        # This matches the Ubuntu version used in our Travis releases
+        os: [ubuntu-16.04]
       # Don't cancel jobs on other platforms if one fails
       fail-fast: false
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   manager:
-    name: Build and Test Manager
+    name: Build and Test
     
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,51 +49,19 @@ jobs:
           yarn do server_manager/web_app/build
           yarn do server_manager/test
 
-  linux_only:
-    name: Build and Test Shadowbox, Metrics Server, and Sentry Webhook
-
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v1
-
-      - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Show Environment Info
-        run: yarn -v
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Check yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      
-      - name: Install dependencies
-        run: yarn --prefer-offline
-
-      - name: Lint
-        run: yarn lint
-      
       - name: Shadowbox
+        if: runner.os == 'Linux'
         run: |
           yarn do shadowbox/server/build
           yarn do shadowbox/test
           yarn do shadowbox/integration_test/run
       
       - name: Metrics Server
+        if: runner.os == 'Linux'
         run: |
           yarn do metrics_server/build
           yarn do metrics_server/test
       
       - name:  Sentry Webhook
+        if: runner.os == 'Linux'
         run: yarn do sentry_webhook/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,13 @@ name: Build and Test
 on: push
 
 jobs:
-  build-and-test:
-    name: Build and Test
-    runs-on: ubuntu-latest
+  manager:
+    name: Build and Test Manager
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: {{ matrix.os }}
     
     # Ideally we would run all the build steps in parallel.  We may be able to drastically reduce
     # job startup overhead by caching the master branch and running 'git pull' as opposed to a full
@@ -50,6 +54,58 @@ jobs:
           yarn do server_manager/electron_app/build
           yarn do server_manager/web_app/build
           yarn do server_manager/test
+      
+      - name: Metrics Server
+        run: |
+          yarn do metrics_server/build
+          yarn do metrics_server/test
+      
+      - name:  Sentry Webhook
+        run: yarn do sentry_webhook/build
+
+  linux_only:
+    name: Build and Test Shadowbox, Metrics Server, and Sentry Webhook
+
+    runs-on: ubuntu-latest
+    
+    # Ideally we would run all the build steps in parallel.  We may be able to drastically reduce
+    # job startup overhead by caching the master branch and running 'git pull' as opposed to a full
+    # clone on every CI run.
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Show Environment Info
+        run: yarn -v
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Check yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Install dependencies
+        run: yarn --prefer-offline
+
+      - name: Lint
+        run: yarn lint
+      
+      - name: Shadowbox
+        run: |
+          yarn do shadowbox/server/build
+          yarn do shadowbox/test
+          yarn do shadowbox/integration_test/run
       
       - name: Metrics Server
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,12 @@ on: push
 jobs:
   manager:
     name: Build and Test Manager
+    
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
-    runs-on: {{ matrix.os }}
     
     # Ideally we would run all the build steps in parallel.  We may be able to drastically reduce
     # job startup overhead by caching the master branch and running 'git pull' as opposed to a full
@@ -21,7 +22,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
 
       - name: Show Environment Info
         run: yarn -v
@@ -35,8 +36,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          restore-keys: ${{ runner.os }}-yarn-
       
       - name: Install dependencies
         run: yarn --prefer-offline
@@ -78,7 +78,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
 
       - name: Show Environment Info
         run: yarn -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,25 +43,12 @@ jobs:
 
       - name: Lint
         run: yarn lint
-      
-      - name: Shadowbox
-        run: |
-          yarn do shadowbox/server/build
-          yarn do shadowbox/test
 
-      - name: Server Manager
+      - name: Manager
         run: |
           yarn do server_manager/electron_app/build
           yarn do server_manager/web_app/build
           yarn do server_manager/test
-      
-      - name: Metrics Server
-        run: |
-          yarn do metrics_server/build
-          yarn do metrics_server/test
-      
-      - name:  Sentry Webhook
-        run: yarn do sentry_webhook/build
 
   linux_only:
     name: Build and Test Shadowbox, Metrics Server, and Sentry Webhook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Build and Test
 
 on: push
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   manager:
     name: Build and Test Manager
@@ -12,8 +16,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Don't cancel jobs on other platforms if one fails
       fail-fast: false
-
-    shell: bash
       
     steps:
       - name: Checkout repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Build and Test
+
+on: push
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    
+    # Ideally we would run all the build steps in parallel.  We may be able to drastically reduce
+    # job startup overhead by caching the master branch and running 'git pull' as opposed to a full
+    # clone on every CI run.
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Show Environment Info
+        run: yarn -v
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Check yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Install dependencies
+        run: yarn --prefer-offline
+
+      - name: Lint
+        run: yarn lint
+      
+      - name: Shadowbox
+        run: |
+          yarn do shadowbox/server/build
+          yarn do shadowbox/test
+
+      - name: Server Manager
+        run: |
+          yarn do server_manager/electron_app/build
+          yarn do server_manager/web_app/build
+          yarn do server_manager/test
+      
+      - name: Metrics Server
+        run: |
+          yarn do metrics_server/build
+          yarn do metrics_server/test
+      
+      - name:  Sentry Webhook
+        run: yarn do sentry_webhook/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Manager
         run: |
           yarn do server_manager/electron_app/build
-          yarn do server_manager/web_app/build
           yarn do server_manager/test
 
       - name: Shadowbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,21 @@ jobs:
         - RELEASE_NAME=server-$(date -I)
         - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
 
+    - stage: "Deploy Server"	
+      name: Server Testing	
+      sudo: required	
+      services: docker	
+      script:	
+        # https://docs.travis-ci.com/user/docker/	
+        - |	
+          sudo rm -f /usr/local/bin/docker-compose	
+          curl -L https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m) > docker-compose	
+          chmod +x docker-compose	
+          sudo mv docker-compose /usr/local/bin	
+        - yarn do shadowbox/test
+        - yarn do shadowbox/docker/build && cd src/shadowbox/integration_test && ./test.sh
+    
+    
     - stage: "Deploy Server"
       name: Server Docker Image
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ jobs:
   include:
     - stage: "Server Daily Release"
       script:
-        - RELEASE_NAME=server-$(date -I)
-        - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
-
+        - CREATE_RELEASE_URL=https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
+        - SERVER_RELEASE_NAME=server-$(date -I)
+        - curl --data '{"tag_name":"'$SERVER_RELEASE_NAME'","name":"'$SERVER_RELEASE_NAME'","prerelease":true}' $CREATE_RELEASE_URL
+        - MANAGER_RELEASE_NAME=v$(date -I)
+        - curl --data '{"tag_name":"'$MANAGER_RELEASE_NAME'","name":"'$MANAGER_RELEASE_NAME'","prerelease":true}' $CREATE_RELEASE_URL
     - stage: "Deploy Server"	
       name: Server Testing	
       sudo: required	

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_install:
 stages:
   - name: "Server Daily Release"
     if: type = cron
-  - name: Test
-    if: type != cron
   - name: "Deploy Server"
     if: tag =~ ^server-
   - name: "Manager Release"
@@ -39,37 +37,6 @@ jobs:
       script:
         - RELEASE_NAME=server-$(date -I)
         - curl --data '{"tag_name":"'$RELEASE_NAME'","name":"'$RELEASE_NAME'","prerelease":true}' https://api.github.com/repos/Jigsaw-Code/outline-server/releases?access_token=$CI_USER_TOKEN
-
-    # Ideally, we would split this stage in some way, e.g. by component or by
-    # build/test commands, to make it clearer in the Travis UI exactly which
-    # command failed. However, since each stage incurs a significantly start-up
-    # cost, we combine test and build commands for all components into one fast
-    # stage.
-    - stage: Test
-      name: Unit Tests
-      script:
-        - yarn lint
-        - yarn do metrics_server/build
-        - yarn do metrics_server/test
-        - yarn do sentry_webhook/build
-        - yarn do shadowbox/server/build
-        - yarn do shadowbox/test
-        - yarn do server_manager/electron_app/build
-        - yarn do server_manager/web_app/build
-        - yarn do server_manager/test
-
-    - stage: Test
-      name: Server Integration Test
-      sudo: required
-      services: docker
-      script:
-        # https://docs.travis-ci.com/user/docker/
-        - |
-          sudo rm -f /usr/local/bin/docker-compose
-          curl -L https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m) > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
-        - yarn do shadowbox/docker/build && cd src/shadowbox/integration_test && ./test.sh
 
     - stage: "Deploy Server"
       name: Server Docker Image

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ stages:
     if: type = cron
   - name: Test
     if: type != cron
-  - name: "deploy"
+  - name: "Deploy Server"
     if: tag =~ ^server-
   - name: "Manager Release"
     if: tag =~ ^v[0-9]
@@ -71,7 +71,7 @@ jobs:
           sudo mv docker-compose /usr/local/bin
         - yarn do shadowbox/docker/build && cd src/shadowbox/integration_test && ./test.sh
 
-    - stage: deploy
+    - stage: "Deploy Server"
       name: Server Docker Image
       sudo: required
       services: docker
@@ -83,16 +83,8 @@ jobs:
         - docker tag outline/shadowbox quay.io/outline/shadowbox:daily
         - docker push quay.io/outline/shadowbox:daily
 
-    - stage: deploy
-      name: Manager Linux
-      addons:
-        apt:
-          packages:
-          - rpm
-      script: yarn do server_manager/electron_app/package_linux
-
     # https://www.electron.build/multi-platform-build
-    - stage: deploy
+    - stage: "Manager Release"
       name: Manager Windows
       sudo: required
       services: docker
@@ -105,11 +97,6 @@ jobs:
             -v ~/.cache/electron-builder:/root/.cache/electron-builder
             electronuserland/builder:wine
             /bin/bash -c "yarn do server_manager/electron_app/package_only_windows" || travis_terminate $?
-
-    - stage: deploy
-      name: Manager macOS
-      os: osx
-      script: yarn do server_manager/electron_app/package_macos
 
     # Note that because we cannot currently sign Windows binaries on Travis,
     # these must be manually built and uploaded to the releases page.

--- a/src/shadowbox/integration_test/target/Dockerfile
+++ b/src/shadowbox/integration_test/target/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pin to a known good signed image to avoid failures from the Docker notary service
 FROM gcr.io/distroless/python3@sha256:58087520b3c929fe77e1ef3fc95062dbe80bbda265e0e7966c4997c71a9636ea
 COPY index.html .
 ENTRYPOINT ["python", "-m", "http.server", "80"]

--- a/src/shadowbox/integration_test/test.sh
+++ b/src/shadowbox/integration_test/test.sh
@@ -80,6 +80,7 @@ function cleanup() {
   status=$?
   if ((DEBUG != 1)); then
     docker-compose --project-name=integrationtest down
+    rm -rf ${TMP_STATE_DIR} || echo "Failed to cleanup files at ${TMP_STATE_DIR}"
   fi
   return $status
 }


### PR DESCRIPTION
* Doesn't also build the Linux or Mac manager on server deploy
* Correctly builds a Windows binary on manager release (although we still have to manually upload build artifacts)
* Renames the Shadowbox deployment step
* Moves our unit tests to Github Actions to avoid the waiting on travis-ci.org