### PR TITLE
Fix electron-builder release builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Manager
         run: |
-          yarn do server_manager/electron_app/release_linux
+          SENTRY_DSN='test' yarn do server_manager/electron_app/release_linux
           yarn do server_manager/test
 
       - name: Shadowbox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Manager
         run: |
-          yarn do server_manager/electron_app/build
+          yarn do server_manager/electron_app/release_linux
           yarn do server_manager/test
 
       - name: Shadowbox

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -77,7 +77,7 @@
     "@types/semver": "^5.5.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.3",
-    "electron": "^13.1.2",
+    "electron": "13.1.2",
     "electron-builder": "~22.4.0",
     "electron-icon-maker": "^0.0.4",
     "electron-notarize": "^0.2.1",


### PR DESCRIPTION
electron-builder cannot tolerate electron versions that are specified
with semantic versioning syntax: https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-547115107

This change also adds release builds to the presubmit, to prevent
regressions.