### PR TITLE
fix(server): fix isPortUsed for IPv6

### DIFF
--- a/src/shadowbox/infrastructure/get_port.spec.ts
+++ b/src/shadowbox/infrastructure/get_port.spec.ts
@@ -49,7 +49,8 @@ describe('PortProvider', () => {
 
   describe('reserveNewPort', () => {
     it('Returns a port not in use', async () => {
-      for (let i = 0; i < 1000; ++i) {
+      // We run 100 times to try to trigger possible race conditions.
+      for (let i = 0; i < 100; ++i) {
         const port = await new get_port.PortProvider().reserveNewPort();
         expect(await get_port.isPortUsed(port)).toBeFalsy();
       }
@@ -95,14 +96,8 @@ function listen(): Promise<net.Server> {
   });
 }
 
-async function closeServer(server: net.Server): Promise<void> {
+function closeServer(server: net.Server): Promise<void> {
   return new Promise((resolve, reject) => {
-    server.close((err) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
+    server.close(err => err ? reject(err) : resolve());
   });
 }

--- a/src/shadowbox/infrastructure/get_port.spec.ts
+++ b/src/shadowbox/infrastructure/get_port.spec.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Server } from 'http';
 import * as net from 'net';
 
 import * as get_port from './get_port';

--- a/src/shadowbox/infrastructure/get_port.ts
+++ b/src/shadowbox/infrastructure/get_port.ts
@@ -75,7 +75,7 @@ export function isPortUsed(port: number): Promise<boolean> {
       }
       server.close();
     });
-    server.listen({host: 'localhost', port, exclusive: true}, () => {
+    server.listen({port, exclusive: true}, () => {
       isUsed = false;
       server.close();
     });


### PR DESCRIPTION
I found this issue because my DO server entered an infinite loop when I created a key on port 53. This happaned  because there's a systemd resolver daemon running on port 53, but our code failed to detect the port conflict.

Without the change to get_port, the IPv6 test fails.
