### PR TITLE
chore: Update electron to 18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5498,6 +5498,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5786,9 +5795,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6247,9 +6256,9 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "version": "0.0.981744",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+      "integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
       "dev": true
     },
     "node_modules/dezalgo": {
@@ -7015,9 +7024,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.879",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.879.tgz",
-      "integrity": "sha512-zJo+D9GwbJvM31IdFmwcGvychhk4KKbKYo2GWlsn+C/dxz2NwmbhGJjWwTfFSF2+eFH7VvfA8MCZ8SOqTrlnpw==",
+      "version": "1.4.122",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
+      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
       "dev": true
     },
     "node_modules/electron-updater": {
@@ -15704,36 +15713,27 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.6.0.tgz",
+      "integrity": "sha512-EJXhTyY5bXNPLFXPGcY9JaF6EKJIX8ll8cGG3WUK+553Jx96oDf1cB+lkFOro9p0X16tY+9xx7zYWl+vnWgW2g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.981744",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.5.0"
       },
       "engines": {
         "node": ">=10.18.1"
-      }
-    },
-    "node_modules/puppeteer/node_modules/agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/puppeteer/node_modules/extract-zip": {
@@ -15782,19 +15782,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/puppeteer/node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "5",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/puppeteer/node_modules/locate-path": {
@@ -21575,12 +21562,12 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -21828,7 +21815,7 @@
         "electron-builder": "~22.10.5",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^0.2.1",
-        "electron-to-chromium": "^1.3.752",
+        "electron-to-chromium": "^1.4.122",
         "gulp": "^4.0.0",
         "gulp-posthtml": "^3.0.4",
         "gulp-replace": "^1.0.0",
@@ -21841,7 +21828,7 @@
         "postcss": "^7.0.29",
         "postcss-rtl": "^1.7.3",
         "posthtml-postcss": "^0.2.6",
-        "puppeteer": "^5.5.0",
+        "puppeteer": "^13.6.0",
         "style-loader": "^1.2.1",
         "ts-loader": "^7.0.1",
         "webpack": "^4.43.0",
@@ -26488,6 +26475,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -26706,9 +26702,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -27069,9 +27065,9 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "version": "0.0.981744",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+      "integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
       "dev": true
     },
     "dezalgo": {
@@ -27722,9 +27718,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.879",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.879.tgz",
-      "integrity": "sha512-zJo+D9GwbJvM31IdFmwcGvychhk4KKbKYo2GWlsn+C/dxz2NwmbhGJjWwTfFSF2+eFH7VvfA8MCZ8SOqTrlnpw==",
+      "version": "1.4.122",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
+      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
       "dev": true
     },
     "electron-updater": {
@@ -33534,7 +33530,7 @@
         "electron-builder": "~22.10.5",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^0.2.1",
-        "electron-to-chromium": "^1.3.752",
+        "electron-to-chromium": "^1.4.122",
         "electron-updater": "^4.1.2",
         "express": "^4.17.1",
         "google-auth-library": "^7.0.2",
@@ -33554,7 +33550,7 @@
         "postcss": "^7.0.29",
         "postcss-rtl": "^1.7.3",
         "posthtml-postcss": "^0.2.6",
-        "puppeteer": "^5.5.0",
+        "puppeteer": "^13.6.0",
         "request": "^2.87.0",
         "style-loader": "^1.2.1",
         "ts-loader": "^7.0.1",
@@ -34744,31 +34740,25 @@
       }
     },
     "puppeteer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.6.0.tgz",
+      "integrity": "sha512-EJXhTyY5bXNPLFXPGcY9JaF6EKJIX8ll8cGG3WUK+553Jx96oDf1cB+lkFOro9p0X16tY+9xx7zYWl+vnWgW2g==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.981744",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.5.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        },
         "extract-zip": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -34798,16 +34788,6 @@
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "5",
-            "debug": "4"
           }
         },
         "locate-path": {
@@ -39552,9 +39532,9 @@
       }
     },
     "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,9 +1777,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "version": "16.11.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
