### PR TITLE
fix(manager): Prevent colliding servers

### DIFF
--- a/src/server_manager/electron_app/preload.ts
+++ b/src/server_manager/electron_app/preload.ts
@@ -47,9 +47,12 @@ if (sentryDsn) {
   });
 }
 
-contextBridge.exposeInMainWorld('trustCertificate', (host: string, fingerprint: string) => {
-  return ipcRenderer.sendSync('trust-certificate', host, fingerprint);
-});
+contextBridge.exposeInMainWorld(
+  'trustCertificate',
+  (host: string, fingerprint: string): boolean => {
+    return ipcRenderer.sendSync('trust-certificate', host, fingerprint);
+  }
+);
 
 contextBridge.exposeInMainWorld('openImage', (basename: string) => {
   ipcRenderer.send('open-image', basename);

--- a/src/server_manager/web_app/browser_main.ts
+++ b/src/server_manager/web_app/browser_main.ts
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(window as any).trustCertificate = (host: string, fingerprint: string) => {
+(window as any).trustCertificate = (host: string, fingerprint: string): boolean => {
   console.log(`Requested to trust certificate for ${host}: ${fingerprint}`);
+  return true; // Simulate success for the gallery.
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/server_manager/web_app/digitalocean_server.ts
+++ b/src/server_manager/web_app/digitalocean_server.ts
@@ -187,7 +187,10 @@ export class DigitalOceanServer extends ShadowboxServer implements server.Manage
       const apiAddress = this.getManagementApiAddress();
       const parsed = new URL(apiAddress);
       // Loaded both the cert and url without exceptions, they can be set.
-      trustCertificate(parsed.host, certificateFingerprint);
+      if (!trustCertificate(parsed.host, certificateFingerprint)) {
+        console.error('Failed to mark certificate trusted');
+        return false;
+      }
       this.setManagementApiUrl(apiAddress);
       return true;
     } catch (e) {

--- a/src/server_manager/web_app/gcp_server.ts
+++ b/src/server_manager/web_app/gcp_server.ts
@@ -180,7 +180,9 @@ export class GcpServer extends ShadowboxServer implements server.ManagedServer {
         const apiUrl = outlineGuestAttributes.get('apiUrl');
         try {
           const parsed = new URL(apiUrl);
-          trustCertificate(parsed.host, certSha256);
+          if (!trustCertificate(parsed.host, certSha256)) {
+            throw new Error('Failed to mark certificate trusted');
+          }
         } catch (e) {
           console.error(e);
           this.setInstallState(InstallState.FAILED);

--- a/src/server_manager/web_app/manual_server.ts
+++ b/src/server_manager/web_app/manual_server.ts
@@ -31,7 +31,9 @@ class ManualServer extends ShadowboxServer implements server.ManualServer {
     try {
       const parsed = new URL(manualServerConfig.apiUrl);
       const fingerprint = btoa(hexToString(manualServerConfig.certSha256));
-      trustCertificate(parsed.host, fingerprint);
+      if (!trustCertificate(parsed.host, fingerprint)) {
+        console.error('Failed to trust certificate');
+      }
     } catch (e) {
       // Error trusting certificate, may be due to bad user input.
       console.error('Error trusting certificate');


### PR DESCRIPTION
With this change, each server added during a session must
have a distinct host:port.  (Reuse of the same host:port is
allowed if the certificate fingerprint has not changed.)

This prevents certain attacks by hypothetical malicious servers.