### PR TITLE
Force production build environment for releases

### DIFF
--- a/src/server_manager/electron_app/release_linux_action.sh
+++ b/src/server_manager/electron_app/release_linux_action.sh
@@ -16,6 +16,8 @@
 
 source src/server_manager/scripts/fill_packaging_opts.sh "$0" "$@"
 
+export BUILD_ENV='production'
+
 yarn 'do' server_manager/electron_app/build
 yarn 'do' server_manager/electron_app/write_production_environment
 

--- a/src/server_manager/electron_app/release_macos_action.sh
+++ b/src/server_manager/electron_app/release_macos_action.sh
@@ -23,6 +23,8 @@ fi
 
 source src/server_manager/scripts/fill_packaging_opts.sh "$0" "$@"
 
+export BUILD_ENV='production'
+
 yarn 'do' server_manager/electron_app/build
 yarn 'do' server_manager/electron_app/write_production_environment
 

--- a/src/server_manager/electron_app/release_windows_action.sh
+++ b/src/server_manager/electron_app/release_windows_action.sh
@@ -16,6 +16,8 @@
 
 source src/server_manager/scripts/fill_packaging_opts.sh "$0" "$@"
 
+export BUILD_ENV='production'
+
 yarn 'do' server_manager/electron_app/build
 yarn 'do' server_manager/electron_app/write_production_environment
 


### PR DESCRIPTION
Prevents us from creating signed 'development' releases.