### PR TITLE
Install Docker on GCP using the Ubuntu dpkg method

### DIFF
--- a/src/server_manager/install_scripts/gcp_install_server.sh
+++ b/src/server_manager/install_scripts/gcp_install_server.sh
@@ -95,6 +95,25 @@ function finish {
 }
 trap finish EXIT
 
+# Docker is not installed by default.  If we don't install it here,
+# install.sh will download it using the get.docker.com script (much slower).
+log_for_sentry "Downloading Docker"
+# Following instructions from https://docs.docker.com/engine/install/ubuntu/#install-from-a-package
+
+declare -ar PACKAGES=(
+  'containerd.io_1.4.9-1_amd64.deb'
+  'docker-ce_20.10.8~3-0~ubuntu-focal_amd64.deb'
+  'docker-ce-cli_20.10.8~3-0~ubuntu-focal_amd64.deb'
+)
+
+declare packages_csv
+packages_csv="$(printf ',%s' "${PACKAGES[@]}")"
+packages_csv="${packages_csv:1}"
+curl --remote-name-all --fail "https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/{${packages_csv}}"
+log_for_sentry "Installing Docker"
+dpkg --install "${PACKAGES[@]}"
+rm "${PACKAGES[@]}"
+
 # Run install script asynchronously, so tags can be written as soon as they are ready.
 log_for_sentry "Running install_server.sh"
 ./install_server.sh&

--- a/src/server_manager/web_app/gcp_account.ts
+++ b/src/server_manager/web_app/gcp_account.ts
@@ -223,7 +223,7 @@ export class GcpAccount implements gcp.Account {
         {
           boot: true,
           initializeParams: {
-            sourceImage: 'projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts',
+            sourceImage: 'projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts',
           },
         },
       ],

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -43,13 +43,13 @@ enum InstallState {
 
 function getCompletionFraction(state: InstallState): number {
   // Values are based on observed installation timing.
-  // Installation typically takes ~5 minutes in total.
+  // Installation typically takes ~2.6 minutes in total.
   switch (state) {
-    case InstallState.UNKNOWN: return 0.005;
-    case InstallState.INSTANCE_CREATED: return 0.03;
-    case InstallState.IP_ALLOCATED: return 0.04;
-    case InstallState.INSTANCE_RUNNING: return 0.2;
-    case InstallState.CERTIFICATE_CREATED: return 0.8;
+    case InstallState.UNKNOWN: return 0.01;
+    case InstallState.INSTANCE_CREATED: return 0.12;
+    case InstallState.IP_ALLOCATED: return 0.14;
+    case InstallState.INSTANCE_RUNNING: return 0.4;
+    case InstallState.CERTIFICATE_CREATED: return 0.7;
     case InstallState.COMPLETED: return 1.0;
     default: return 0;
   }
@@ -188,6 +188,7 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
   }
 
   private setInstallState(newState: InstallState): void {
+    console.debug(InstallState[newState]);
     this.installState.set(newState);
     if (isFinal(newState)) {
       this.installState.close();


### PR DESCRIPTION
This cuts the GCP server setup time approximately in half, likely
because it avoids multiple calls to "apt update", which
synchronizes all known package repositories.

This PR also updates the underlying Ubuntu image to the latest LTS
release.