### PR TITLE
Fix docker keyring permissions due to custom umask

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -158,7 +158,10 @@ function fetch() {
 }
 
 function install_docker() {
+  umask 0022
+  (chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg 2>/dev/null || true)
   (fetch https://get.docker.com/ | sh) >&2
+  umask 0007
 }
 
 function start_docker() {

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -158,10 +158,13 @@ function fetch() {
 }
 
 function install_docker() {
-  umask 0022
-  (chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg 2>/dev/null || true)
-  (fetch https://get.docker.com/ | sh) >&2
-  umask 0007
+  (
+    # Change umask so that /usr/share/keyrings/docker-archive-keyring.gpg has the right permissions.
+    # See https://github.com/Jigsaw-Code/outline-server/issues/951.
+    # We do this in a subprocess so the umask for the calling process is unaffected.
+    umask 0022
+    fetch https://get.docker.com/ | sh
+  ) >&2
 }
 
 function start_docker() {


### PR DESCRIPTION
Due to `umask 0007` set in `install_shadowbox` function, official docker installation script creates
`/usr/share/keyrings/docker-archive-keyring.gpg` file without read-other permission, which later
leads to permanent apt-update failure.

```
# sudo bash -c "$(cat install_server.sh)"
> Verifying that Docker is installed .......... NOT INSTALLED
> Would you like to install Docker? This will run 'curl https://get.docker.com/ | sh'. [Y/n] y
> Installing Docker ........................... OK
> Verifying Docker installation ............... 
Last error: # Executing docker install script, commit: 93d2499759296ac1f9c510605fef85052a2c32be
+ sh -c apt-get update -qq >/dev/null
W: GPG error: https://download.docker.com/linux/ubuntu focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8
E: The repository 'https://download.docker.com/linux/ubuntu focal InRelease' is not signed.

Sorry! Something went wrong. If you can't figure this out, please copy and paste all this output into the Outline Manager screen, and send it to us, to see if we can help you.
Full log: /tmp/outline_log8Bv
```

Fix this issue by reverting the custom umask to a default one and manually fix
the existing file permissions, if any.