+      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -6856,14 +6856,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
-      "integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.1.0.tgz",
+      "integrity": "sha512-P55wdHNTRMo7a/agC84ZEZDYEK/pTBcQdlp8lFbHcx3mO4Kr+Im/J5p2uQgiuXtown31HqNh2paL3V0p+E6rpQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.0.1",
-        "@types/node": "^14.6.2",
+        "@electron/get": "^1.13.0",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
       "bin": {
@@ -7129,12 +7129,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
-      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -21808,7 +21802,7 @@
         "@polymer/paper-tooltip": "^3.0.0",
         "@sentry/electron": "^2",
         "@webcomponents/webcomponentsjs": "^2.0.0",
-        "circle-flags": "git+ssh://git@github.com/HatScripts/circle-flags.git#f1913a16694e8d19daa88d59e61886b762313c2d",
+        "circle-flags": "https://github.com/HatScripts/circle-flags",
         "clipboard-polyfill": "^2.4.6",
         "dotenv": "~8.2.0",
         "electron-updater": "^4.1.2",
@@ -21822,7 +21816,7 @@
         "web-animations-js": "^2.3.1"
       },
       "devDependencies": {
-        "@types/node": "^15.12.2",
+        "@types/node": "^16.11.29",
         "@types/node-forge": "^0.6.9",
         "@types/polymer": "^1.2.9",
         "@types/puppeteer": "^5.4.2",
@@ -21830,7 +21824,7 @@
         "@types/semver": "^5.5.0",
         "copy-webpack-plugin": "^5.1.1",
         "css-loader": "^3.5.3",
-        "electron": "13.3.0",
+        "electron": "18.1.0",
         "electron-builder": "~22.10.5",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^0.2.1",
@@ -21863,7 +21857,7 @@
         "ip-regex": "^4.1.0",
         "js-yaml": "^3.12.0",
         "node-fetch": "^2.6.7",
-        "outline-shadowsocksconfig": "git+ssh://git@github.com/Jigsaw-Code/outline-shadowsocksconfig.git#add590ed57277653d02dd2031ae301500ae881e1",
+        "outline-shadowsocksconfig": "github:Jigsaw-Code/outline-shadowsocksconfig#v0.2.0",
         "prom-client": "^11.1.3",
         "randomstring": "^1.1.5",
         "restify": "^8.5.1",
@@ -23465,9 +23459,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "version": "16.11.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
+      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -27598,22 +27592,14 @@
       }
     },
     "electron": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
-      "integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.1.0.tgz",
+      "integrity": "sha512-P55wdHNTRMo7a/agC84ZEZDYEK/pTBcQdlp8lFbHcx3mO4Kr+Im/J5p2uQgiuXtown31HqNh2paL3V0p+E6rpQ==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.0.1",
-        "@types/node": "^14.6.2",
+        "@electron/get": "^1.13.0",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-          "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
-          "dev": true
-        }
       }
     },
     "electron-builder": {
@@ -33532,19 +33518,19 @@
         "@polymer/paper-toast": "^3.0.0",
         "@polymer/paper-tooltip": "^3.0.0",
         "@sentry/electron": "^2",
-        "@types/node": "^15.12.2",
+        "@types/node": "^16.11.29",
         "@types/node-forge": "^0.6.9",
         "@types/polymer": "^1.2.9",
         "@types/puppeteer": "^5.4.2",
         "@types/request": "^2.47.1",
         "@types/semver": "^5.5.0",
         "@webcomponents/webcomponentsjs": "^2.0.0",
-        "circle-flags": "git+ssh://git@github.com/HatScripts/circle-flags.git#f1913a16694e8d19daa88d59e61886b762313c2d",
+        "circle-flags": "https://github.com/HatScripts/circle-flags",
         "clipboard-polyfill": "^2.4.6",
         "copy-webpack-plugin": "^5.1.1",
         "css-loader": "^3.5.3",
         "dotenv": "~8.2.0",
-        "electron": "13.3.0",
+        "electron": "18.1.0",
         "electron-builder": "~22.10.5",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^0.2.1",
@@ -33600,7 +33586,7 @@
         "ip-regex": "^4.1.0",
         "js-yaml": "^3.12.0",
         "node-fetch": "^2.6.7",
-        "outline-shadowsocksconfig": "git+ssh://git@github.com/Jigsaw-Code/outline-shadowsocksconfig.git#add590ed57277653d02dd2031ae301500ae881e1",
+        "outline-shadowsocksconfig": "github:Jigsaw-Code/outline-shadowsocksconfig#v0.2.0",
         "prom-client": "^11.1.3",
         "randomstring": "^1.1.5",
         "restify": "^8.5.1",

--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -74,7 +74,6 @@ function createMainWindow() {
     webPreferences: {
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js'),
-      nativeWindowOpen: true,
       webviewTag: false,
     },
   });

