### PR TITLE
fix: avoid malicious path traversal in manager's open-image method

### DIFF
--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -259,8 +259,9 @@ function main() {
   });
 
   // Handle "show me where" requests from the renderer process.
-  ipcMain.on('open-image', (event: IpcEvent, basename: string) => {
-    const p = path.join(IMAGES_BASENAME, basename);
+  ipcMain.on('open-image', (event: IpcEvent, img_path: string) => {
+    const p = path.join(IMAGES_BASENAME, path.resolve('/', img_path));
+
     if (!shell.openPath(p)) {
       console.error(`could not open image at ${p}`);
     }


### PR DESCRIPTION
There is an Electron IPC event 'open-image' that accepts any path,
including relative paths that would expose system filenames such as
/etc/passwd.  This change resolves all paths to be rooted at the base
directory for ...server_manager/web_app.