### PR TITLE
Force remove integration test logfiles

### DIFF
--- a/src/shadowbox/integration_test/run_action.sh
+++ b/src/shadowbox/integration_test/run_action.sh
@@ -28,7 +28,7 @@ if ./test.sh > "${LOGFILE}" 2>&1 ; then
   echo "Test Passed!"
   # Removing the log file sometimes fails on Travis.  There's no point in us cleaning it up
   # on a CI build anyways.
-  [[ -z TRAVIS_JOB_ID ]] || rm "${LOGFILE}"
+  rm -f "${LOGFILE}"
 else
   result=$?
   echo "Test Failed!  Logs:"

--- a/src/shadowbox/integration_test/run_action.sh
+++ b/src/shadowbox/integration_test/run_action.sh
@@ -26,7 +26,9 @@ declare -i result=0
 
 if ./test.sh > "${LOGFILE}" 2>&1 ; then
   echo "Test Passed!"
-  rm "${LOGFILE}"
+  # Removing the log file sometimes fails on Travis.  There's no point in us cleaning it up
+  # on a CI build anyways.
+  [[ -z TRAVIS_JOB_ID ]] || rm "${LOGFILE}"
 else
   result=$?
   echo "Test Failed!  Logs:"


### PR DESCRIPTION
This should help occasional flaky failures we get from "permission failed" errors when trying to delete the log file