### PR TITLE
fix(manager/web): 💊 show Sydney flag in DO region page

### DIFF
--- a/src/server_manager/model/digitalocean.ts
+++ b/src/server_manager/model/digitalocean.ts
@@ -25,12 +25,13 @@ export class Region implements location.CloudLocation {
     nyc: location.NEW_YORK_CITY,
     sfo: location.SAN_FRANCISCO,
     sgp: location.SINGAPORE,
+    syd: location.SYDNEY,
     tor: location.TORONTO,
   };
   constructor(public readonly id: string) {}
 
   get location(): location.GeoLocation {
-    return Region.LOCATION_MAP[this.id.substr(0, 3).toLowerCase()];
+    return Region.LOCATION_MAP[this.id.substring(0, 3).toLowerCase()];
   }
 }
 


### PR DESCRIPTION
The Sydney flag and its city name was not displayed appropriately in DigitalOcean's region selection page. It was a simple fix by just adding it to the available regions. Also [`substr` function is deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr), I replaced it with the [standard `substring` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring).

**after fix**

<img width="780" alt="image" src="https://user-images.githubusercontent.com/93548144/204391281-b791dc4e-b8b2-47b0-9e7d-f469d6349c7c.png">