### PR TITLE
Fix metrics

### DIFF
--- a/src/shadowbox/server/shared_metrics.spec.ts
+++ b/src/shadowbox/server/shared_metrics.spec.ts
@@ -20,6 +20,7 @@ import {AccessKeyConfigJson} from './server_access_key';
 
 import {ServerConfigJson} from './server_config';
 import {
+  CountryUsage,
   DailyFeatureMetricsReportJson,
   HourlyServerMetricsReportJson,
   KeyUsage,
@@ -82,10 +83,17 @@ describe('OutlineSharedMetricsPublisher', () => {
       );
 
       publisher.startSharing();
-      usageMetrics.usage = [
-        {accessKeyId: 'user-0', inboundBytes: 11, countries: ['AA', 'BB']},
-        {accessKeyId: 'user-1', inboundBytes: 22, countries: ['CC']},
-        {accessKeyId: 'user-0', inboundBytes: 33, countries: ['AA', 'DD']},
+      usageMetrics.keyUsage = [
+        {accessKeyId: 'user-0', inboundBytes: 11},
+        {accessKeyId: 'user-1', inboundBytes: 22},
+        {accessKeyId: 'user-0', inboundBytes: 33},
+      ];
+      usageMetrics.countryUsage = [
+        {country: 'AA', inboundBytes: 11},
+        {country: 'BB', inboundBytes: 11},
+        {country: 'CC', inboundBytes: 22},
+        {country: 'AA', inboundBytes: 33},
+        {country: 'DD', inboundBytes: 33},
       ];
 
       clock.nowMs += 60 * 60 * 1000;
@@ -95,16 +103,25 @@ describe('OutlineSharedMetricsPublisher', () => {
         startUtcMs: startTime,
         endUtcMs: clock.nowMs,
         userReports: [
-          {userId: 'M(user-0)', bytesTransferred: 11, countries: ['AA', 'BB']},
-          {userId: 'M(user-1)', bytesTransferred: 22, countries: ['CC']},
-          {userId: 'M(user-0)', bytesTransferred: 33, countries: ['AA', 'DD']},
+          {userId: 'M(user-0)', bytesTransferred: 11, countries: []},
+          {userId: 'M(user-1)', bytesTransferred: 22, countries: []},
+          {userId: 'M(user-0)', bytesTransferred: 33, countries: []},
+          {userId: '', bytesTransferred: 11, countries: ['AA']},
+          {userId: '', bytesTransferred: 11, countries: ['BB']},
+          {userId: '', bytesTransferred: 22, countries: ['CC']},
+          {userId: '', bytesTransferred: 33, countries: ['AA']},
+          {userId: '', bytesTransferred: 33, countries: ['DD']},
         ],
       });
 
       startTime = clock.nowMs;
-      usageMetrics.usage = [
-        {accessKeyId: 'user-0', inboundBytes: 44, countries: ['EE']},
-        {accessKeyId: 'user-2', inboundBytes: 55, countries: ['FF']},
+      usageMetrics.keyUsage = [
+        {accessKeyId: 'user-0', inboundBytes: 44},
+        {accessKeyId: 'user-2', inboundBytes: 55},
+      ];
+      usageMetrics.countryUsage = [
+        {country: 'EE', inboundBytes: 44},
+        {country: 'FF', inboundBytes: 55},
       ];
 
       clock.nowMs += 60 * 60 * 1000;
@@ -114,8 +131,10 @@ describe('OutlineSharedMetricsPublisher', () => {
         startUtcMs: startTime,
         endUtcMs: clock.nowMs,
         userReports: [
-          {userId: 'M(user-0)', bytesTransferred: 44, countries: ['EE']},
-          {userId: 'M(user-2)', bytesTransferred: 55, countries: ['FF']},
+          {userId: 'M(user-0)', bytesTransferred: 44, countries: []},
+          {userId: 'M(user-2)', bytesTransferred: 55, countries: []},
+          {userId: '', bytesTransferred: 44, countries: ['EE']},
+          {userId: '', bytesTransferred: 55, countries: ['FF']},
         ],
       });
 
@@ -138,10 +157,17 @@ describe('OutlineSharedMetricsPublisher', () => {
       );
 
       publisher.startSharing();
-      usageMetrics.usage = [
-        {accessKeyId: 'user-0', inboundBytes: 11, countries: ['AA', 'SY']},
-        {accessKeyId: 'user-1', inboundBytes: 22, countries: ['CC']},
-        {accessKeyId: 'user-0', inboundBytes: 33, countries: ['AA', 'DD']},
+      usageMetrics.keyUsage = [
+        {accessKeyId: 'user-0', inboundBytes: 11},
+        {accessKeyId: 'user-1', inboundBytes: 22},
+        {accessKeyId: 'user-0', inboundBytes: 33},
+      ];
+      usageMetrics.countryUsage = [
+        {country: 'AA', inboundBytes: 11},
+        {country: 'SY', inboundBytes: 11},
+        {country: 'CC', inboundBytes: 22},
+        {country: 'AA', inboundBytes: 33},
+        {country: 'DD', inboundBytes: 33},
       ];
 
       clock.nowMs += 60 * 60 * 1000;
@@ -151,8 +177,13 @@ describe('OutlineSharedMetricsPublisher', () => {
         startUtcMs: startTime,
         endUtcMs: clock.nowMs,
         userReports: [
-          {userId: 'M(user-1)', bytesTransferred: 22, countries: ['CC']},
-          {userId: 'M(user-0)', bytesTransferred: 33, countries: ['AA', 'DD']},
+          {userId: 'M(user-0)', bytesTransferred: 11, countries: []},
+          {userId: 'M(user-1)', bytesTransferred: 22, countries: []},
+          {userId: 'M(user-0)', bytesTransferred: 33, countries: []},
+          {userId: '', bytesTransferred: 11, countries: ['AA']},
+          {userId: '', bytesTransferred: 22, countries: ['CC']},
+          {userId: '', bytesTransferred: 33, countries: ['AA']},
+          {userId: '', bytesTransferred: 33, countries: ['DD']},
         ],
       });
       publisher.stopSharing();
@@ -258,11 +289,19 @@ class FakeMetricsCollector implements MetricsCollectorClient {
 }
 
 class ManualUsageMetrics implements UsageMetrics {
-  public usage = [] as KeyUsage[];
-  getUsage(): Promise<KeyUsage[]> {
-    return Promise.resolve(this.usage);
+  public keyUsage = [] as KeyUsage[];
+  public countryUsage = [] as CountryUsage[];
+  
+  getKeyUsage(): Promise<KeyUsage[]> {
+    return Promise.resolve(this.keyUsage);
   }
+
+  getCountryUsage(): Promise<CountryUsage[]> {
+    return Promise.resolve(this.countryUsage)
+  }
+
   reset() {
-    this.usage = [] as KeyUsage[];
+    this.keyUsage = [] as KeyUsage[];
+    this.countryUsage = [] as CountryUsage[];
   }
 }

--- a/src/shadowbox/server/shared_metrics.ts
+++ b/src/shadowbox/server/shared_metrics.ts
@@ -30,7 +30,11 @@ const SANCTIONED_COUNTRIES = new Set(['CU', 'KP', 'SY']);
 // Used internally to track key usage.
 export interface KeyUsage {
   accessKeyId: string;
-  countries: string[];
+  inboundBytes: number;
+}
+
+export interface CountryUsage {
+  country: string;
   inboundBytes: number;
 }
 
@@ -74,7 +78,8 @@ export interface SharedMetricsPublisher {
 }
 
 export interface UsageMetrics {
-  getUsage(): Promise<KeyUsage[]>;
+  getKeyUsage(): Promise<KeyUsage[]>;
+  getCountryUsage(): Promise<CountryUsage[]>;
   reset();
 }
 
@@ -84,22 +89,34 @@ export class PrometheusUsageMetrics implements UsageMetrics {
 
   constructor(private prometheusClient: PrometheusClient) {}
 
-  async getUsage(): Promise<KeyUsage[]> {
+  async getKeyUsage(): Promise<KeyUsage[]> {
     const timeDeltaSecs = Math.round((Date.now() - this.resetTimeMs) / 1000);
     // We measure the traffic to and from the target, since that's what we are protecting.
     const result = await this.prometheusClient.query(
-      `sum(increase(shadowsocks_data_bytes{dir=~"p>t|p<t"}[${timeDeltaSecs}s])) by (location, access_key)`
+      `sum(increase(shadowsocks_data_bytes{dir=~"p>t|p<t"}[${timeDeltaSecs}s])) by (access_key)`
     );
     const usage = [] as KeyUsage[];
     for (const entry of result.result) {
       const accessKeyId = entry.metric['access_key'] || '';
-      let countries = [];
-      const countriesStr = entry.metric['location'] || '';
-      if (countriesStr) {
-        countries = countriesStr.split(',').map((e) => e.trim());
-      }
       const inboundBytes = Math.round(parseFloat(entry.value[1]));
-      usage.push({accessKeyId, countries, inboundBytes});
+      if (inboundBytes > 0) {
+        usage.push({accessKeyId, inboundBytes});
+      }
+    }
+    return usage;
+  }
+
+  async getCountryUsage(): Promise<CountryUsage[]> {
+    const timeDeltaSecs = Math.round((Date.now() - this.resetTimeMs) / 1000);
+    // We measure the traffic to and from the target, since that's what we are protecting.
+    const result = await this.prometheusClient.query(
+      `sum(increase(shadowsocks_data_bytes_per_location{dir=~"p>t|p<t"}[${timeDeltaSecs}s])) by (location)`
+    );
+    const usage = [] as CountryUsage[];
+    for (const entry of result.result) {
+      const country = entry.metric['location'] || '';
+      const inboundBytes = Math.round(parseFloat(entry.value[1]));
+      usage.push({country, inboundBytes});
     }
     return usage;
   }
@@ -174,7 +191,9 @@ export class OutlineSharedMetricsPublisher implements SharedMetricsPublisher {
         return;
       }
       try {
-        await this.reportServerUsageMetrics(await usageMetrics.getUsage());
+        const keyUsagePromise = usageMetrics.getKeyUsage()
+        const countryUsagePromise = usageMetrics.getCountryUsage()
+        await this.reportServerUsageMetrics(await keyUsagePromise, await countryUsagePromise);
         usageMetrics.reset();
       } catch (err) {
         logging.error(`Failed to report server usage metrics: ${err}`);
@@ -208,21 +227,41 @@ export class OutlineSharedMetricsPublisher implements SharedMetricsPublisher {
     return this.serverConfig.data().metricsEnabled || false;
   }
 
-  private async reportServerUsageMetrics(usageMetrics: KeyUsage[]): Promise<void> {
+  private async reportServerUsageMetrics(keyUsageMetrics: KeyUsage[], countryUsageMetrics: CountryUsage[]): Promise<void> {
     const reportEndTimestampMs = this.clock.now();
 
     const userReports = [] as HourlyUserMetricsReportJson[];
-    for (const keyUsage of usageMetrics) {
+    // HACK! We use the same backend reporting endpoint for key and country usage.
+    // A row with empty country is for key usage, a row with empty userId is for country usage.
+    // Note that this reports usage twice. If you want the total, filter to rows with non empty countries.
+    for (const keyUsage of keyUsageMetrics) {
       if (keyUsage.inboundBytes === 0) {
         continue;
       }
-      if (hasSanctionedCountry(keyUsage.countries)) {
+      const userId = this.toMetricsId(keyUsage.accessKeyId);
+      if (!userId) {
         continue;
       }
       userReports.push({
-        userId: this.toMetricsId(keyUsage.accessKeyId) || '',
+        userId,
         bytesTransferred: keyUsage.inboundBytes,
-        countries: [...keyUsage.countries],
+        countries: [],
+      });
+    }
+    for (const countryUsage of countryUsageMetrics) {
+      if (countryUsage.inboundBytes === 0) {
+        continue;
+      }
+      if (isSanctionedCountry(countryUsage.country)) {
+        continue;
+      }
+      // Make sure to always set the country to differentiate the row
+      // from key usage rows.
+      const country = countryUsage.country || 'ZZ';
+      userReports.push({
+        userId: '',
+        bytesTransferred: countryUsage.inboundBytes,
+        countries: [country],
       });
     }
     const report = {
@@ -254,11 +293,6 @@ export class OutlineSharedMetricsPublisher implements SharedMetricsPublisher {
   }
 }
 
-function hasSanctionedCountry(countries: string[]) {
-  for (const country of countries) {
-    if (SANCTIONED_COUNTRIES.has(country)) {
-      return true;
-    }
-  }
-  return false;
+function isSanctionedCountry(country: string) {
+  return SANCTIONED_COUNTRIES.has(country);
 }


### PR DESCRIPTION
Data usage is no longer linked to both key and country.
We now query usage twice: one for key and one for country, and report both.