### PR TITLE
feat(server): include icanhazip as an alternative to ipinfo and checkip of domains.google.com

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -402,6 +402,7 @@ function set_hostname() {
   # We have more than one to try in case one starts failing
   # (e.g. https://github.com/Jigsaw-Code/outline-server/issues/776).
   local -ar urls=(
+    'https://icanhazip.com/'
     'https://ipinfo.io/ip'
     'https://domains.google.com/checkip'
   )


### PR DESCRIPTION
Add icanhazip.com as an alternative. Both ipinfo and checkip are sometimes inaccessible from certain areas.