### PR TITLE
fix(devtools): only run the size label on internal PRs

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       # size-label-action fails to work when coming from a fork:
       # https://github.com/pascalgn/size-label-action/issues/10
-      - if: '! github.event.pull_request.head.repo.fork'
+      - if: ${{ !github.event.pull_request.head.repo.fork }}
         name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       # size-label-action fails to work when coming from a fork:
       # https://github.com/pascalgn/size-label-action/issues/10
-      - if: ${{ github.event.pull_request.head.repo.fork }}
+      - if: ${{ !github.event.pull_request.head.repo.fork }}
         name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       # size-label-action fails to work when coming from a fork:
       # https://github.com/pascalgn/size-label-action/issues/10
-      - if: ${{ !github.event.pull_request.head.repo.fork }}
+      - if: ${{ github.event.pull_request.head.repo.fork }}
         name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -46,7 +46,9 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - if: github.event.pull_request.head.repo.full_name == github.repository
+      # size-label-action fails to work when coming from a fork:
+      # https://github.com/pascalgn/size-label-action/issues/10
+      - if: ! github.event.pull_request.head.repo.fork
         name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -46,7 +46,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - if: ${{ github.event.pull_request.head.repo.full_name == 'Jigsaw-Code/outline-server' }}
+      - if: github.event.pull_request.head.repo.full_name == github.repository
         name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -46,7 +46,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Apply Size Label
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'Jigsaw-Code/outline-server' }}
+        name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:
           IGNORED: |

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       # size-label-action fails to work when coming from a fork:
       # https://github.com/pascalgn/size-label-action/issues/10
-      - if: ! github.event.pull_request.head.repo.fork
+      - if: '! github.event.pull_request.head.repo.fork'
         name: Apply Size Label
         uses: pascalgn/size-label-action@a4655c448bb838e8d73b81e97fd0831bb4cbda1e
         env:


### PR DESCRIPTION
when the case here is flipped, the check gets skipped: https://github.com/Jigsaw-Code/outline-server/runs/8024106621?check_suite_focus=true