### PR TITLE
Fix GCP billing account list visibility problem

### DIFF
--- a/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
+++ b/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
@@ -262,7 +262,7 @@ export class GcpCreateServerApp extends LitElement {
               </div>
             </div>
             <div class="section-content">
-              <paper-dropdown-menu id="billingAccount" no-label-float="">
+              <paper-dropdown-menu id="billingAccount" no-label-float="" horizontal-align="left">
                 <paper-listbox slot="dropdown-content" selected="${
         this.selectedBillingAccountId}" attr-for-selected="name" @selected-changed="${
         this.onBillingAccountSelected}">


### PR DESCRIPTION
When billing accounts are present with long names, they would be cut off
on the left side.  This shifts the list to extend right instead of left.