### PR TITLE
Load per key data limits from the config file

### DIFF
--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -503,6 +503,7 @@ describe('ServerAccessKeyRepository', () => {
     await Promise.all([repo1.createNewAccessKey(), repo1.createNewAccessKey()]);
     // Modify properties
     repo1.renameAccessKey('1', 'name');
+    repo1.setAccessKeyDataLimit('0', {bytes: 1});
 
     // Create a 2nd repo from the same config file. This simulates what
     // might happen after the shadowbox server is restarted.

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -64,7 +64,7 @@ function makeAccessKey(hostname: string, accessKeyJson: AccessKeyStorageJson): A
     password: accessKeyJson.password,
   };
   return new ServerAccessKey(
-      accessKeyJson.id, accessKeyJson.name, accessKeyJson.metricsId, proxyParams);
+      accessKeyJson.id, accessKeyJson.name, accessKeyJson.metricsId, proxyParams, accessKeyJson.dataLimit);
 }
 
 function accessKeyToStorageJson(accessKey: AccessKey): AccessKeyStorageJson {


### PR DESCRIPTION
Fixes a bug where we don't load the data limits on individual keys from the config file when restarting the server.  This would result in dropping the data limits, while instead we want them to be properly persisted.