### PR TITLE
Remove deprecated buffer constructor

### DIFF
--- a/src/server_manager/electron_app/start.action.sh
+++ b/src/server_manager/electron_app/start.action.sh
@@ -16,7 +16,7 @@
 
 run_action server_manager/electron_app/build
 
-readonly NODE_MODULES_BIN_DIR="${ROOT_DIR}/src/server_manager/node_modules/.bin"
+readonly NODE_MODULES_BIN_DIR="${ROOT_DIR}/node_modules/.bin"
 
 cd "${BUILD_DIR}/server_manager/electron_app/static"
 OUTLINE_DEBUG='true' \

--- a/src/server_manager/electron_app/start.action.sh
+++ b/src/server_manager/electron_app/start.action.sh
@@ -19,5 +19,5 @@ run_action server_manager/electron_app/build
 cd "${BUILD_DIR}/server_manager/electron_app/static"
 
 OUTLINE_DEBUG='true' \
-    SB_METRICS_URL='https://dev.metrics.getoutline.org' \
-    electron .
+  SB_METRICS_URL='https://dev.metrics.getoutline.org' \
+  electron .

--- a/src/server_manager/electron_app/start.action.sh
+++ b/src/server_manager/electron_app/start.action.sh
@@ -16,9 +16,8 @@
 
 run_action server_manager/electron_app/build
 
-readonly NODE_MODULES_BIN_DIR="${ROOT_DIR}/node_modules/.bin"
-
 cd "${BUILD_DIR}/server_manager/electron_app/static"
+
 OUTLINE_DEBUG='true' \
-SB_METRICS_URL='https://dev.metrics.getoutline.org' \
-"${NODE_MODULES_BIN_DIR}/electron" .
+    SB_METRICS_URL='https://dev.metrics.getoutline.org' \
+    electron .

--- a/src/server_manager/install_scripts/build_do_install_script_ts.node.js
+++ b/src/server_manager/install_scripts/build_do_install_script_ts.node.js
@@ -15,10 +15,9 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 
 const tarballBinary = fs.readFileSync(process.argv[2]);
-const base64Tarball = new Buffer(tarballBinary).toString('base64');
+const base64Tarball = tarballBinary.toString('base64');
 const scriptText = `
 (base64 --decode | tar --extract --gzip ) <<EOM
 ${base64Tarball}

--- a/src/server_manager/install_scripts/build_gcp_install_script_ts.node.js
+++ b/src/server_manager/install_scripts/build_gcp_install_script_ts.node.js
@@ -15,10 +15,9 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 
 const tarballBinary = fs.readFileSync(process.argv[2]);
-const base64Tarball = new Buffer(tarballBinary).toString('base64');
+const base64Tarball = tarballBinary.toString('base64');
 const scriptText = `
 (base64 --decode | tar --extract --gzip ) <<EOM
 ${base64Tarball}


### PR DESCRIPTION
`new Buffer` was deprecated in Node 8 (i believe) for security reasons. `readFileSync` already returns a `Buffer` - is there a reason we were doing this?

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

TODO:
- [x] verify if script is the same 
- [x] try to create a DO server