### PR TITLE
Hide closed billing accounts from the UI

### DIFF
--- a/src/server_manager/model/gcp.ts
+++ b/src/server_manager/model/gcp.ts
@@ -88,6 +88,9 @@ export interface Account {
   /** Lists the Google Cloud Platform projects available with the user. */
   listProjects(): Promise<Project[]>;
 
-  /** Lists the Google Cloud Platform billing accounts associated with the user. */
-  listBillingAccounts(): Promise<BillingAccount[]>;
+  /**
+   * Lists the active Google Cloud Platform billing accounts associated with
+   * the user.
+   */
+  listOpenBillingAccounts(): Promise<BillingAccount[]>;
 }

--- a/src/server_manager/web_app/gcp_account.ts
+++ b/src/server_manager/web_app/gcp_account.ts
@@ -166,7 +166,7 @@ export class GcpAccount implements gcp.Account {
   }
 
   /** @see {@link Account#listBillingAccounts}. */
-  async listBillingAccounts(): Promise<BillingAccount[]> {
+  async listOpenBillingAccounts(): Promise<BillingAccount[]> {
     const response = await this.apiClient.listBillingAccounts();
     if (response.billingAccounts?.length > 0) {
       return response.billingAccounts

--- a/src/server_manager/web_app/gcp_account.ts
+++ b/src/server_manager/web_app/gcp_account.ts
@@ -169,12 +169,12 @@ export class GcpAccount implements gcp.Account {
   async listBillingAccounts(): Promise<BillingAccount[]> {
     const response = await this.apiClient.listBillingAccounts();
     if (response.billingAccounts?.length > 0) {
-      return response.billingAccounts.map(billingAccount => {
-        return {
-          id: billingAccount.name.substring(billingAccount.name.lastIndexOf('/') + 1),
-          name: billingAccount.displayName,
-        };
-      });
+      return response.billingAccounts
+          .filter(billingAccount => billingAccount.open)
+          .map(billingAccount => ({
+        id: billingAccount.name.substring(billingAccount.name.lastIndexOf('/') + 1),
+        name: billingAccount.displayName,
+      }));
     }
     return [];
   }

--- a/src/server_manager/web_app/testing/models.ts
+++ b/src/server_manager/web_app/testing/models.ts
@@ -79,7 +79,7 @@ export class FakeGcpAccount implements gcp.Account {
   async isProjectHealthy(projectId: string): Promise<boolean> {
     return true;
   }
-  async listBillingAccounts(): Promise<gcp.BillingAccount[]> {
+  async listOpenBillingAccounts(): Promise<gcp.BillingAccount[]> {
     return this.billingAccounts;
   }
   async listProjects(): Promise<gcp.Project[]> {

--- a/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
+++ b/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
@@ -298,7 +298,7 @@ export class GcpCreateServerApp extends LitElement {
     this.init();
     this.account = account;
 
-    this.billingAccounts = await this.account.listBillingAccounts();
+    this.billingAccounts = await this.account.listOpenBillingAccounts();
     const projects = await this.account.listProjects();
     // TODO: We don't support multiple projects atm, but we will want to allow
     //  the user to choose the appropriate one.
@@ -337,7 +337,7 @@ export class GcpCreateServerApp extends LitElement {
   }
 
   private async refreshBillingAccounts(): Promise<void> {
-    this.billingAccounts = await this.account.listBillingAccounts();
+    this.billingAccounts = await this.account.listOpenBillingAccounts();
     // TODO: listBillingAccounts() can reject, resulting in an uncaught
     // exception here that is shown in the debug console but not reflected
     // in the UI.  We need to something better than failing silently.


### PR DESCRIPTION
This will also ensure that the user is prompted to add a billing account
if all the existing accounts are closed.