### PR TITLE
bump ssconfig version

### DIFF
--- a/src/shadowbox/package.json
+++ b/src/shadowbox/package.json
@@ -10,7 +10,7 @@
     "Using https:// for ShadowsocksConfig to avoid adding git in the Docker image"
   ],
   "dependencies": {
-    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.1.2",
+    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#v0.1.3",
     "ip-regex": "^4.1.0",
     "js-yaml": "^3.12.0",
     "node-fetch": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,9 +1239,9 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-ShadowsocksConfig@Jigsaw-Code/outline-shadowsocksconfig#^v0.1.2:
-  version "0.1.2"
-  resolved "https://codeload.github.com/Jigsaw-Code/outline-shadowsocksconfig/tar.gz/e491bd06e98b1b9f3c4745e8eb66c503c490745d"
+ShadowsocksConfig@Jigsaw-Code/outline-shadowsocksconfig#v0.1.3:
+  version "0.1.3"
+  resolved "https://codeload.github.com/Jigsaw-Code/outline-shadowsocksconfig/tar.gz/a1bf62a2ceedf489215457de80d5c477e976a604"
   dependencies:
     js-base64 "^3.5.2"
     punycode "^1.4.1"


### PR DESCRIPTION
This pulls in the legacy ss:// url encoding fix from https://github.com/Jigsaw-Code/outline-shadowsocksconfig/pull/16