### PR TITLE
Fix login bug after free trial period expires

### DIFF
--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -376,7 +376,7 @@ export class App {
           result.push(server);
         }
       } catch (e) {
-        if (e instanceof HttpError && e.getStatusCode() == 403) {
+        if (e instanceof HttpError && e.getStatusCode() === 403) {
           // listServers() throws an HTTP 403 if the outline project has been
           // created but the billing account has been removed, which can
           // easily happen after the free trial period expires.  This is

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -29,7 +29,7 @@ import {filterOptions, getShortName} from './location_formatting';
 import {parseManualServerConfig} from './management_urls';
 import {AppRoot, ServerListEntry} from './ui_components/app-root';
 import {DisplayAccessKey, ServerView} from './ui_components/outline-server-view';
-import {DisplayCloudId} from './ui_components/cloud-assets';
+import {HttpError} from '../cloud/gcp_api';
 
 // The Outline DigitalOcean team's referral code:
 //   https://www.digitalocean.com/help/referral-program/
@@ -369,10 +369,24 @@ export class App {
     const result = [];
     const gcpProjects = await this.gcpAccount.listProjects();
     for (const gcpProject of gcpProjects) {
-      const servers = await this.gcpAccount.listServers(gcpProject.id);
-      for (const server of servers) {
-        this.addServer(this.gcpAccount.getId(), server);
-        result.push(server);
+      try {
+        const servers = await this.gcpAccount.listServers(gcpProject.id);
+        for (const server of servers) {
+          this.addServer(this.gcpAccount.getId(), server);
+          result.push(server);
+        }
+      } catch (e) {
+        if (e instanceof HttpError && e.getStatusCode() == 403) {
+          // listServers() throws an HTTP 403 if the outline project has been
+          // created but the billing account has been removed, which can
+          // easily happen after the free trial period expires.  This is
+          // harmless, because a project with no billing cannot contain any
+          // servers, and the GCP server creation flow will check and correct
+          // the billing account setup.
+          console.warn(`Ignoring HTTP 403 for GCP project "${gcpProject.id}"`);
+        } else {
+          throw e;
+        }
       }
     }
     return result;

--- a/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
+++ b/src/server_manager/web_app/ui_components/outline-gcp-create-server-app.ts
@@ -254,9 +254,7 @@ export class GcpCreateServerApp extends LitElement {
       // TODO: Surface this error to the user.
       console.warn('Error fetching GCP account info', e);
     }
-    const isProjectHealthy =
-        this.project ? await this.account.isProjectHealthy(this.project.id) : false;
-    if (this.project && isProjectHealthy) {
+    if (await this.isProjectHealthy()) {
       this.showRegionPicker();
     } else if (!(this.billingAccounts?.length > 0)) {
       this.showBillingAccountSetup();
@@ -271,6 +269,12 @@ export class GcpCreateServerApp extends LitElement {
     } else {
       this.showProjectSetup(this.project);
     }
+  }
+
+  private async isProjectHealthy(): Promise<boolean> {
+    return this.project ?
+        await this.account.isProjectHealthy(this.project.id)
+        : false;
   }
 
   disconnectedCallback() {
@@ -294,7 +298,11 @@ export class GcpCreateServerApp extends LitElement {
 
     if (this.billingAccounts?.length > 0) {
       this.stopRefreshingBillingAccounts();
-      this.showProjectSetup();
+      if (await this.isProjectHealthy()) {
+        this.showRegionPicker();
+      } else {
+        this.showProjectSetup(this.project);
+      }
       window.bringToFront();
     }
   }


### PR DESCRIPTION
When the free trial period expires, the Outline project is left linked
to an inactive billing account, and all instances are deleted.
Attempting to list the instances associated with a project that lacks
billing results in an HTTP 403.  Currently, this results in GCP login
failure, with a generic error message.

This change makes the manager handle this account state gracefully,
taking the user to the billing setup screen, and from there directly
to the server creation screen.