### PR TITLE
GCP: Make server creation more responsive

### DIFF
--- a/src/server_manager/cloud/gcp_api.ts
+++ b/src/server_manager/cloud/gcp_api.ts
@@ -44,9 +44,7 @@ export type Instance = Readonly<{
 }>;
 
 /** @see https://cloud.google.com/compute/docs/reference/rest/v1/addresses */
-type StaticIp = Readonly<{
-  name: string;
-}>;
+type StaticIp = Readonly<{}>;
 
 const GCE_V1_API = 'https://compute.googleapis.com/compute/v1';
 
@@ -165,7 +163,6 @@ type ItemsResponse<T> = Readonly<{items: T; nextPageToken: string;}>;
 
 type ListInstancesResponse = ItemsResponse<Instance[]>;
 type ListAllInstancesResponse = ItemsResponse<{[zone: string]: {instances: Instance[];}}>;
-type ListAllStaticIpsResponse = ItemsResponse<{[region: string]: {addresses: StaticIp[];}}>;
 type ListZonesResponse = ItemsResponse<Zone[]>;
 type ListProjectsResponse = Readonly<{projects: Project[]; nextPageToken: string;}>;
 type ListFirewallsResponse = ItemsResponse<Firewall[]>;
@@ -322,18 +319,17 @@ export class RestApiClient {
   }
 
   /**
-   * Lists all static IPs in a project.
+   * Retrieves a static IP address, if it exists.
    *
-   * @see https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
+   * @see https://cloud.google.com/compute/docs/reference/rest/v1/addresses/get
    *
-   * @param zone - Indicates the GCP project and zone.
-   * @param filter - See documentation.
+   * @param region - The GCP project and region.
+   * @param addressName - The name of the static IP address resource.
    */
