### PR TITLE
Fixes unresponsive outline-do-oauth-step

### DIFF
--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -518,6 +518,8 @@ export class App {
     const oauth = runDigitalOceanOauth();
     const handleOauthFlowCancelled = () => {
       oauth.cancel();
+      this.disconnectDigitalOceanAccount();
+      this.showIntro();
     };
     this.appRoot.getAndShowDigitalOceanOauthFlow(handleOauthFlowCancelled);
     try {

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -341,7 +341,7 @@ export class App {
       this.appRoot.adminEmail = await this.digitalOceanAccount.getName();
       const status = await this.digitalOceanAccount.getStatus();
       if (status !== digitalocean.Status.ACTIVE) {
-        return;
+        return [];
       }
       const servers = await this.digitalOceanAccount.listServers();
       for (const server of servers) {


### PR DESCRIPTION
Outline Manager `outline-do-oauth-step` unresponsive when the DigitalOcean login flow fails. 

This seems to happen when the DigitalOcean ` GET /v2/account` call returns `status !== active`, although it's difficult to reproduce.

This fixes the `loadDigitalOceanServers` return type and adds logic to disconnect and show intro when the DigitalOcean OAuth cancel button is pressed in app.

Fixes #816 