### PR TITLE
[DRAFT] [PROTOTYPE] Simple implementation of single user dynamic keys

### DIFF
--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -47,21 +47,22 @@ export interface AccessKey {
   readonly isOverDataLimit: boolean;
   // The key's current data limit.  If it exists, it overrides the server default data limit.
   readonly dataLimit?: DataLimit;
+  // The token mapping to this key
+  readonly token?: Token;
 }
 
 export type Token = string;
 
 export interface AccessKeyRepository {
-  // Creates a new dynamic key
-  createDynamicKey(token?: Token|undefined): Promise<string>;
+  // Creates a new access key.  If a token is provided, it's used for the key.  Otherwise one is generated
+  // automatically.
+  createAccessKey(token?: Token|undefined): Promise<AccessKey>;
   // Rotates the dynamic key mapped to the given token.  Rejects if no key exists for the given
   // token.
-  updateDynamicKey(token: Token): Promise<string>;
+  updateDynamicKey(token: Token): Promise<AccessKey>;
   // Retrieves the config for a dynamic key.  Returns undefined if no key exists for the given
   // token.
   getDynamicKey(token: Token): AccessKey|undefined;
-  // Creates a new access key. Parameters are chosen automatically.
-  createNewStaticAccessKey(): Promise<AccessKey>;
   // Removes the access key given its id. Throws on failure.
   removeAccessKey(id: AccessKeyId);
   // Lists all existing access keys

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -53,10 +53,10 @@ export type Token = string;
 
 export interface AccessKeyRepository {
   // Creates a new dynamic key
-  createDynamicKey(token?: Token|undefined): Promise<Token>;
+  createDynamicKey(token?: Token|undefined): Promise<string>;
   // Rotates the dynamic key mapped to the given token.  Rejects if no key exists for the given
   // token.
-  updateDynamicKey(token: Token): Promise<AccessKey>;
+  updateDynamicKey(token: Token): Promise<string>;
   // Retrieves the config for a dynamic key.  Returns undefined if no key exists for the given
   // token.
   getDynamicKey(token: Token): AccessKey|undefined;

--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -32,6 +32,7 @@ export interface DataLimit {
   readonly bytes: number;
 }
 
+// TODOBEFOREMERGE we should rename this to AccessConfig or something like that
 // AccessKey is what admins work with. It gives ProxyParams a name and identity.
 export interface AccessKey {
   // The unique identifier for this access key.
@@ -48,9 +49,19 @@ export interface AccessKey {
   readonly dataLimit?: DataLimit;
 }
 
+export type Token = string;
+
 export interface AccessKeyRepository {
+  // Creates a new dynamic key
+  createDynamicKey(token?: Token|undefined): Promise<Token>;
+  // Rotates the dynamic key mapped to the given token.  Rejects if no key exists for the given
+  // token.
+  updateDynamicKey(token: Token): Promise<AccessKey>;
+  // Retrieves the config for a dynamic key.  Returns undefined if no key exists for the given
+  // token.
+  getDynamicKey(token: Token): AccessKey|undefined;
   // Creates a new access key. Parameters are chosen automatically.
-  createNewAccessKey(): Promise<AccessKey>;
+  createNewStaticAccessKey(): Promise<AccessKey>;
   // Removes the access key given its id. Throws on failure.
   removeAccessKey(id: AccessKeyId);
   // Lists all existing access keys

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -187,7 +187,7 @@ async function main() {
 
   const accessKeyRepository = new ServerAccessKeyRepository(
       serverConfig.data().portForNewAccessKeys, proxyHostname, accessKeyConfig, shadowsocksServer,
-      prometheusClient, certHash(certificate), apiPortNumber, serverConfig.data().accessKeyDataLimit);
+      prometheusClient, serverConfig.data().accessKeyDataLimit);
 
   const metricsReader = new PrometheusUsageMetrics(prometheusClient);
   const toMetricsId = (id: AccessKeyId) => {
@@ -205,7 +205,7 @@ async function main() {
 
   const managerService = new ShadowsocksManagerService(
       process.env.SB_DEFAULT_SERVER_NAME || 'Outline Server', serverConfig, accessKeyRepository,
-      managerMetrics, metricsPublisher);
+      managerMetrics, metricsPublisher, apiPortNumber, certHash(certificate));
 
   const apiServer = restify.createServer({
     certificate,

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -805,6 +805,12 @@ function fakeSharedMetricsReporter(): SharedMetricsPublisher {
 
 function getAccessKeyRepository(): ServerAccessKeyRepository {
   return new ServerAccessKeyRepository(
-      OLD_PORT, 'hostname', new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
-      new FakeShadowsocksServer(), new FakePrometheusClient({}));
+      OLD_PORT,
+      'hostname',
+      new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
+      new FakeShadowsocksServer(),
+      new FakePrometheusClient({}),
+      'TODOBEFOREPUSH',
+      9999,
+      null);
 }

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -228,8 +228,8 @@ describe('ShadowsocksManagerService', () => {
     it('lists access keys with expected properties', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewAccessKey();
-      await repo.createNewAccessKey();
+      const accessKey = await repo.createNewStaticAccessKey();
+      await repo.createNewStaticAccessKey();
       const accessKeyName = 'new name';
       await repo.renameAccessKey(accessKey.id, accessKeyName);
       const res = {
@@ -265,7 +265,7 @@ describe('ShadowsocksManagerService', () => {
     });
     it('Create returns a 500 when the repository throws an exception', (done) => {
       const repo = getAccessKeyRepository();
-      spyOn(repo, 'createNewAccessKey').and.throwError('cannot write to disk');
+      spyOn(repo, 'createNewStaticAccessKey').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
 
       const res = {send: (httpCode, data) => {}};
@@ -285,14 +285,14 @@ describe('ShadowsocksManagerService', () => {
                           .accessKeys(repo)
                           .build();
 
-      const oldKey = await repo.createNewAccessKey();
+      const oldKey = await repo.createNewStaticAccessKey();
       const res = {
         send: (httpCode) => {
           expect(httpCode).toEqual(204);
         }
       };
       await service.setPortForNewAccessKeys({params: {port: NEW_PORT}}, res, () => {});
-      const newKey = await repo.createNewAccessKey();
+      const newKey = await repo.createNewStaticAccessKey();
       expect(newKey.proxyParams.portNumber).toEqual(NEW_PORT);
       expect(oldKey.proxyParams.portNumber).not.toEqual(NEW_PORT);
       responseProcessed = true;
@@ -435,8 +435,8 @@ describe('ShadowsocksManagerService', () => {
     it('removes keys', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const key1 = await repo.createNewAccessKey();
-      const key2 = await repo.createNewAccessKey();
+      const key1 = await repo.createNewStaticAccessKey();
+      const key2 = await repo.createNewStaticAccessKey();
       const res = {
         send: (httpCode, data) => {
           expect(httpCode).toEqual(204);
@@ -486,7 +486,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
 
-      const key = await repo.createNewAccessKey();
+      const key = await repo.createNewStaticAccessKey();
       const res = {send: (httpCode, data) => {}};
       service.renameAccessKey({params: {id: 123}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -513,7 +513,7 @@ describe('ShadowsocksManagerService', () => {
     it('sets access key data limit', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const key = await repo.createNewAccessKey();
+      const key = await repo.createNewStaticAccessKey();
       const limit = {bytes: 1000};
       const res = {send: (httpCode) => {
         expect(httpCode).toEqual(204);
@@ -527,7 +527,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects negative numbers', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const keyId = (await repo.createNewAccessKey()).id;
+      const keyId = (await repo.createNewStaticAccessKey()).id;
       const limit = {bytes: -1};
       service.setAccessKeyDataLimit({params: {id: keyId, limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -539,7 +539,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects non-numeric limits', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const keyId = (await repo.createNewAccessKey()).id;
+      const keyId = (await repo.createNewStaticAccessKey()).id;
       const limit = {bytes: "1"};
       service.setAccessKeyDataLimit({params: {id: keyId, limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -551,7 +551,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects an empty request', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const keyId = (await repo.createNewAccessKey()).id;
+      const keyId = (await repo.createNewStaticAccessKey()).id;
       const limit = {} as DataLimit;
       service.setAccessKeyDataLimit({params: {id: keyId, limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -563,7 +563,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects requests for nonexistent keys', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      await repo.createNewAccessKey();
+      await repo.createNewStaticAccessKey();
       const limit: DataLimit = {bytes: 1000};
       service.setAccessKeyDataLimit({params: {id: "not an id", limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(404);
@@ -577,7 +577,7 @@ describe('ShadowsocksManagerService', () => {
     it('removes an access key data limit', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const key = await repo.createNewAccessKey();
+      const key = await repo.createNewStaticAccessKey();
       repo.setAccessKeyDataLimit(key.id, {bytes: 1000});
       await repo.enforceAccessKeyDataLimits();
       const res = {send: (httpCode) => {
@@ -591,7 +591,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 404 for a nonexistent key', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      await repo.createNewAccessKey();
+      await repo.createNewStaticAccessKey();
       service.removeAccessKeyDataLimit({params: {id: "not an id"}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(404);
         responseProcessed = true;
@@ -631,7 +631,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 400 when limit is missing values', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewAccessKey();
+      const accessKey = await repo.createNewStaticAccessKey();
       const limit = {} as DataLimit;
       const res = {send: (httpCode, data) => {}};
       service.setDefaultDataLimit({params: {limit}}, res, (error) => {
@@ -643,7 +643,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 400 when limit has negative values', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewAccessKey();
+      const accessKey = await repo.createNewStaticAccessKey();
       const limit = {bytes: -1};
       const res = {send: (httpCode, data) => {}};
       service.setDefaultDataLimit({params: {limit}}, res, (error) => {
@@ -656,7 +656,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       spyOn(repo, 'setDefaultDataLimit').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      await repo.createNewAccessKey();
+      await repo.createNewStaticAccessKey();
       const limit = {bytes: 10000};
       const res = {send: (httpCode, data) => {}};
       service.setDefaultDataLimit({params: {limit}}, res, (error) => {
@@ -692,7 +692,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       spyOn(repo, 'removeDefaultDataLimit').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewAccessKey();
+      const accessKey = await repo.createNewStaticAccessKey();
       const res = {send: (httpCode, data) => {}};
       service.removeDefaultDataLimit({params: {id: accessKey.id}}, res, (error) => {
         expect(error.statusCode).toEqual(500);
@@ -779,7 +779,7 @@ class ShadowsocksManagerServiceBuilder {
 
 async function createNewAccessKeyWithName(
     repo: AccessKeyRepository, name: string): Promise<AccessKey> {
-  const accessKey = await repo.createNewAccessKey();
+  const accessKey = await repo.createNewStaticAccessKey();
   try {
     repo.renameAccessKey(accessKey.id, name);
   } catch (e) {

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -228,8 +228,8 @@ describe('ShadowsocksManagerService', () => {
     it('lists access keys with expected properties', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewStaticAccessKey();
-      await repo.createNewStaticAccessKey();
+      const accessKey = await repo.createAccessKey();
+      await repo.createAccessKey();
       const accessKeyName = 'new name';
       await repo.renameAccessKey(accessKey.id, accessKeyName);
       const res = {
@@ -265,7 +265,7 @@ describe('ShadowsocksManagerService', () => {
     });
     it('Create returns a 500 when the repository throws an exception', (done) => {
       const repo = getAccessKeyRepository();
-      spyOn(repo, 'createNewStaticAccessKey').and.throwError('cannot write to disk');
+      spyOn(repo, 'createAccessKey').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
 
       const res = {send: (httpCode, data) => {}};
@@ -285,14 +285,14 @@ describe('ShadowsocksManagerService', () => {
                           .accessKeys(repo)
                           .build();
 
-      const oldKey = await repo.createNewStaticAccessKey();
+      const oldKey = await repo.createAccessKey();
       const res = {
         send: (httpCode) => {
           expect(httpCode).toEqual(204);
         }
       };
       await service.setPortForNewAccessKeys({params: {port: NEW_PORT}}, res, () => {});
-      const newKey = await repo.createNewStaticAccessKey();
+      const newKey = await repo.createAccessKey();
       expect(newKey.proxyParams.portNumber).toEqual(NEW_PORT);
       expect(oldKey.proxyParams.portNumber).not.toEqual(NEW_PORT);
       responseProcessed = true;
@@ -435,8 +435,8 @@ describe('ShadowsocksManagerService', () => {
     it('removes keys', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const key1 = await repo.createNewStaticAccessKey();
-      const key2 = await repo.createNewStaticAccessKey();
+      const key1 = await repo.createAccessKey();
+      const key2 = await repo.createAccessKey();
       const res = {
         send: (httpCode, data) => {
           expect(httpCode).toEqual(204);
@@ -486,7 +486,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
 
-      const key = await repo.createNewStaticAccessKey();
+      const key = await repo.createAccessKey();
       const res = {send: (httpCode, data) => {}};
       service.renameAccessKey({params: {id: 123}}, res, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -513,7 +513,7 @@ describe('ShadowsocksManagerService', () => {
     it('sets access key data limit', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const key = await repo.createNewStaticAccessKey();
+      const key = await repo.createAccessKey();
       const limit = {bytes: 1000};
       const res = {send: (httpCode) => {
         expect(httpCode).toEqual(204);
@@ -527,7 +527,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects negative numbers', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const keyId = (await repo.createNewStaticAccessKey()).id;
+      const keyId = (await repo.createAccessKey()).id;
       const limit = {bytes: -1};
       service.setAccessKeyDataLimit({params: {id: keyId, limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -539,7 +539,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects non-numeric limits', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const keyId = (await repo.createNewStaticAccessKey()).id;
+      const keyId = (await repo.createAccessKey()).id;
       const limit = {bytes: "1"};
       service.setAccessKeyDataLimit({params: {id: keyId, limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -551,7 +551,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects an empty request', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const keyId = (await repo.createNewStaticAccessKey()).id;
+      const keyId = (await repo.createAccessKey()).id;
       const limit = {} as DataLimit;
       service.setAccessKeyDataLimit({params: {id: keyId, limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(400);
@@ -563,7 +563,7 @@ describe('ShadowsocksManagerService', () => {
     it('rejects requests for nonexistent keys', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      await repo.createNewStaticAccessKey();
+      await repo.createAccessKey();
       const limit: DataLimit = {bytes: 1000};
       service.setAccessKeyDataLimit({params: {id: "not an id", limit}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(404);
@@ -577,7 +577,7 @@ describe('ShadowsocksManagerService', () => {
     it('removes an access key data limit', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const key = await repo.createNewStaticAccessKey();
+      const key = await repo.createAccessKey();
       repo.setAccessKeyDataLimit(key.id, {bytes: 1000});
       await repo.enforceAccessKeyDataLimits();
       const res = {send: (httpCode) => {
@@ -591,7 +591,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 404 for a nonexistent key', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      await repo.createNewStaticAccessKey();
+      await repo.createAccessKey();
       service.removeAccessKeyDataLimit({params: {id: "not an id"}}, {send: () => {}}, (error) => {
         expect(error.statusCode).toEqual(404);
         responseProcessed = true;
@@ -631,7 +631,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 400 when limit is missing values', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewStaticAccessKey();
+      const accessKey = await repo.createAccessKey();
       const limit = {} as DataLimit;
       const res = {send: (httpCode, data) => {}};
       service.setDefaultDataLimit({params: {limit}}, res, (error) => {
@@ -643,7 +643,7 @@ describe('ShadowsocksManagerService', () => {
     it('returns 400 when limit has negative values', async (done) => {
       const repo = getAccessKeyRepository();
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewStaticAccessKey();
+      const accessKey = await repo.createAccessKey();
       const limit = {bytes: -1};
       const res = {send: (httpCode, data) => {}};
       service.setDefaultDataLimit({params: {limit}}, res, (error) => {
@@ -656,7 +656,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       spyOn(repo, 'setDefaultDataLimit').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      await repo.createNewStaticAccessKey();
+      await repo.createAccessKey();
       const limit = {bytes: 10000};
       const res = {send: (httpCode, data) => {}};
       service.setDefaultDataLimit({params: {limit}}, res, (error) => {
@@ -692,7 +692,7 @@ describe('ShadowsocksManagerService', () => {
       const repo = getAccessKeyRepository();
       spyOn(repo, 'removeDefaultDataLimit').and.throwError('cannot write to disk');
       const service = new ShadowsocksManagerServiceBuilder().accessKeys(repo).build();
-      const accessKey = await repo.createNewStaticAccessKey();
+      const accessKey = await repo.createAccessKey();
       const res = {send: (httpCode, data) => {}};
       service.removeDefaultDataLimit({params: {id: accessKey.id}}, res, (error) => {
         expect(error.statusCode).toEqual(500);
@@ -771,15 +771,16 @@ class ShadowsocksManagerServiceBuilder {
   }
 
   build(): ShadowsocksManagerService {
+    // TODO do this for real
     return new ShadowsocksManagerService(
         this.defaultServerName_, this.serverConfig_, this.accessKeys_, this.managerMetrics_,
-        this.metricsPublisher_);
+        this.metricsPublisher_, null, null);
   }
 }
 
 async function createNewAccessKeyWithName(
     repo: AccessKeyRepository, name: string): Promise<AccessKey> {
-  const accessKey = await repo.createNewStaticAccessKey();
+  const accessKey = await repo.createAccessKey();
   try {
     repo.renameAccessKey(accessKey.id, name);
   } catch (e) {
@@ -810,7 +811,5 @@ function getAccessKeyRepository(): ServerAccessKeyRepository {
       new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0}),
       new FakeShadowsocksServer(),
       new FakePrometheusClient({}),
-      'TODOBEFOREPUSH',
-      9999,
       null);
 }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -112,6 +112,8 @@ export function bindService(
   // Dynamic, single-user keys
   apiServer.put(`${apiPrefix}/experimental/dynamic-key`, service.createDynamicKey.bind(service));
   // Since GET on a resource should be idempotent, we use an in-path token instead of request bodies
+  // TODO: this exposes us to a malicious client POST-ing when they should GET and invalidating
+  // other clients using the key, allowing a DoS on the key.
   apiServer.post(
       `${apiPrefix}/experimental/dynamic-key/:token`, service.updateDynamicKey.bind(service));
   apiServer.get(

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -650,6 +650,6 @@ class RepoBuilder {
   public build(): ServerAccessKeyRepository {
     return new ServerAccessKeyRepository(
         this.port_, 'hostname', this.keyConfig_, this.shadowsocksServer_, this.prometheusClient_,
-        this.defaultDataLimit_);
+        'TODOBEFOREPUSH', 54321, this.defaultDataLimit_);
   }
 }

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -32,7 +32,7 @@ describe('ServerAccessKeyRepository', () => {
 
   it('Can create new access keys', (done) => {
     const repo = new RepoBuilder().build();
-    repo.createNewStaticAccessKey().then((accessKey) => {
+    repo.createAccessKey().then((accessKey) => {
       expect(accessKey).toBeDefined();
       done();
     });
@@ -40,14 +40,14 @@ describe('ServerAccessKeyRepository', () => {
 
   it('Creates access keys under limit', async (done) => {
     const repo = new RepoBuilder().build();
-    const accessKey = await repo.createNewStaticAccessKey();
+    const accessKey = await repo.createAccessKey();
     expect(accessKey.isOverDataLimit).toBeFalsy();
     done();
   });
 
   it('Can remove access keys', (done) => {
     const repo = new RepoBuilder().build();
-    repo.createNewStaticAccessKey().then((accessKey) => {
+    repo.createAccessKey().then((accessKey) => {
       expect(countAccessKeys(repo)).toEqual(1);
       expect(repo.removeAccessKey.bind(repo, accessKey.id)).not.toThrow();
       expect(countAccessKeys(repo)).toEqual(0);
@@ -57,7 +57,7 @@ describe('ServerAccessKeyRepository', () => {
 
   it('removeAccessKey throws for missing keys', (done) => {
     const repo = new RepoBuilder().build();
-    repo.createNewStaticAccessKey().then((accessKey) => {
+    repo.createAccessKey().then((accessKey) => {
       expect(countAccessKeys(repo)).toEqual(1);
       expect(repo.removeAccessKey.bind(repo, 'badId')).toThrowError(errors.AccessKeyNotFound);
       expect(countAccessKeys(repo)).toEqual(1);
@@ -67,7 +67,7 @@ describe('ServerAccessKeyRepository', () => {
 
   it('Can rename access keys', (done) => {
     const repo = new RepoBuilder().build();
-    repo.createNewStaticAccessKey().then((accessKey) => {
+    repo.createAccessKey().then((accessKey) => {
       const NEW_NAME = 'newName';
       expect(repo.renameAccessKey.bind(repo, accessKey.id, NEW_NAME)).not.toThrow();
       // List keys again and expect to see the NEW_NAME.
@@ -79,7 +79,7 @@ describe('ServerAccessKeyRepository', () => {
 
   it('renameAccessKey throws for missing keys', (done) => {
     const repo = new RepoBuilder().build();
-    repo.createNewStaticAccessKey().then((accessKey) => {
+    repo.createAccessKey().then((accessKey) => {
       const NEW_NAME = 'newName';
       expect(repo.renameAccessKey.bind(repo, 'badId', NEW_NAME))
           .toThrowError(errors.AccessKeyNotFound);
@@ -94,7 +94,7 @@ describe('ServerAccessKeyRepository', () => {
     const portProvider = new PortProvider();
     const port = await portProvider.reserveNewPort();
     const repo = new RepoBuilder().port(port).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     expect(key.proxyParams.portNumber).toEqual(port);
     done();
   });
@@ -104,7 +104,7 @@ describe('ServerAccessKeyRepository', () => {
     const port = await portProvider.reserveNewPort();
     const repo = new RepoBuilder().build();
     await repo.setPortForNewAccessKeys(port);
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     expect(key.proxyParams.portNumber).toEqual(port);
     done();
   });
@@ -113,7 +113,7 @@ describe('ServerAccessKeyRepository', () => {
     const portProvider = new PortProvider();
     const oldPort = await portProvider.reserveNewPort();
     const repo = new RepoBuilder().port(oldPort).build();
-    const oldKey = await repo.createNewStaticAccessKey();
+    const oldKey = await repo.createAccessKey();
 
     const newPort = await portProvider.reserveNewPort();
     await repo.setPortForNewAccessKeys(newPort);
@@ -153,7 +153,7 @@ describe('ServerAccessKeyRepository', () => {
     const portProvider = new PortProvider();
     const oldPort = await portProvider.reserveNewPort();
     const repo = new RepoBuilder().port(oldPort).build();
-    await repo.createNewStaticAccessKey();
+    await repo.createAccessKey();
 
     await expectNoAsyncThrow(portProvider.reserveNewPort.bind(portProvider));
     // simulate the first key's connection on its port
@@ -169,7 +169,7 @@ describe('ServerAccessKeyRepository', () => {
     const server = new FakeShadowsocksServer();
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo = new RepoBuilder().shadowsocksServer(server).keyConfig(config).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     const limit = {bytes: 5000};
     await expectNoAsyncThrow(repo.setAccessKeyDataLimit.bind(repo, key.id, {bytes: 5000}));
     expect(key.dataLimit).toEqual(limit);
@@ -191,7 +191,7 @@ describe('ServerAccessKeyRepository', () => {
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
     await repo.start(new ManualClock());
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 0});
 
     expect(key.isOverDataLimit).toBeTruthy();
@@ -213,8 +213,8 @@ describe('ServerAccessKeyRepository', () => {
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
     await repo.start(new ManualClock());
-    const lowerLimitThanDefault = await repo.createNewStaticAccessKey();
-    const higherLimitThanDefault = await repo.createNewStaticAccessKey();
+    const lowerLimitThanDefault = await repo.createAccessKey();
+    const higherLimitThanDefault = await repo.createAccessKey();
     await repo.setDefaultDataLimit({bytes: 1000});
 
     expect(lowerLimitThanDefault.isOverDataLimit).toBeFalsy();
@@ -231,7 +231,7 @@ describe('ServerAccessKeyRepository', () => {
     const server = new FakeShadowsocksServer();
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo = new RepoBuilder().shadowsocksServer(server).keyConfig(config).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 1});
     await expectNoAsyncThrow(repo.removeAccessKeyDataLimit.bind(repo, key.id));
     expect(key.dataLimit).toBeFalsy();
@@ -244,7 +244,7 @@ describe('ServerAccessKeyRepository', () => {
     const prometheusClient = new FakePrometheusClient({'0': 500});
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await repo.start(new ManualClock());
     await repo.setDefaultDataLimit({bytes: 0});
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 1000});
@@ -261,7 +261,7 @@ describe('ServerAccessKeyRepository', () => {
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
     await repo.start(new ManualClock());
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 0});
 
     expect(key.isOverDataLimit).toBeTruthy();
@@ -283,8 +283,8 @@ describe('ServerAccessKeyRepository', () => {
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
     await repo.start(new ManualClock());
-    const lowerLimitThanDefault = await repo.createNewStaticAccessKey();
-    const higherLimitThanDefault = await repo.createNewStaticAccessKey();
+    const lowerLimitThanDefault = await repo.createAccessKey();
+    const higherLimitThanDefault = await repo.createAccessKey();
     await repo.setDefaultDataLimit({bytes: 1000});
 
     expect(lowerLimitThanDefault.isOverDataLimit).toBeFalsy();
@@ -308,7 +308,7 @@ describe('ServerAccessKeyRepository', () => {
     const server = new FakeShadowsocksServer();
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo = new RepoBuilder().shadowsocksServer(server).keyConfig(config).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 1});
     await expectNoAsyncThrow(repo.removeAccessKeyDataLimit.bind(repo, key.id));
     expect(key.dataLimit).toBeFalsy();
@@ -321,7 +321,7 @@ describe('ServerAccessKeyRepository', () => {
     const prometheusClient = new FakePrometheusClient({'0': 500});
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await repo.start(new ManualClock());
     await repo.setDefaultDataLimit({bytes: 0});
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 1000});
@@ -337,7 +337,7 @@ describe('ServerAccessKeyRepository', () => {
     const prometheusClient = new FakePrometheusClient({'0': 500});
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     await repo.start(new ManualClock());
 
     await setKeyLimitAndEnforce(repo, key.id, {bytes: 0});
@@ -363,8 +363,8 @@ describe('ServerAccessKeyRepository', () => {
     const prometheusClient = new FakePrometheusClient({'0': 500, '1': 200});
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
-    const accessKey1 = await repo.createNewStaticAccessKey();
-    const accessKey2 = await repo.createNewStaticAccessKey();
+    const accessKey1 = await repo.createAccessKey();
+    const accessKey2 = await repo.createAccessKey();
     await repo.start(new ManualClock());
 
     repo.setDefaultDataLimit({bytes: 250});
@@ -409,8 +409,8 @@ describe('ServerAccessKeyRepository', () => {
                      .defaultDataLimit({bytes: 200})
                      .build();
 
-    const accessKey1 = await repo.createNewStaticAccessKey();
-    const accessKey2 = await repo.createNewStaticAccessKey();
+    const accessKey1 = await repo.createAccessKey();
+    const accessKey2 = await repo.createAccessKey();
     await repo.start(new ManualClock());
     expect(server.getAccessKeys().length).toEqual(1);
 
@@ -432,7 +432,7 @@ describe('ServerAccessKeyRepository', () => {
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).defaultDataLimit(limit).build();
     for (let i = 0; i < Object.keys(prometheusClient.bytesTransferredById).length; ++i) {
-      await repo.createNewStaticAccessKey();
+      await repo.createAccessKey();
     }
     await repo.enforceAccessKeyDataLimits();
     for (const key of repo.listAccessKeys()) {
@@ -454,8 +454,8 @@ describe('ServerAccessKeyRepository', () => {
     const prometheusClient = new FakePrometheusClient({'0': 200, '1': 300});
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).defaultDataLimit({bytes: 500}).build();
-    const perKeyLimited = await repo.createNewStaticAccessKey();
-    const defaultLimited = await repo.createNewStaticAccessKey();
+    const perKeyLimited = await repo.createAccessKey();
+    const defaultLimited = await repo.createAccessKey();
     await setKeyLimitAndEnforce(repo, perKeyLimited.id, {bytes: 100});
 
     await repo.enforceAccessKeyDataLimits();
@@ -480,8 +480,8 @@ describe('ServerAccessKeyRepository', () => {
                      .defaultDataLimit({bytes: 200})
                      .build();
 
-    const accessKey1 = await repo.createNewStaticAccessKey();
-    const accessKey2 = await repo.createNewStaticAccessKey();
+    const accessKey1 = await repo.createAccessKey();
+    const accessKey2 = await repo.createAccessKey();
 
     await repo.enforceAccessKeyDataLimits();
     const accessKeys = await repo.listAccessKeys();
@@ -500,7 +500,7 @@ describe('ServerAccessKeyRepository', () => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo1 = new RepoBuilder().keyConfig(config).build();
     // Create 2 new access keys
-    await Promise.all([repo1.createNewStaticAccessKey(), repo1.createNewStaticAccessKey()]);
+    await Promise.all([repo1.createAccessKey(), repo1.createAccessKey()]);
     // Modify properties
     repo1.renameAccessKey('1', 'name');
 
@@ -516,13 +516,13 @@ describe('ServerAccessKeyRepository', () => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     // Create a repo with 1 access key, then delete that access key.
     const repo1 = new RepoBuilder().keyConfig(config).build();
-    repo1.createNewStaticAccessKey().then((accessKey1) => {
+    repo1.createAccessKey().then((accessKey1) => {
       repo1.removeAccessKey(accessKey1.id);
 
       // Create a 2nd repo with one access key, and verify that
       // it hasn't reused the first access key's ID.
       const repo2 = new RepoBuilder().keyConfig(config).build();
-      repo2.createNewStaticAccessKey().then((accessKey2) => {
+      repo2.createAccessKey().then((accessKey2) => {
         expect(accessKey1.id).not.toEqual(accessKey2.id);
         done();
       });
@@ -533,8 +533,8 @@ describe('ServerAccessKeyRepository', () => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo = new RepoBuilder().keyConfig(config).build();
 
-    const accessKey1 = await repo.createNewStaticAccessKey();
-    const accessKey2 = await repo.createNewStaticAccessKey();
+    const accessKey1 = await repo.createAccessKey();
+    const accessKey2 = await repo.createAccessKey();
     // Create a new repository with the same configuration. The keys should not be exposed to the
     // server until `start` is called.
     const server = new FakeShadowsocksServer();
@@ -553,9 +553,9 @@ describe('ServerAccessKeyRepository', () => {
     const prometheusClient = new FakePrometheusClient({'0': 500, '1': 200, '2': 400});
     const repo =
         new RepoBuilder().prometheusClient(prometheusClient).shadowsocksServer(server).build();
-    const accessKey1 = await repo.createNewStaticAccessKey();
-    const accessKey2 = await repo.createNewStaticAccessKey();
-    const accessKey3 = await repo.createNewStaticAccessKey();
+    const accessKey1 = await repo.createAccessKey();
+    const accessKey2 = await repo.createAccessKey();
+    const accessKey3 = await repo.createAccessKey();
     await repo.setDefaultDataLimit({bytes: 300});
     const clock = new ManualClock();
     await repo.start(clock);
@@ -585,7 +585,7 @@ describe('ServerAccessKeyRepository', () => {
     const newHostname = 'host2';
     const repo = new RepoBuilder().build();
     repo.setHostname(newHostname);
-    const key = await repo.createNewStaticAccessKey();
+    const key = await repo.createAccessKey();
     expect(key.proxyParams.hostname).toEqual(newHostname);
     done();
   });
@@ -650,6 +650,6 @@ class RepoBuilder {
   public build(): ServerAccessKeyRepository {
     return new ServerAccessKeyRepository(
         this.port_, 'hostname', this.keyConfig_, this.shadowsocksServer_, this.prometheusClient_,
-        'TODOBEFOREPUSH', 54321, this.defaultDataLimit_);
+        this.defaultDataLimit_);
   }
 }


### PR DESCRIPTION
This is a simple, incomplete prototype of single-user dynamic keys.  Tokens are implemented as uuid's.  Persistence is implemented by maintaining a separate mapping of token -> key id.  We use an in-path token as opposed to passing it in the request body because that allows us to keep `GET` idempotent.

```sh
$ curl -X PUT -k https://localhost:8081/TestApiPrefix/experimental/dynamic-key                          

{"token":"ab3809bd-8c81-4f79-ac6e-9c733961b58d"}      
                                      
$ curl -k https://localhost:8081/TestApiPrefix/experimental/dynamic-key/ab3809bd-8c81-4f79-ac6e-9c733961b58d

{"id":"0","name":"","password":"sCANyHDjpyr6","port":9999,"method":"chacha20-ietf-poly1305","accessUrl":"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpzQ0FOeUhEanB5cjY@127.0.0.1:9999/?outline=1"}
    
$ curl -X POST -k https://localhost:8081/TestApiPrefix/experimental/dynamic-key/ab3809bd-8c81-4f79-ac6e-9c733961b58d

{"id":"1","name":"","password":"2VlkCml7sbk5","port":9999,"method":"chacha20-ietf-poly1305","accessUrl":"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNToyVmxrQ21sN3NiazU@127.0.0.1:9999/?outline=1"}
    
$ curl -k https://localhost:8081/TestApiPrefix/experimental/dynamic-key/ab3809bd-8c81-4f79-ac6e-9c733961b58d 

{"id":"1","name":"","password":"2VlkCml7sbk5","port":9999,"method":"chacha20-ietf-poly1305","accessUrl":"ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNToyVmxrQ21sN3NiazU@127.0.0.1:9999/?outline=1"}
```

I'll update this description as I implement more details.  Some things not included

* The access service is just part of the manager service
* Not SIP008 compliant
* No consideration for port of the access service
* No cert fingerprint
* Nothing keeping clients from DoS-ing the key by POST ing to their key path instead of GET ing
* No UI