### PR TITLE
fix(manager): remove dev tools

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -74,6 +74,7 @@ function createMainWindow() {
     maximizable: false,
     icon: path.join(__dirname, 'server_manager', 'web_app', 'images', 'launcher-icon.png'),
     webPreferences: {
+      devTools: debugMode,
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js'),
       webviewTag: false,


### PR DESCRIPTION
https://git.radicallyopensecurity.com/ros/google-outline/-/issues/7

Seems to do the trick, don't see the dev tools here on mac anyway:

<img width="211" alt="Screen Shot 2022-07-28 at 14 48 27" src="https://user-images.githubusercontent.com/3759828/181614951-03646128-4ceb-4b0e-90fe-7dd6d185d31f.png">
