### PR TITLE
Populate an unreachable server's view with the server id

### DIFF
--- a/src/server_manager/model/server.ts
+++ b/src/server_manager/model/server.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 export interface Server {
-  // Gets a globally unique identifier for this Server.
+  // Gets a globally unique identifier for this Server.  THIS MUST NOT make a network request, as
+  // it's used to identify unreachable servers.
   getId(): string;
 
   // Gets the server's name for display.

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -813,11 +813,13 @@ export class App {
 
   private async setServerUnreachableView(server: server.Server): Promise<void> {
     // Display the unreachable server state within the server view.
-    const serverView = await this.appRoot.getServerView(server.getId());
+    const serverId = server.getId();
+    const serverView = await this.appRoot.getServerView(serverId);
     serverView.selectedPage = 'unreachableView';
     serverView.isServerManaged = isManagedServer(server);
     serverView.serverName =
         this.makeDisplayName(server);  // Don't get the name from the remote server.
+    serverView.serverId = serverId;
     serverView.retryDisplayingServer = async () => {
       await this.updateServerView(server);
     };
@@ -1163,7 +1165,6 @@ export class App {
       console.error(msg);
       throw new Error(msg);
     }
-
     const confirmationTitle = this.appRoot.localize('confirmation-server-remove-title');
     const confirmationText = this.appRoot.localize('confirmation-server-remove');
     const confirmationButton = this.appRoot.localize('remove');


### PR DESCRIPTION
This fixes issues forgetting an unreachable server which were caused by the missing id keeping us from finding the server to forget.

Fix https://github.com/Jigsaw-Code/outline-server/issues/888
Fix https://github.com/Jigsaw-Code/outline-server/issues/886
Fix https://github.com/Jigsaw-Code/outline-server/issues/873