### PR TITLE
Bump shadowbox to 1.6.1

### DIFF
--- a/src/shadowbox/package.json
+++ b/src/shadowbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-server",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Outline server",
   "main": "build/server/main.js",
   "author": "Outline",


### PR DESCRIPTION
This is to release the bugfix from https://github.com/Jigsaw-Code/outline-server/pull/881