-  // TODO: Pagination
-  listAllStaticIps(projectId: string): Promise<ListAllStaticIpsResponse> {
-    return this.fetchAuthenticated(
+  getStaticIp(region: RegionLocator, addressName: string): Promise<StaticIp> {
+    return this.fetchAuthenticated<ComputeEngineOperation>(
         'GET',
-        new URL(`${projectUrl(projectId)}/aggregated/addresses`),
+        new URL(`${regionUrl(region)}/addresses/${addressName}`),
         this.GCP_HEADERS);
   }
 

--- a/src/server_manager/cloud/gcp_api.ts
+++ b/src/server_manager/cloud/gcp_api.ts
@@ -193,13 +193,14 @@ export class RestApiClient {
    *
    * @param scope - Indicates the GCP project and zone.
    * @param data - Request body data. See documentation.
+   * @return The initial operation response.  Call computeEngineOperationZoneWait
+   *     to wait for the creation process to complete.
    */
   async createInstance(scope: ZoneScope, data: {}): Promise<ComputeEngineOperation> {
-    const operation = await this.fetchAuthenticated<ComputeEngineOperation>(
+    return this.fetchAuthenticated<ComputeEngineOperation>(
         'POST',
         new URL(`${zoneLink(scope)}/instances`),
         this.GCP_HEADERS, null, data);
-    return await this.computeEngineOperationZoneWait(scope, operation.name);
   }
 
   /**

--- a/src/server_manager/cloud/gcp_api.ts
+++ b/src/server_manager/cloud/gcp_api.ts
@@ -124,7 +124,7 @@ export type ResourceManagerOperation = Readonly<{name: string; done: boolean; er
  * @see https://cloud.google.com/compute/docs/reference/rest/v1/globalOperations
  * @see https://cloud.google.com/compute/docs/reference/rest/v1/zoneOperations
  */
-type ComputeEngineOperation = Readonly<
+export type ComputeEngineOperation = Readonly<
     {id: string; name: string; targetId: string; status: string; error: {errors: Status[]}}>;
 
 /**
@@ -214,13 +214,14 @@ export class RestApiClient {
    * @see https://cloud.google.com/compute/docs/reference/rest/v1/instances/delete
    *
    * @param instance - Identifies the instance to delete.
+   * @return The initial operation response.  Call computeEngineOperationZoneWait
+   *     to wait for the deletion process to complete.
    */
-  async deleteInstance(instance: InstanceLocator): Promise<void> {
-    const operation = await this.fetchAuthenticated<ComputeEngineOperation>(
+  deleteInstance(instance: InstanceLocator): Promise<ComputeEngineOperation> {
+    return this.fetchAuthenticated<ComputeEngineOperation>(
         'DELETE',
         new URL(instanceUrl(instance)),
         this.GCP_HEADERS);
-    await this.computeEngineOperationZoneWait(instance, operation.name);
   }
 
   /**
@@ -309,13 +310,14 @@ export class RestApiClient {
    *
    * @param region - The GCP project and region.
    * @param addressName - The name of the static IP address resource.
+   * @return The initial operation response.  Call computeEngineOperationRegionWait
+   *     to wait for the deletion process to complete.
    */
-  async deleteStaticIp(region: RegionLocator, addressName: string): Promise<void> {
-    const operation = await this.fetchAuthenticated<ComputeEngineOperation>(
+  deleteStaticIp(region: RegionLocator, addressName: string): Promise<ComputeEngineOperation> {
+    return this.fetchAuthenticated<ComputeEngineOperation>(
         'DELETE',
         new URL(`${regionUrl(region)}/addresses/${addressName}`),
         this.GCP_HEADERS);
-    await this.computeEngineOperationRegionWait(region, operation.name);
   }
 
   /**

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -1112,6 +1112,8 @@ export class App {
     const confirmationButton = this.appRoot.localize('destroy');
     this.appRoot.getConfirmation(confirmationTitle, confirmationText, confirmationButton, () => {
       this.digitalOceanRetry(() => {
+            // On GCP, deletion takes 1-2 minutes.
+            // TODO: Add an activity indicator in OutlineServerView during deletion.
             return serverToDelete.getHost().delete();
           })
           .then(
@@ -1187,6 +1189,10 @@ export class App {
       console.error(msg);
       throw new Error(msg);
     }
+    // On GCP, deletion takes 1-2 minutes.
+    // TODO: Make the cancel button show an immediate state transition,
+    // indicate that deletion is in-progress, and allow the user to return
+    // to server creation in the meantime.
     serverToCancel.getHost().delete().then(() => {
       this.removeServer(serverToCancel.getId());
       this.showIntro();

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -1112,7 +1112,6 @@ export class App {
     const confirmationButton = this.appRoot.localize('destroy');
     this.appRoot.getConfirmation(confirmationTitle, confirmationText, confirmationButton, () => {
       this.digitalOceanRetry(() => {
-            // On GCP, deletion takes 1-2 minutes.
             // TODO: Add an activity indicator in OutlineServerView during deletion.
             return serverToDelete.getHost().delete();
           })
@@ -1189,7 +1188,6 @@ export class App {
       console.error(msg);
       throw new Error(msg);
     }
-    // On GCP, deletion takes 1-2 minutes.
     // TODO: Make the cancel button show an immediate state transition,
     // indicate that deletion is in-progress, and allow the user to return
     // to server creation in the meantime.

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -49,7 +49,7 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
       private apiClient: gcp_api.RestApiClient) {
     super(id);
     // Optimization: start the check for a static IP immediately.
-    const hasStaticIp = this.hasStaticIp();
+    const hasStaticIp: Promise<boolean> = this.hasStaticIp();
     this.instanceReadiness = instanceCreation.then(async () => {
       if (!await hasStaticIp) {
         await this.promoteEphemeralIp();

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -174,20 +174,20 @@ class GcpHost implements server.ManagedServerHost {
       projectId: this.locator.projectId
     };
     // By convention, the static IP for an Outline instance uses the instance's name.
-    // This process takes ~8 seconds.
     await this.waitForDelete(
         this.apiClient.deleteStaticIp(regionLocator, this.gcpInstanceName),
         'Deleted server did not have a static IP');
-    // This process takes 1-2 minutes.
     await this.waitForDelete(
         this.apiClient.deleteInstance(this.locator),
         'No instance for deleted server');
     this.setInstallState(InstallState.DELETED);
   }
 
-  private async waitForDelete(deletion: Promise<unknown>, msg404: string): Promise<void> {
+  private async waitForDelete(deletion: Promise<gcp_api.ComputeEngineOperation>, msg404: string): Promise<void> {
     try {
       await deletion;
+      // We assume that deletion will eventually succeed once the operation has
+      // been queued successfully, so there's no need to wait for it.
     } catch (e) {
       if (is404(e)) {
         console.warn(msg404);

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -28,6 +28,8 @@ enum InstallState {
   SUCCESS,
   // Server is in an error state.
   ERROR,
+  // Server deletion has been initiated.
+  DELETING,
   // Server has been deleted.
   DELETED
 }
@@ -35,17 +37,66 @@ enum InstallState {
 export class GcpServer extends ShadowboxServer implements server.ManagedServer {
   private static readonly GUEST_ATTRIBUTES_POLLING_INTERVAL_MS = 5 * 1000;
 
+  private readonly instanceReadiness: Promise<void>;
   private readonly gcpHost: GcpHost;
   private installState: InstallState = InstallState.UNKNOWN;
 
   constructor(
       id: string,
       private locator: gcp_api.InstanceLocator,
-      gcpInstanceName: string,  // See makeGcpInstanceName() in gcp_account.ts.
-      private instanceCreation: Promise<void>,
+      private gcpInstanceName: string,  // See makeGcpInstanceName() in gcp_account.ts.
+      instanceCreation: Promise<unknown>,
       private apiClient: gcp_api.RestApiClient) {
     super(id);
-    this.gcpHost = new GcpHost(locator, gcpInstanceName, instanceCreation, apiClient, this.onDelete.bind(this));
+    // Optimization: start the check for a static IP immediately.
+    const hasStaticIp = this.hasStaticIp();
+    this.instanceReadiness = instanceCreation.then(async () => {
+      if (!await hasStaticIp) {
+        await this.promoteEphemeralIp();
+      }
+    }).catch((e) => {
+      this.setInstallState(InstallState.ERROR);
+      throw e;
+    })
+    this.gcpHost = new GcpHost(locator, gcpInstanceName, this.instanceReadiness, apiClient, this.setInstallState.bind(this));
+  }
+
+  private getRegionLocator(): gcp_api.RegionLocator {
+    return {
+      regionId: new Zone(this.locator.zoneId).regionId,
+      projectId: this.locator.projectId
+    }
+  }
+
+  private async hasStaticIp(): Promise<boolean> {
+    try {
+      // By convention, the static IP for an Outline instance uses the instance's name.
+      await this.apiClient.getStaticIp(this.getRegionLocator(), this.gcpInstanceName);
+      return true;
+    } catch (e) {
+      if (is404(e)) {
+        // The IP address has not yet been reserved.
+        return false;
+      }
+      throw new errors.ServerInstallFailedError(`Static IP check failed: ${e}`);
+    }
+  }
+
+  private async promoteEphemeralIp(): Promise<void> {
+    const instance = await this.apiClient.getInstance(this.locator);
+    // Promote ephemeral IP to static IP
+    const ipAddress = instance.networkInterfaces[0].accessConfigs[0].natIP;
+    const createStaticIpData = {
+      name: instance.name,
+      description: instance.description,
+      address: ipAddress,
+    };
+    const createStaticIpOperation = await this.apiClient.createStaticIp(
+        this.getRegionLocator(), createStaticIpData);
+    const operationErrors = createStaticIpOperation.error?.errors;
+    if (operationErrors) {
+      throw new errors.ServerInstallFailedError(`Firewall creation failed: ${operationErrors}`);
+    }
   }
 
   getHost(): ManagedServerHost {
@@ -57,7 +108,7 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
   }
 
   async waitOnInstall(): Promise<void> {
-    await this.instanceCreation;  // Throws if instance creation fails.
+    await this.instanceReadiness;  // Throws if instance preparation fails.
     while (this.installState === InstallState.UNKNOWN) {
       const outlineGuestAttributes = await this.getOutlineGuestAttributes();
       if (outlineGuestAttributes.has('apiUrl') && outlineGuestAttributes.has('certSha256')) {
@@ -66,12 +117,20 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
         trustCertificate(certSha256);
         this.setManagementApiUrl(apiUrl);
         this.installState = InstallState.SUCCESS;
+        break;
       } else if (outlineGuestAttributes.has('install-error')) {
         this.installState = InstallState.ERROR;
-        throw new errors.ServerInstallFailedError();
+        break;
       }
 
       await sleep(GcpServer.GUEST_ATTRIBUTES_POLLING_INTERVAL_MS);
+    }
+
+    if (this.installState === InstallState.ERROR) {
+      throw new errors.ServerInstallFailedError();
+    } else if (this.installState === InstallState.DELETING ||
+               this.installState === InstallState.DELETED) {
+      throw new errors.DeletedServerError();
     }
   }
 
@@ -86,37 +145,57 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
     return result;
   }
 
-  private onDelete() {
-    // TODO: Consider setInstallState.
-    this.installState = InstallState.DELETED;
+  setInstallState(newState: InstallState): void {
+    this.installState = newState;
   }
 }
 
 class GcpHost implements server.ManagedServerHost {
   constructor(
-      private locator: gcp_api.InstanceLocator,
-      private gcpInstanceName: string,
-      private instanceCreation: Promise<void>,
-      private apiClient: gcp_api.RestApiClient,
-      private deleteCallback: Function) {}
+      private readonly locator: gcp_api.InstanceLocator,
+      private readonly gcpInstanceName: string,
+      private readonly instanceReadiness: Promise<unknown>,
+      private readonly apiClient: gcp_api.RestApiClient,
+      private readonly setInstallState: (newState: InstallState) => void) {}
 
-  // TODO: Throw error and show message on failure
   async delete(): Promise<void> {
+    this.setInstallState(InstallState.DELETING);
     // The GCP API documentation doesn't specify whether instances can be deleted
     // before creation has finished, and the static IP allocation is entirely
-    // asynchronous, so we must wait for creation to complete before starting deletion.
-    // Also, if creation failed, then deletion is trivially successful.
+    // asynchronous, so we must wait for instance setup to complete before starting
+    // deletion. Also, if creation failed, then deletion is trivially successful.
     try {
-      await this.instanceCreation;
+      await this.instanceReadiness;
     } catch (e) {
-      console.warn(`Skipping deletion due to failed instance creation: ${e}`);
-      return;
+      console.warn(`Attempting deletion of server that failed setup: ${e}`);
     }
-    const regionId = this.getCloudLocation().regionId;
+    const regionLocator = {
+      regionId: this.getCloudLocation().regionId,
+      projectId: this.locator.projectId
+    };
     // By convention, the static IP for an Outline instance uses the instance's name.
-    await this.apiClient.deleteStaticIp({regionId, ...this.locator}, this.gcpInstanceName);
-    this.apiClient.deleteInstance(this.locator);
-    this.deleteCallback();
+    // This process takes ~8 seconds.
+    await this.waitForDelete(
+        this.apiClient.deleteStaticIp(regionLocator, this.gcpInstanceName),
+        'Deleted server did not have a static IP');
+    // This process takes 1-2 minutes.
+    await this.waitForDelete(
+        this.apiClient.deleteInstance(this.locator),
+        'No instance for deleted server');
+    this.setInstallState(InstallState.DELETED);
+  }
+
+  private async waitForDelete(deletion: Promise<unknown>, msg404: string): Promise<void> {
+    try {
+      await deletion;
+    } catch (e) {
+      if (is404(e)) {
+        console.warn(msg404);
+        return;
+      }
+      this.setInstallState(InstallState.ERROR);
+      throw e;
+    }
   }
 
   getHostId(): string {
@@ -134,4 +213,8 @@ class GcpHost implements server.ManagedServerHost {
   getCloudLocation(): Zone {
     return new Zone(this.locator.zoneId);
   }
+}
+
+function is404(error: Error): boolean {
+  return error instanceof gcp_api.HttpError && error.getStatusCode() === 404;
 }

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -75,8 +75,7 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
     }
   }
 
-  private async getOutlineGuestAttributes():
-      Promise<Map<string, string>> {
+  private async getOutlineGuestAttributes(): Promise<Map<string, string>> {
     const result = new Map<string, string>();
     const guestAttributes =
         await this.apiClient.getGuestAttributes(this.locator, 'outline/');

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -57,7 +57,7 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
     }).catch((e) => {
       this.setInstallState(InstallState.ERROR);
       throw e;
-    })
+    });
     this.gcpHost = new GcpHost(locator, gcpInstanceName, this.instanceReadiness, apiClient, this.setInstallState.bind(this));
   }
 
@@ -65,7 +65,7 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
     return {
       regionId: new Zone(this.locator.zoneId).regionId,
       projectId: this.locator.projectId
-    }
+    };
   }
 
   private async hasStaticIp(): Promise<boolean> {

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -105,7 +105,13 @@ class GcpHost implements server.ManagedServerHost {
     // The GCP API documentation doesn't specify whether instances can be deleted
     // before creation has finished, and the static IP allocation is entirely
     // asynchronous, so we must wait for creation to complete before starting deletion.
-    await this.instanceCreation;
+    // Also, if creation failed, then deletion is trivially successful.
+    try {
+      await this.instanceCreation;
+    } catch (e) {
+      console.warn(`Skipping deletion due to failed instance creation: ${e}`);
+      return;
+    }
     const regionId = this.getCloudLocation().regionId;
     // By convention, the static IP for an Outline instance uses the instance's name.
     await this.apiClient.deleteStaticIp({regionId, ...this.locator}, this.gcpInstanceName);


### PR DESCRIPTION
Currently, if the user starts server creation in GCP, they are stuck
on the region picker page until server creation completes. This takes
a long time, and is different from DigitalOcean, where server creation
is faster because it hasn't fully completed when the creation request
returns.

This change makes the GCP behavior match the DigitalOcean behavior, by
creating a ManagedServer object as soon as we know what the instance's
ID will be. This works by creating the Server object earlier, before
the instance is actually ready.