### PR TITLE
Try no ids

### DIFF
--- a/src/server_manager/model/digitalocean.ts
+++ b/src/server_manager/model/digitalocean.ts
@@ -26,8 +26,6 @@ export enum Status {
 }
 
 export interface Account {
-  // Returns the Account's unique id.
-  getId(): string;
   // Returns a user-friendly name (email address) associated with the account.
   getName(): Promise<string>;
   // Returns the status of the account.

--- a/src/server_manager/model/server.ts
+++ b/src/server_manager/model/server.ts
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 export interface Server {
-  // Gets the server ID.
-  getId(): string;
-
   // Gets the server's name for display.
   getName(): string;
 

--- a/src/server_manager/web_app/digitalocean_account.ts
+++ b/src/server_manager/web_app/digitalocean_account.ts
@@ -125,8 +125,7 @@ export class DigitalOceanAccount implements digitalocean.Account {
 
   // Creates a DigitalOceanServer object and adds it to the in-memory server list.
   private createDigitalOceanServer(digitalOcean: DigitalOceanSession, dropletInfo: DropletInfo) {
-    const server =
-        new DigitalOceanServer(`${this.id}:${dropletInfo.id}`, digitalOcean, dropletInfo);
+    const server = new DigitalOceanServer(digitalOcean, dropletInfo);
     this.servers.push(server);
     return server;
   }

--- a/src/server_manager/web_app/digitalocean_server.ts
+++ b/src/server_manager/web_app/digitalocean_server.ts
@@ -60,11 +60,10 @@ export class DigitalOceanServer extends ShadowboxServer implements server.Manage
   private eventQueue = new EventEmitter();
   private installState: InstallState = InstallState.UNKNOWN;
 
-  constructor(
-      id: string, private digitalOcean: DigitalOceanSession, private dropletInfo: DropletInfo) {
+  constructor(private digitalOcean: DigitalOceanSession, private dropletInfo: DropletInfo) {
     // Consider passing a RestEndpoint object to the parent constructor,
     // to better encapsulate the management api address logic.
-    super(id);
+    super();
     console.info('DigitalOceanServer created');
     this.eventQueue.once('server-active', () => console.timeEnd('activeServer'));
     this.pollInstallState();

--- a/src/server_manager/web_app/shadowbox_server.ts
+++ b/src/server_manager/web_app/shadowbox_server.ts
@@ -58,11 +58,7 @@ export class ShadowboxServer implements server.Server {
   private managementApiAddress: string;
   private serverConfig: ServerConfigJson;
 
-  constructor(private readonly id: string) {}
-
-  getId(): string {
-    return this.id;
-  }
+  constructor() {}
 
   listAccessKeys(): Promise<server.AccessKey[]> {
     console.info('Listing access keys');

--- a/src/server_manager/web_app/ui_components/outline-server-view.js
+++ b/src/server_manager/web_app/ui_components/outline-server-view.js
@@ -619,7 +619,7 @@ export class ServerView extends DirMixin(PolymerElement) {
     static get properties() {
       return {
         metricsId: String,
-        serverId: String,
+        server: Object,
         serverName: String,
         serverHostname: String,
         serverVersion: String,
@@ -667,7 +667,8 @@ export class ServerView extends DirMixin(PolymerElement) {
 
     constructor() {
       super();
-      this.serverId = '';
+      /** @type {unknown} */
+      this.server = null;
       this.metricsId = '';
       this.serverName = '';
       this.serverHostname = '';
@@ -863,10 +864,9 @@ export class ServerView extends DirMixin(PolymerElement) {
                                                       accessKey.name || accessKey.placeholderName;
     const defaultDataLimitBytes =
         this.isDefaultDataLimitEnabled ? this.defaultDataLimitBytes : undefined;
-    const serverId = this.serverId;
     this.dispatchEvent(makePublicEvent(
         'OpenPerKeyDataLimitDialogRequested',
-        {keyId, keyDataLimitBytes, keyName, serverId, defaultDataLimitBytes}));
+        {keyId, keyDataLimitBytes, keyName, server: this.server, defaultDataLimitBytes}));
   }
 
   _handleRenameAccessKeyPressed(event) {


### PR DESCRIPTION
This PR illustrates how we could do most of the app logic without IDs. It's not for review, but as a study.

I'm effectively using the account and server objects as the "ids". You can do lookups by scanning and doing equality comparisons, but not indexed lookups.

Scanning instead if indexing can  be a performance issue, but in practice it doesn't matter in this case. However I still ran into 2 major issues:
1. `getServerView` expects an ID
2. We need a persistent ID for `LAST_DISPLAYED_SERVER_STORAGE_KEY`

It's possible to work around # 1 by either scanning the DOM tree, or by properly doing attribute binding with the serverList. Instead of looking up the server view, we should be setting the properties on the serverList instead.

# 2 requires a persistent ID that survives restarts, so we can't use the objects as identity.  Therefore we can't get away from using stable IDs. We could use random ids for the objects, like we do in the client, but that would require persisting the random ids. Instead, we can compose persistent IDs without persisting them by combining the account uuid and the droplet id, as I do on https://github.com/Jigsaw-Code/outline-server/pull/852.

