### PR TITLE
fix(manager): support for Alpine Linux

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -58,8 +58,8 @@ readonly SENTRY_LOG_FILE=${SENTRY_LOG_FILE:-}
 # - STDERR is only used in the event of a fatal error
 # - Detailed logs are recorded to this FULL_LOG, which is preserved if an error occurred.
 # - The most recent error is stored in LAST_ERROR, which is never preserved.
-FULL_LOG="$(mktemp -t outline_logXXX)"
-LAST_ERROR="$(mktemp -t outline_last_errorXXX)"
+FULL_LOG="$(mktemp -t outline_logXXXXXX)"
+LAST_ERROR="$(mktemp -t outline_last_errorXXXXXX)"
 readonly FULL_LOG LAST_ERROR
 
 function log_command() {

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -168,7 +168,9 @@ function install_docker() {
 }
 
 function start_docker() {
-  systemctl enable --now docker.service >&2
+  #systemctl enable --now docker.service >&2
+  rc-update add docker default
+  service docker start
 }
 
 function docker_container_exists() {

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -171,7 +171,8 @@ function start_docker() {
   if command -v systemctl &> /dev/null; then
     systemctl enable --now docker.service >&2
     service docker start
-  else #dirty hack to support Alpine Linux
+  else
+    # Hack to support Alpine Linux
     rc-update add docker boot
     rc-service docker start
   fi

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -168,9 +168,13 @@ function install_docker() {
 }
 
 function start_docker() {
-  #systemctl enable --now docker.service >&2
-  rc-update add docker default
-  service docker start
+  if command -v systemctl &> /dev/null; then
+    systemctl enable --now docker.service >&2
+    service docker start
+  else #dirty hack to support Alpine Linux
+    rc-update add docker default
+    rc-update add docker boot && rc-service docker start
+  fi
 }
 
 function docker_container_exists() {

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -172,8 +172,8 @@ function start_docker() {
     systemctl enable --now docker.service >&2
     service docker start
   else #dirty hack to support Alpine Linux
-    rc-update add docker default
-    rc-update add docker boot && rc-service docker start
+    rc-update add docker boot
+    rc-service docker start
   fi
 }
 


### PR DESCRIPTION
A couple of fixes: option to use rc-status instead of systemctl, and changed names of logfiles to properly support BusyBox's logging.