### PR TITLE
fix: remove broken feedback form

### DIFF
--- a/src/server_manager/web_app/ui_components/app-root.ts
+++ b/src/server_manager/web_app/ui_components/app-root.ts
@@ -392,6 +392,8 @@ export class AppRoot extends polymerElementWithLocalize {
           <!-- Links section -->
           <paper-listbox>
             <span on-tap="maybeCloseDrawer"><a href="https://s3.amazonaws.com/outline-vpn/index.html#/en/support/dataCollection">[[localize('nav-data-collection')]]</a></span>
+            <!-- TODO(daniellacosse): restore this once the feedback form is fixed -->
+            <!-- <span on-tap="submitFeedbackTapped">[[localize('nav-feedback')]]</span> -->
             <span on-tap="maybeCloseDrawer"><a href="https://s3.amazonaws.com/outline-vpn/index.html#/en/support/">[[localize('nav-help')]]</a></span>
             <span on-tap="aboutTapped">[[localize('nav-about')]]</span>
             <div id="links-footer">


### PR DESCRIPTION
This is to ensure we're compliant. I'll be following this up with a true fix ASAP.