--- a/src/server_manager/electron_app/tsconfig.json
+++ b/src/server_manager/electron_app/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2021",
     "removeComments": false,
     "noImplicitAny": true,
     "module": "commonjs",
     "rootDir": ".",
-    "lib": ["dom", "es2016"]
+    "lib": ["dom", "es2021"]
   },
   "include": ["*.ts", "../types/*.d.ts"],
   "exclude": ["node_modules"],

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -70,7 +70,7 @@
     "PUPPETEER_CHROMIUM_REVISION": "870763"
   },
   "devDependencies": {
-    "@types/node": "^15.12.2",
+    "@types/node": "^16.11.29",
     "@types/node-forge": "^0.6.9",
     "@types/polymer": "^1.2.9",
     "@types/puppeteer": "^5.4.2",
@@ -78,7 +78,7 @@
     "@types/semver": "^5.5.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.3",
-    "electron": "13.3.0",
+    "electron": "18.1.0",
     "electron-builder": "~22.10.5",
     "electron-icon-maker": "^0.0.4",
     "electron-notarize": "^0.2.1",

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -67,7 +67,7 @@
     }
   },
   "config": {
-    "PUPPETEER_CHROMIUM_REVISION": "870763"
+    "PUPPETEER_CHROMIUM_REVISION": "1086"
   },
   "devDependencies": {
     "@types/node": "^16.11.29",
@@ -82,7 +82,7 @@
     "electron-builder": "~22.10.5",
     "electron-icon-maker": "^0.0.4",
     "electron-notarize": "^0.2.1",
-    "electron-to-chromium": "^1.3.752",
+    "electron-to-chromium": "^1.4.122",
     "gulp": "^4.0.0",
     "gulp-posthtml": "^3.0.4",
     "gulp-replace": "^1.0.0",
@@ -95,7 +95,7 @@
     "postcss": "^7.0.29",
     "postcss-rtl": "^1.7.3",
     "posthtml-postcss": "^0.2.6",
-    "puppeteer": "^5.5.0",
+    "puppeteer": "^13.6.0",
     "style-loader": "^1.2.1",
     "ts-loader": "^7.0.1",
     "webpack": "^4.43.0",

--- a/src/server_manager/web_app/data_formatting.spec.ts
+++ b/src/server_manager/web_app/data_formatting.spec.ts
@@ -36,11 +36,11 @@ describe('formatBytesParts', () => {
       expect(russian.value).toEqual('3');
 
       const simplifiedChinese = formatting.formatBytesParts(1.5 * 10 ** 9, 'zh-CN');
-      expect(simplifiedChinese.unit).toEqual('吉字节');
+      expect(simplifiedChinese.unit).toEqual('GB');
       expect(simplifiedChinese.value).toEqual('1.5');
 
       const farsi = formatting.formatBytesParts(133.5 * 10 ** 6, 'fa');
-      expect(farsi.unit).toEqual('مگابایت');
+      expect(farsi.unit).toEqual('MB');
       expect(farsi.value).toEqual('۱۳۳٫۵');
     });
   }

--- a/src/server_manager/web_app/data_formatting.ts
+++ b/src/server_manager/web_app/data_formatting.ts
@@ -14,12 +14,7 @@
   limitations under the License.
 */
 
-// import '@formatjs/intl-numberformat/polyfill'
-
 // Utility functions for internationalizing numbers and units
-
-// WARNING!  This assumes an ES2020 target as this will always run on browser code in
-// electron's built-in Chromium.  This code shouldn't be used by anything running in Node.
 
 const TERABYTE = 10 ** 12;
 const GIGABYTE = 10 ** 9;


### PR DESCRIPTION
This includes changes to the tsconfig recommended for Node.JS 16
and a required change to remove an obsolete attribute.