### PR TITLE
Improve GCP instance name construction

### DIFF
--- a/src/server_manager/web_app/gcp_account.ts
+++ b/src/server_manager/web_app/gcp_account.ts
@@ -25,9 +25,16 @@ import * as server_install from "./server_install";
 
 /** Returns a unique, RFC1035-style name as required by GCE. */
 function makeGcpInstanceName(): string {
+  function pad2(val: number) { return val.toString().padStart(2, '0'); }
+
   const now = new Date();
-  const isoMinusMilliseconds = now.toISOString().substring(0, 19);
-  return `outline-${isoMinusMilliseconds.toLowerCase().replace(/:/g, '-')}`;
+  const year = now.getUTCFullYear().toString();
+  const month = pad2(now.getUTCMonth() + 1);  // January is month 0.
+  const day = pad2(now.getUTCDate());
+  const hour = pad2(now.getUTCHours());
+  const minute = pad2(now.getUTCMinutes());
+  const second = pad2(now.getUTCSeconds());
+  return `outline-${year}${month}${day}-${hour}${minute}${second}`;
 }
 
 // Regions where the first f1-micro instance is free.

--- a/src/server_manager/web_app/gcp_account.ts
+++ b/src/server_manager/web_app/gcp_account.ts
@@ -26,8 +26,8 @@ import * as server_install from "./server_install";
 /** Returns a unique, RFC1035-style name as required by GCE. */
 function makeGcpInstanceName(): string {
   const now = new Date();
-  return `outline-${now.getFullYear()}${now.getMonth()}${now.getDate()}-${now.getUTCHours()}${
-      now.getUTCMinutes()}${now.getUTCSeconds()}`;
+  const isoMinusMilliseconds = now.toISOString().substring(0, 19);
+  return `outline-${isoMinusMilliseconds.toLowerCase().replace(/:/g, '-')}`;
 }
 
 // Regions where the first f1-micro instance is free.


### PR DESCRIPTION
The current code generates names by concatenating integers in a custom
format, with several bugs:
* Leading zeros are discarded
* The date is in local time, but the time is in UTC.
* Months are presented zero-indexed (i.e. January is month zero)

This change corrects these issues.