### PR TITLE
Update sentry webhook runtime to node 12

### DIFF
--- a/src/sentry_webhook/deploy_action.sh
+++ b/src/sentry_webhook/deploy_action.sh
@@ -17,4 +17,4 @@
 yarn do sentry_webhook/build
 
 cp src/sentry_webhook/package.json build/sentry_webhook/
-gcloud --project=uproxysite functions deploy postSentryEventToSalesforce --trigger-http --source=build/sentry_webhook --entry-point=postSentryEventToSalesforce
+gcloud --project=uproxysite functions deploy postSentryEventToSalesforce --runtime=nodejs12 --trigger-http --source=build/sentry_webhook --entry-point=postSentryEventToSalesforce


### PR DESCRIPTION
- The sentry webhook cloud function is running on a deprecated node 6 runtime, causing all requests to fail.
- Updates the runtime to node 12.