### PR TITLE
Fix DataUsageByAccessKey and ServerConfig

### DIFF
--- a/src/server_manager/model/server.ts
+++ b/src/server_manager/model/server.ts
@@ -29,7 +29,7 @@ export interface Server {
   listAccessKeys(): Promise<AccessKey[]>;
 
   // Returns stats for bytes transferred across all access keys of this server.
-  getDataUsage(): Promise<DataUsageByAccessKey>;
+  getDataUsage(): Promise<BytesByAccessKey>;
 
   // Adds a new access key to this server.
   addAccessKey(): Promise<AccessKey>;
@@ -169,18 +169,7 @@ export interface AccessKey {
   accessUrl: string;
 }
 
-// Byte transfer stats for the past 30 days, including both inbound and outbound.
-// TODO: this is copied at src/shadowbox/model/metrics.ts.  Both copies should
-// be kept in sync, until we can find a way to share code between the web_app
-// and shadowbox.
-export interface DataUsageByAccessKey {
-  // The accessKeyId should be of type AccessKeyId, however that results in the tsc
-  // error TS1023: An index signature parameter type must be 'string' or 'number'.
-  // See https://github.com/Microsoft/TypeScript/issues/2491
-  // TODO: this still says "UserId", changing to "AccessKeyId" will require
-  // a change on the shadowbox server.
-  bytesTransferredByUserId: {[accessKeyId: string]: number};
-}
+export type BytesByAccessKey = Map<AccessKeyId, number>;
 
 // Data transfer allowance, measured in bytes.
 // NOTE: Must be kept in sync with the definition in src/shadowbox/access_key.ts.

--- a/src/server_manager/web_app/app.spec.ts
+++ b/src/server_manager/web_app/app.spec.ts
@@ -202,7 +202,7 @@ class FakeServer implements server.Server {
     return new Date();
   }
   getDataUsage() {
-    return Promise.resolve({bytesTransferredByUserId: {}});
+    return Promise.resolve(new Map<server.AccessKeyId, number>());
   }
   addAccessKey() {
     return Promise.reject(new Error('FakeServer.addAccessKey not implemented'));

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -767,11 +767,10 @@ export class App {
 
   private async refreshTransferStats(selectedServer: server.Server, serverView: ServerView) {
     try {
-      const stats = await selectedServer.getDataUsage();
+      const usageMap = await selectedServer.getDataUsage();
       let totalBytes = 0;
-      // tslint:disable-next-line:forin
-      for (const accessKeyId in stats.bytesTransferredByUserId) {
-        totalBytes += stats.bytesTransferredByUserId[accessKeyId];
+      for (const accessKeyBytes of usageMap.values()) {
+        totalBytes += accessKeyBytes;
       }
       serverView.totalInboundBytes = totalBytes;
 
@@ -785,7 +784,7 @@ export class App {
       // did.
       for (const accessKey of serverView.accessKeyRows) {
         const accessKeyId = accessKey.id;
-        const transferredBytes = stats.bytesTransferredByUserId[accessKeyId] || 0;
+        const transferredBytes = usageMap.get(accessKeyId) ?? 0;
         let relativeTraffic =
             totalBytes ? 100 * transferredBytes / totalBytes : (accessKeyDataLimit ? 100 : 0);
         if (relativeTraffic > 100) {

--- a/src/server_manager/web_app/shadowbox_server.ts
+++ b/src/server_manager/web_app/shadowbox_server.ts
@@ -17,13 +17,6 @@ import * as semver from 'semver';
 import * as errors from '../infrastructure/errors';
 import * as server from '../model/server';
 
-// Interfaces used by metrics REST APIs.
-interface MetricsEnabled {
-  metricsEnabled: boolean;
-}
-export interface ServerName {
-  name: string;
-}
 interface ServerConfigJson {
   name: string;
   metricsEnabled: boolean;

--- a/src/server_manager/web_app/shadowbox_server.ts
+++ b/src/server_manager/web_app/shadowbox_server.ts
@@ -48,8 +48,6 @@ interface DataUsageByAccessKeyJson {
   bytesTransferredByUserId: {[accessKeyId: string]: number};
 }
 
-export type DataUsageByAccessKey = Map<server.AccessKeyId, number>;
-
 export class ShadowboxServer implements server.Server {
   private managementApiAddress: string;
   private serverConfig: ServerConfigJson;


### PR DESCRIPTION
This PR fixes a violations of domain-driven design: a concept was shared with model and serialization.
With the change the serialization format `DataUsageByAccessKey` is no longer shared with the model. Note how the old "UserId" concept is no longer exposed to the model.

I've renamed the serialization format `DataUsageByAccessKeyJson` and made it private, to make sure it doesn't leak.
I also renamed `ServerConfig` to `ServerConfigJson` to make it clearer that it's a serialization format.

/cc @alalamav @JonathanDCohen 