### PR TITLE
fix(manager): 💊 manager's icon is not shown in Ubuntu Dock

### DIFF
--- a/src/server_manager/README.md
+++ b/src/server_manager/README.md
@@ -14,7 +14,7 @@ To run the Outline Manager Electron app with a development build (code not minif
 BUILD_ENV=development npm run action server_manager/electron_app/start ${PLATFORM}
 ```
 
-Where `${PLATFORM}` is one of `linux`, `mac`, `windows`.
+Where `${PLATFORM}` is one of `linux`, `macos`, `windows`.
 
 ## Development Server
 

--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -72,7 +72,7 @@ function createMainWindow() {
     minWidth: 600,
     minHeight: 768,
     maximizable: false,
-    icon: path.join(__dirname, 'web_app', 'ui_components', 'icons', 'launcher.png'),
+    icon: path.join(__dirname, 'server_manager', 'web_app', 'images', 'launcher-icon.png'),
     webPreferences: {
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js'),


### PR DESCRIPTION
Our app's icon is not shown in Ubuntu Dock because of the wrong image path:

<img width="870" alt="image" src="https://user-images.githubusercontent.com/93548144/176346973-d3285140-bbab-443d-97ad-04180c9094ac.png">

After the fix, the icon is shown correctly on all platforms:

<img width="967" alt="image" src="https://user-images.githubusercontent.com/93548144/176346203-fe213ac6-d673-40b1-bdf9-52f385fb6649.png">

<img width="143" alt="image" src="https://user-images.githubusercontent.com/93548144/176458625-0a68f88a-4b72-4097-9b66-3357139e033c.png">

<img width="292" alt="image" src="https://user-images.githubusercontent.com/93548144/176459397-a6015e2a-50c0-4b90-9289-fe0c56d6d24b.png">


Related PR: https://github.com/Jigsaw-Code/outline-client/pull/1327