### PR TITLE
Stop refreshing billing status if the page is closed

### DIFF
--- a/src/server_manager/web_app/ui_components/app-root.js
+++ b/src/server_manager/web_app/ui_components/app-root.js
@@ -570,7 +570,10 @@ export class AppRoot extends mixinBehaviors
         type: Boolean,
         computed: '_computeHasAcceptedTermsOfService(userAcceptedTos)',
       },
-      currentPage: {type: String},
+      currentPage: {
+        type: String,
+        observer: '_currentPageChanged',
+      },
       shouldShowSideBar: {type: Boolean},
       sideBarMarginClass: {
         type: String,
@@ -697,6 +700,14 @@ export class AppRoot extends mixinBehaviors
 
   showServerView() {
     this.currentPage = 'serverView';
+  }
+
+  _currentPageChanged() {
+    if (this.currentPage !== 'gcpCreateServer') {
+      // The refresh loop will be restarted by App, which calls
+      // GcpCreateServerApp.start() whenever it switches back to this page.
+      this.$.gcpCreateServer.stopRefreshingBillingAccounts();
+    }
   }
 
   /**

--- a/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
+++ b/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
@@ -349,7 +349,7 @@ export class GcpCreateServerApp extends LitElement {
     }
   }
 
-  private stopRefreshingBillingAccounts(): void {
+  public stopRefreshingBillingAccounts(): void {
     window.clearInterval(this.billingAccountsRefreshLoop);
     this.billingAccountsRefreshLoop = null;
   }


### PR DESCRIPTION
This stops unnecessary polling if the user navigates away from the GCP flow
after logging in but before adding a billing account.