### PR TITLE
refactor(manager): ♻️ change electron-updater's url to S3

### DIFF
--- a/src/server_manager/scripts/get_electron_build_flags.mjs
+++ b/src/server_manager/scripts/get_electron_build_flags.mjs
@@ -49,7 +49,7 @@ export async function getElectronBuildFlags(platform, buildMode) {
       ...buildFlags,
       '--config.generateUpdatesFilesForAllChannels=true',
       '--config.publish.provider=generic',
-      '--config.publish.url=https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/',
+      '--config.publish.url=https://s3.amazonaws.com/outline-releases/manager/',
     ];
   }
 


### PR DESCRIPTION
In this PR, I switched `electron-updater`'s checking-update-url to Amazon S3, so [`outline-releases` GitHub repository](https://github.com/Jigsaw-Code/outline-releases/tree/master/manager) can be deprecated (but we still need to update the yaml files for backward compatibility).