### PR TITLE
fix(manager): 💊 integrate with the latest Sentry library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,10 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "1.13.0",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.14.1.tgz",
+      "integrity": "sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -97,7 +98,7 @@
         "node": ">=8.6"
       },
       "optionalDependencies": {
-        "global-agent": "^2.0.2",
+        "global-agent": "^3.0.0",
         "global-tunnel-ng": "^2.7.1"
       }
     },
@@ -1253,151 +1254,127 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.37.1.tgz",
+      "integrity": "sha512-MfVbKzEVHKVH6ZyMCKLtPXvMtRCvxqQzrnK735sYW6EyMpcMYhukBU0pq7ws1E/KaCZjAJi1wDx2nqf2yPIVdQ==",
       "dependencies": {
-        "@sentry/core": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/core": "7.37.1",
+        "@sentry/replay": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/browser/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/core": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
+      "integrity": "sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==",
       "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/core/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/electron": {
-      "version": "2.5.4",
-      "license": "MIT",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-4.3.0.tgz",
+      "integrity": "sha512-LqFMvgycMd+Mcs4Km9S8YBtaHISHSiIUVUz6mgAr2khKY6SNhkW9A4GcoOKtzRJreqYLVeBSbaUVttQfQ4Ot7g==",
       "dependencies": {
-        "@sentry/browser": "6.7.1",
-        "@sentry/core": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/node": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^2.2.0"
+        "@sentry/browser": "7.37.1",
+        "@sentry/core": "7.37.1",
+        "@sentry/node": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
+        "deepmerge": "4.3.0",
+        "tslib": "^2.5.0"
       }
     },
-    "node_modules/@sentry/hub": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
+    "node_modules/@sentry/electron/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.1.tgz",
+      "integrity": "sha512-nGerngIo5JwinJgl7m0SaL/xI+YRBlhb53gbkuLSAAcnoitBFzbp7LjywsqYFTWuWDIyk7O2t124GNxtolBAgA==",
       "dependencies": {
-        "@sentry/core": "6.7.1",
-        "@sentry/hub": "6.7.1",
-        "@sentry/tracing": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/node/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@sentry/tracing": {
-      "version": "6.7.1",
-      "license": "MIT",
+    "node_modules/@sentry/replay": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.37.1.tgz",
+      "integrity": "sha512-3sHOE/oPirdvJbOn0IA/wpds12Sm2WaEtiAeC0+5Gg5mxQzFBLRrsA1Mz/ifzPGwr+ETn3sCyPCnd9b3PWaWMQ==",
       "dependencies": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
-    "node_modules/@sentry/tracing/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
     "node_modules/@sentry/types": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.1.tgz",
+      "integrity": "sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.7.1",
-      "license": "BSD-3-Clause",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.1.tgz",
+      "integrity": "sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==",
       "dependencies": {
-        "@sentry/types": "6.7.1",
+        "@sentry/types": "7.37.1",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1412,8 +1389,9 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^1.0.1"
       },
@@ -3848,9 +3826,10 @@
       "license": "ISC"
     },
     "node_modules/boolean": {
-      "version": "3.1.4",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "dev": true,
-      "license": "MIT",
       "optional": true
     },
     "node_modules/brace-expansion": {
@@ -4274,8 +4253,9 @@
     },
     "node_modules/cacheable-request": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -4291,8 +4271,9 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -4305,8 +4286,9 @@
     },
     "node_modules/cacheable-request/node_modules/lowercase-keys": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5705,6 +5687,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-compare": {
       "version": "1.0.0",
       "dev": true,
@@ -5805,8 +5795,9 @@
     },
     "node_modules/defer-to-connect": {
       "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
@@ -6492,12 +6483,13 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.1.0",
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.9.tgz",
+      "integrity": "sha512-XT5LkTzIHB+ZtD3dTmNnKjVBWrDWReCKt9G1uAFLz6uJMEVcIUiYO+fph5pLXETiBw/QZBx8egduMEfIccLx+g==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
@@ -7020,8 +7012,9 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -7131,8 +7124,9 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
-      "license": "MIT",
       "optional": true
     },
     "node_modules/es6-iterator": {
@@ -8841,8 +8835,9 @@
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -9169,13 +9164,13 @@
       }
     },
     "node_modules/global-agent": {
-      "version": "2.2.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
-        "core-js": "^3.6.5",
         "es6-error": "^4.1.1",
         "matcher": "^3.0.0",
         "roarr": "^2.15.3",
@@ -9188,8 +9183,9 @@
     },
     "node_modules/global-agent/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -9199,9 +9195,10 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
-      "license": "ISC",
       "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -9215,8 +9212,9 @@
     },
     "node_modules/global-agent/node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC",
       "optional": true
     },
     "node_modules/global-modules": {
@@ -9260,8 +9258,9 @@
     },
     "node_modules/global-tunnel-ng": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
+      "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "encodeurl": "^1.0.2",
@@ -9299,9 +9298,10 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -9387,8 +9387,9 @@
     },
     "node_modules/got": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^0.14.0",
         "@szmarczak/http-timer": "^1.1.2",
@@ -10085,9 +10086,10 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -11393,8 +11395,9 @@
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -12145,7 +12148,8 @@
     },
     "node_modules/lru_map": {
       "version": "0.3.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -12269,8 +12273,9 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
@@ -12281,8 +12286,9 @@
     },
     "node_modules/matcher/node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -13037,8 +13043,9 @@
     },
     "node_modules/normalize-url": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13532,8 +13539,9 @@
     },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -15960,8 +15968,9 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -15977,8 +15986,9 @@
     },
     "node_modules/roarr/node_modules/sprintf-js": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/rtlcss": {
@@ -16335,8 +16345,9 @@
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
@@ -16350,8 +16361,9 @@
     },
     "node_modules/serialize-error/node_modules/type-fest": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -17515,8 +17527,9 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
       },
@@ -18100,8 +18113,9 @@
     },
     "node_modules/to-readable-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -18408,6 +18422,7 @@
     },
     "node_modules/tslib": {
       "version": "2.4.0",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -18436,8 +18451,9 @@
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -18651,8 +18667,9 @@
     },
     "node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -19726,6 +19743,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/webpack-node-externals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+      "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "1.4.3",
       "dev": true,
@@ -20038,7 +20064,7 @@
     },
     "src/server_manager": {
       "name": "outline-manager",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache",
       "dependencies": {
         "@polymer/app-layout": "^3.0.0",
@@ -20063,9 +20089,9 @@
         "@polymer/paper-tabs": "^3.0.0",
         "@polymer/paper-toast": "^3.0.0",
         "@polymer/paper-tooltip": "^3.0.0",
-        "@sentry/electron": "^2",
+        "@sentry/electron": "^4.3.0",
         "@webcomponents/webcomponentsjs": "^2.0.0",
-        "circle-flags": "git+ssh://git@github.com/HatScripts/circle-flags.git#a21fc224b3079631993b3b8189c490fa0899ea9f",
+        "circle-flags": "https://github.com/HatScripts/circle-flags",
         "clipboard-polyfill": "^2.4.6",
         "dotenv": "~8.2.0",
         "electron-updater": "^4.1.2",
@@ -20087,7 +20113,7 @@
         "@types/semver": "^5.5.0",
         "copy-webpack-plugin": "^5.1.1",
         "css-loader": "^3.5.3",
-        "electron": "18.1.0",
+        "electron": "19.1.9",
         "electron-builder": "^23.6.0",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^1.2.1",
@@ -20109,7 +20135,8 @@
         "ts-loader": "^7.0.1",
         "webpack": "^4.43.0",
         "webpack-cli": "^4.9.2",
-        "webpack-dev-server": "^4.9.0"
+        "webpack-dev-server": "^4.9.0",
+        "webpack-node-externals": "^3.0.0"
       }
     },
     "src/shadowbox": {
@@ -20119,7 +20146,7 @@
       "dependencies": {
         "ip-regex": "^4.1.0",
         "js-yaml": "^3.12.0",
-        "outline-shadowsocksconfig": "git+ssh://git@github.com/Jigsaw-Code/outline-shadowsocksconfig.git#add590ed57277653d02dd2031ae301500ae881e1",
+        "outline-shadowsocksconfig": "github:Jigsaw-Code/outline-shadowsocksconfig#v0.2.0",
         "prom-client": "^11.1.3",
         "randomstring": "^1.1.5",
         "restify": "^8.5.1",
@@ -20513,13 +20540,15 @@
       "dev": true
     },
     "@electron/get": {
-      "version": "1.13.0",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.14.1.tgz",
+      "integrity": "sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
+        "global-agent": "^3.0.0",
         "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
@@ -21429,80 +21458,70 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.7.1",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.37.1.tgz",
+      "integrity": "sha512-MfVbKzEVHKVH6ZyMCKLtPXvMtRCvxqQzrnK735sYW6EyMpcMYhukBU0pq7ws1E/KaCZjAJi1wDx2nqf2yPIVdQ==",
       "requires": {
-        "@sentry/core": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/core": "7.37.1",
+        "@sentry/replay": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/core": {
-      "version": "6.7.1",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.37.1.tgz",
+      "integrity": "sha512-eS5hoFDjAOl7POZg6K77J0oiypiqR1782oVSB49UkjK+D8tCZzZ5PxPMv0b/O0310p7x4oZ3WGRJaWEN3vY4KQ==",
       "requires": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/electron": {
-      "version": "2.5.4",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-4.3.0.tgz",
+      "integrity": "sha512-LqFMvgycMd+Mcs4Km9S8YBtaHISHSiIUVUz6mgAr2khKY6SNhkW9A4GcoOKtzRJreqYLVeBSbaUVttQfQ4Ot7g==",
       "requires": {
-        "@sentry/browser": "6.7.1",
-        "@sentry/core": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/node": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^2.2.0"
-      }
-    },
-    "@sentry/hub": {
-      "version": "6.7.1",
-      "requires": {
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
+        "@sentry/browser": "7.37.1",
+        "@sentry/core": "7.37.1",
+        "@sentry/node": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
+        "deepmerge": "4.3.0",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
-        }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.7.1",
-      "requires": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1"
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         }
       }
     },
     "@sentry/node": {
-      "version": "6.7.1",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.37.1.tgz",
+      "integrity": "sha512-nGerngIo5JwinJgl7m0SaL/xI+YRBlhb53gbkuLSAAcnoitBFzbp7LjywsqYFTWuWDIyk7O2t124GNxtolBAgA==",
       "requires": {
-        "@sentry/core": "6.7.1",
-        "@sentry/hub": "6.7.1",
-        "@sentry/tracing": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -21510,42 +21529,47 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
-    "@sentry/tracing": {
-      "version": "6.7.1",
+    "@sentry/replay": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.37.1.tgz",
+      "integrity": "sha512-3sHOE/oPirdvJbOn0IA/wpds12Sm2WaEtiAeC0+5Gg5mxQzFBLRrsA1Mz/ifzPGwr+ETn3sCyPCnd9b3PWaWMQ==",
       "requires": {
-        "@sentry/hub": "6.7.1",
-        "@sentry/minimal": "6.7.1",
-        "@sentry/types": "6.7.1",
-        "@sentry/utils": "6.7.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1"
-        }
+        "@sentry/core": "7.37.1",
+        "@sentry/types": "7.37.1",
+        "@sentry/utils": "7.37.1"
       }
     },
     "@sentry/types": {
-      "version": "6.7.1"
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.37.1.tgz",
+      "integrity": "sha512-c2HWyWSgVA0V4+DSW2qVb0yjftrb1X/q2CzCom+ayjGHO72qyWC+9Tc+7ZfotU1mapRjqUWBgkXkbGmao8N8Ug=="
     },
     "@sentry/utils": {
-      "version": "6.7.1",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.37.1.tgz",
+      "integrity": "sha512-/4mJOyDsfysx+5TXyJgSI+Ihw2/0EVJbrHjCyXPDXW5ADwbtU8VdBZ0unOmF0hk4QfftqwM9cyEu3BN4iBJsEA==",
       "requires": {
-        "@sentry/types": "6.7.1",
+        "@sentry/types": "7.37.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
     "@socket.io/base64-arraybuffer": {
@@ -21554,6 +21578,8 @@
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
@@ -23293,7 +23319,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.1.4",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "dev": true,
       "optional": true
     },
@@ -23609,6 +23637,8 @@
     },
     "cacheable-request": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
       "requires": {
         "clone-response": "^1.0.2",
@@ -23622,6 +23652,8 @@
       "dependencies": {
         "get-stream": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -23629,6 +23661,8 @@
         },
         "lowercase-keys": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
           "dev": true
         }
       }
@@ -24584,6 +24618,11 @@
       "version": "0.1.4",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
+    },
     "default-compare": {
       "version": "1.0.0",
       "dev": true,
@@ -24649,6 +24688,8 @@
     },
     "defer-to-connect": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
     "define-lazy-prop": {
@@ -25157,10 +25198,12 @@
       }
     },
     "electron": {
-      "version": "18.1.0",
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.9.tgz",
+      "integrity": "sha512-XT5LkTzIHB+ZtD3dTmNnKjVBWrDWReCKt9G1uAFLz6uJMEVcIUiYO+fph5pLXETiBw/QZBx8egduMEfIccLx+g==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       }
@@ -25551,6 +25594,8 @@
     },
     "env-paths": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true
     },
     "envinfo": {
@@ -25633,6 +25678,8 @@
     },
     "es6-error": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "optional": true
     },
@@ -26810,6 +26857,8 @@
     },
     "fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
@@ -27043,12 +27092,13 @@
       }
     },
     "global-agent": {
-      "version": "2.2.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.1",
-        "core-js": "^3.6.5",
         "es6-error": "^4.1.1",
         "matcher": "^3.0.0",
         "roarr": "^2.15.3",
@@ -27058,6 +27108,8 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -27065,7 +27117,9 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -27074,6 +27128,8 @@
         },
         "yallist": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true,
           "optional": true
         }
@@ -27110,6 +27166,8 @@
     },
     "global-tunnel-ng": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
+      "integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -27133,7 +27191,9 @@
       }
     },
     "globalthis": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -27192,6 +27252,8 @@
     },
     "got": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^0.14.0",
@@ -27679,7 +27741,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-deceiver": {
@@ -28513,6 +28577,8 @@
     },
     "jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -29039,7 +29105,9 @@
       "dev": true
     },
     "lru_map": {
-      "version": "0.3.3"
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -29124,6 +29192,8 @@
     },
     "matcher": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -29132,6 +29202,8 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true,
           "optional": true
         }
@@ -29684,6 +29756,8 @@
     },
     "normalize-url": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "now-and-later": {
@@ -30014,7 +30088,7 @@
         "@polymer/paper-tabs": "^3.0.0",
         "@polymer/paper-toast": "^3.0.0",
         "@polymer/paper-tooltip": "^3.0.0",
-        "@sentry/electron": "^2",
+        "@sentry/electron": "^4.3.0",
         "@types/node": "^16.11.29",
         "@types/node-forge": "^1.0.2",
         "@types/polymer": "^1.2.9",
@@ -30022,12 +30096,12 @@
         "@types/request": "^2.47.1",
         "@types/semver": "^5.5.0",
         "@webcomponents/webcomponentsjs": "^2.0.0",
-        "circle-flags": "git+ssh://git@github.com/HatScripts/circle-flags.git#a21fc224b3079631993b3b8189c490fa0899ea9f",
+        "circle-flags": "https://github.com/HatScripts/circle-flags",
         "clipboard-polyfill": "^2.4.6",
         "copy-webpack-plugin": "^5.1.1",
         "css-loader": "^3.5.3",
         "dotenv": "~8.2.0",
-        "electron": "18.1.0",
+        "electron": "19.1.9",
         "electron-builder": "^23.6.0",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^1.2.1",
@@ -30058,7 +30132,8 @@
         "web-animations-js": "^2.3.1",
         "webpack": "^4.43.0",
         "webpack-cli": "^4.9.2",
-        "webpack-dev-server": "^4.9.0"
+        "webpack-dev-server": "^4.9.0",
+        "webpack-node-externals": "^3.0.0"
       }
     },
     "outline-metrics-server": {
@@ -30081,7 +30156,7 @@
         "@types/tmp": "^0.2.1",
         "ip-regex": "^4.1.0",
         "js-yaml": "^3.12.0",
-        "outline-shadowsocksconfig": "git+ssh://git@github.com/Jigsaw-Code/outline-shadowsocksconfig.git#add590ed57277653d02dd2031ae301500ae881e1",
+        "outline-shadowsocksconfig": "github:Jigsaw-Code/outline-shadowsocksconfig#v0.2.0",
         "prom-client": "^11.1.3",
         "randomstring": "^1.1.5",
         "restify": "^8.5.1",
@@ -30384,6 +30459,8 @@
     },
     "p-cancelable": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
     "p-event": {
@@ -32033,6 +32110,8 @@
     },
     "roarr": {
       "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -32046,6 +32125,8 @@
       "dependencies": {
         "sprintf-js": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
           "dev": true,
           "optional": true
         }
@@ -32302,6 +32383,8 @@
     },
     "serialize-error": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -32310,6 +32393,8 @@
       "dependencies": {
         "type-fest": {
           "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true,
           "optional": true
         }
@@ -33156,6 +33241,8 @@
     },
     "sumchecker": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0"
@@ -33594,6 +33681,8 @@
     },
     "to-readable-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
     "to-regex": {
@@ -33810,7 +33899,8 @@
       }
     },
     "tslib": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -33831,6 +33921,8 @@
     },
     "tunnel": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true,
       "optional": true
     },
@@ -33971,6 +34063,8 @@
     },
     "universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unpipe": {
@@ -34702,6 +34796,12 @@
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
       }
+    },
+    "webpack-node-externals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+      "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6778,9 +6778,10 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.122",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.328.tgz",
+      "integrity": "sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==",
+      "dev": true
     },
     "node_modules/electron-updater": {
       "version": "4.3.9",
@@ -20117,7 +20118,7 @@
         "electron-builder": "^23.6.0",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^1.2.1",
-        "electron-to-chromium": "^1.4.122",
+        "electron-to-chromium": "^1.4.328",
         "gulp": "^4.0.0",
         "gulp-posthtml": "^3.0.4",
         "gulp-replace": "^1.0.0",
@@ -25433,7 +25434,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.122",
+      "version": "1.4.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.328.tgz",
+      "integrity": "sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==",
       "dev": true
     },
     "electron-updater": {
@@ -30105,7 +30108,7 @@
         "electron-builder": "^23.6.0",
         "electron-icon-maker": "^0.0.4",
         "electron-notarize": "^1.2.1",
-        "electron-to-chromium": "^1.4.122",
+        "electron-to-chromium": "^1.4.328",
         "electron-updater": "^4.1.2",
         "express": "^4.17.1",
         "google-auth-library": "^8.0.2",

--- a/src/server_manager/base.webpack.js
+++ b/src/server_manager/base.webpack.js
@@ -63,15 +63,9 @@ exports.makeConfig = (options) => {
     plugins: [
       new webpack.DefinePlugin({
         'outline.gcpAuthEnabled': JSON.stringify(process.env.GCP_AUTH_ENABLED !== 'false'),
-        // Hack to protect against @sentry/electron not having process.type defined.
-        'process.type': JSON.stringify('renderer'),
         // Statically link the Roboto font, rather than link to fonts.googleapis.com
         'window.polymerSkipLoadingFontRoboto': JSON.stringify(true),
       }),
-      // @sentry/electron depends on electron code, even though it's never activated
-      // in the browser. Webpack still tries to build it, but fails with missing APIs.
-      // The IgnorePlugin prevents the compilation of the electron dependency.
-      new webpack.IgnorePlugin({resourceRegExp: /^electron$/, contextRegExp: /@sentry\/electron/}),
       new CopyPlugin(
         [
           {from: 'index.html', to: '.'},

--- a/src/server_manager/electron_app/build.action.sh
+++ b/src/server_manager/electron_app/build.action.sh
@@ -39,19 +39,21 @@ done
 readonly OUT_DIR="${BUILD_DIR}/server_manager/electron_app"
 rm -rf "${OUT_DIR}"
 
+# Electron app root folder
+readonly STATIC_DIR="${OUT_DIR}/static"
+mkdir -p "${STATIC_DIR}"
+
 # Build the Web App.
 run_action server_manager/web_app/build
 
-# Compile the Electron app source.
+# Compile the Electron main process and preload to the app root folder.
 # Since Node.js on Cygwin doesn't like absolute Unix-style paths,
 # we'll use relative paths here.
-tsc -p src/server_manager/electron_app/tsconfig.json --outDir build/server_manager/electron_app/js
+webpack --config=src/server_manager/electron_main.webpack.mjs ${BUILD_ENV:+--mode=${BUILD_ENV}}
+webpack --config=src/server_manager/electron_preload.webpack.mjs ${BUILD_ENV:+--mode=${BUILD_ENV}}
 
 # Assemble everything together.
-readonly STATIC_DIR="${OUT_DIR}/static"
-mkdir -p "${STATIC_DIR}"
 mkdir -p "${STATIC_DIR}/server_manager"
-cp -r "${OUT_DIR}/js/electron_app/"* "${STATIC_DIR}"
 cp -r "${BUILD_DIR}/server_manager/web_app/static" "${STATIC_DIR}/server_manager/web_app/"
 
 # TODO(fortuna): Separate the build of Electron main and the Electron package.

--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -24,7 +24,7 @@ import {fetchWithPin} from './fetch';
 import * as menu from './menu';
 
 // Injected by esbuild/webpack during build
-declare const SENTRY_DSN_: string | undefined;
+declare const SENTRY_DSN: string | undefined;
 
 const app = electron.app;
 const ipcMain = electron.ipcMain;
@@ -41,9 +41,9 @@ const IMAGES_BASENAME = `${path.join(
   'web_app'
 )}`;
 
-if (typeof SENTRY_DSN_ !== 'undefined' && SENTRY_DSN_) {
+if (typeof SENTRY_DSN !== 'undefined' && SENTRY_DSN) {
   Sentry.init({
-    dsn: SENTRY_DSN_,
+    dsn: SENTRY_DSN,
     // Sentry provides a sensible default but we would prefer without the leading
     // "outline-manager@".
     release: electron.app.getVersion(),
@@ -130,8 +130,8 @@ function getWebAppUrl() {
     queryParams.set('metricsUrl', process.env.SB_METRICS_URL);
     console.log(`Will use metrics url ${process.env.SB_METRICS_URL}`);
   }
-  if (typeof SENTRY_DSN_ !== 'undefined' && SENTRY_DSN_) {
-    queryParams.set('sentryDsn', SENTRY_DSN_);
+  if (typeof SENTRY_DSN !== 'undefined' && SENTRY_DSN) {
+    queryParams.set('sentryDsn', SENTRY_DSN);
   }
   if (debugMode) {
     queryParams.set('outlineDebugMode', 'true');

--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -23,7 +23,7 @@ import type {HttpRequest, HttpResponse} from '../infrastructure/path_api';
 import {fetchWithPin} from './fetch';
 import * as menu from './menu';
 
-// Injected by esbuild/webpack during build
+// Injected by webpack during build
 declare const SENTRY_DSN: string | undefined;
 
 const app = electron.app;

--- a/src/server_manager/electron_app/index.ts
+++ b/src/server_manager/electron_app/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as sentry from '@sentry/electron';
+import * as Sentry from '@sentry/electron';
 import * as dotenv from 'dotenv';
 import * as electron from 'electron';
 import {autoUpdater} from 'electron-updater';
@@ -22,6 +22,9 @@ import {URL, URLSearchParams} from 'url';
 import type {HttpRequest, HttpResponse} from '../infrastructure/path_api';
 import {fetchWithPin} from './fetch';
 import * as menu from './menu';
+
+// Injected by esbuild/webpack during build
+declare const SENTRY_DSN_: string | undefined;
 
 const app = electron.app;
 const ipcMain = electron.ipcMain;
@@ -38,20 +41,17 @@ const IMAGES_BASENAME = `${path.join(
   'web_app'
 )}`;
 
-const sentryDsn = process.env.SENTRY_DSN;
-if (sentryDsn) {
-  sentry.init({
-    dsn: sentryDsn,
+if (typeof SENTRY_DSN_ !== 'undefined' && SENTRY_DSN_) {
+  Sentry.init({
+    dsn: SENTRY_DSN_,
     // Sentry provides a sensible default but we would prefer without the leading
     // "outline-manager@".
     release: electron.app.getVersion(),
     maxBreadcrumbs: 100,
-    beforeBreadcrumb: (breadcrumb: sentry.Breadcrumb) => {
+    beforeBreadcrumb: (breadcrumb: Sentry.Breadcrumb) => {
       // Don't submit breadcrumbs for console.debug.
-      if (breadcrumb.category === 'console') {
-        if (breadcrumb.level === sentry.Severity.Debug) {
-          return null;
-        }
+      if (breadcrumb.category === 'console' && breadcrumb.level === 'debug') {
+        return null;
       }
       return breadcrumb;
     },
@@ -76,14 +76,14 @@ function createMainWindow() {
     webPreferences: {
       devTools: debugMode,
       nodeIntegration: false,
-      preload: path.join(__dirname, 'preload.js'),
+      preload: path.join(__dirname, './preload.js'),
       webviewTag: false,
     },
   });
   const webAppUrl = getWebAppUrl();
   win.loadURL(webAppUrl);
 
-  const handleNavigation = (event: Event, url: string) => {
+  const handleNavigation = (url: string) => {
     try {
       const parsed: URL = new URL(url);
       if (
@@ -98,13 +98,14 @@ function createMainWindow() {
     } catch (e) {
       console.warn('Could not parse URL: ' + url);
     }
-    event.preventDefault();
   };
   win.webContents.on('will-navigate', (event: Event, url: string) => {
-    handleNavigation(event, url);
+    handleNavigation(url);
+    event.preventDefault();
   });
-  win.webContents.on('new-window', (event: Event, url: string) => {
-    handleNavigation(event, url);
+  win.webContents.setWindowOpenHandler((details) => {
+    handleNavigation(details.url);
+    return {action: 'deny'};
   });
   win.webContents.on('did-finish-load', () => {
     // Wait until now to check for updates now so that the UI won't miss the event.
@@ -129,8 +130,8 @@ function getWebAppUrl() {
     queryParams.set('metricsUrl', process.env.SB_METRICS_URL);
     console.log(`Will use metrics url ${process.env.SB_METRICS_URL}`);
   }
-  if (sentryDsn) {
-    queryParams.set('sentryDsn', sentryDsn);
+  if (typeof SENTRY_DSN_ !== 'undefined' && SENTRY_DSN_) {
+    queryParams.set('sentryDsn', SENTRY_DSN_);
   }
   if (debugMode) {
     queryParams.set('outlineDebugMode', 'true');

--- a/src/server_manager/electron_app/preload.ts
+++ b/src/server_manager/electron_app/preload.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as sentry from '@sentry/electron';
 import {contextBridge, ipcRenderer} from 'electron';
-import {URL} from 'url';
+import '@sentry/electron/preload';
+import {Breadcrumb} from '@sentry/electron';
 
 import * as digitalocean_oauth from './digitalocean_oauth';
 import * as gcp_oauth from './gcp_oauth';
@@ -23,30 +23,26 @@ import {redactManagerUrl} from './util';
 
 // This file is run in the renderer process *before* nodeIntegration is disabled.
 //
-// Use it for main/renderer process communication and configuring Sentry (which works via
-// main/renderer process messages).
+// Use it for main/renderer process communication.
 
-// Configure Sentry to redact PII from the renderer process requests.
-// For all other config see the main process.
-const params = new URL(document.URL).searchParams;
-const sentryDsn = params.get('sentryDsn');
-if (sentryDsn) {
-  sentry.init({
-    dsn: sentryDsn,
-    beforeBreadcrumb: (breadcrumb: sentry.Breadcrumb) => {
-      // Redact PII from fetch requests.
-      if (breadcrumb.category === 'fetch' && breadcrumb.data && breadcrumb.data.url) {
-        try {
-          breadcrumb.data.url = `(redacted)/${redactManagerUrl(breadcrumb.data.url)}`;
-        } catch (e) {
-          // NOTE: cannot log this failure to console if console breadcrumbs are enabled
-          breadcrumb.data.url = `(error redacting)`;
-        }
-      }
-      return breadcrumb;
-    },
-  });
-}
+// Calling Sentry.init in preload won't work any more due to electron's new
+// sandbox model, all renderers must call Sentry.init() by themselves.
+//
+// Redact PII from the renderer process requests.
+// We are importing `node:url` package in `redactManagerUrl`, which is only
+// available in preload or main process.
+contextBridge.exposeInMainWorld('redactSentryBreadcrumbUrl', (breadcrumb: Breadcrumb) => {
+  // Redact PII from fetch requests.
+  if (breadcrumb.category === 'fetch' && breadcrumb.data && breadcrumb.data.url) {
+    try {
+      breadcrumb.data.url = `(redacted)/${redactManagerUrl(breadcrumb.data.url)}`;
+    } catch (e) {
+      // NOTE: cannot log this failure to console if console breadcrumbs are enabled
+      breadcrumb.data.url = `(error redacting)`;
+    }
+  }
+  return breadcrumb;
+});
 
 contextBridge.exposeInMainWorld(
   'fetchWithPin',

--- a/src/server_manager/electron_app/preload.ts
+++ b/src/server_manager/electron_app/preload.ts
@@ -25,8 +25,8 @@ import {redactManagerUrl} from './util';
 //
 // Use it for main/renderer process communication.
 
-// Calling Sentry.init in preload won't work any more due to electron's new
-// sandbox model, all renderers must call Sentry.init() by themselves.
+// Calling Sentry.init in preload won't work due to electron's new sandbox
+// model, all renderers must call Sentry.init() by themselves.
 //
 // Redact PII from the renderer process requests.
 // We are importing `node:url` package in `redactManagerUrl`, which is only

--- a/src/server_manager/electron_main.webpack.mjs
+++ b/src/server_manager/electron_main.webpack.mjs
@@ -46,7 +46,7 @@ export default {
   },
   plugins: [
     new webpack.DefinePlugin({
-      SENTRY_DSN_: JSON.stringify(process.env.SENTRY_DSN),
+      SENTRY_DSN: JSON.stringify(process.env.SENTRY_DSN),
     }),
   ],
   // don't bundle packages in node_modules

--- a/src/server_manager/electron_main.webpack.mjs
+++ b/src/server_manager/electron_main.webpack.mjs
@@ -1,0 +1,56 @@
+// Copyright 2023 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import webpack from 'webpack';
+import nodeExternals from 'webpack-node-externals';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
+  entry: path.resolve(__dirname, './electron_app/index.ts'),
+  target: 'electron-main',
+  node: {
+    __dirname: false,
+    __filename: false,
+  },
+  devtool: 'inline-source-map',
+  output: {
+    path: path.resolve(__dirname, '../../build/server_manager/electron_app/static'),
+    filename: 'index.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      SENTRY_DSN_: JSON.stringify(process.env.SENTRY_DSN),
+    }),
+  ],
+  // don't bundle packages in node_modules
+  externals: [
+    nodeExternals(),
+  ],
+};

--- a/src/server_manager/electron_preload.webpack.mjs
+++ b/src/server_manager/electron_preload.webpack.mjs
@@ -1,0 +1,46 @@
+// Copyright 2023 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import nodeExternals from 'webpack-node-externals';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
+  entry: path.resolve(__dirname, './electron_app/preload.ts'),
+  target: 'electron-preload',
+  devtool: 'inline-source-map',
+  output: {
+    path: path.resolve(__dirname, '../../build/server_manager/electron_app/static'),
+    filename: 'preload.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  // don't bundle packages in node_modules
+  externals: [
+    nodeExternals(),
+  ],
+};

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -67,7 +67,7 @@
     }
   },
   "config": {
-    "PUPPETEER_CHROMIUM_REVISION": "1086"
+    "PUPPETEER_CHROMIUM_REVISION": "992738"
   },
   "devDependencies": {
     "@types/node": "^16.11.29",
@@ -82,7 +82,7 @@
     "electron-builder": "^23.6.0",
     "electron-icon-maker": "^0.0.4",
     "electron-notarize": "^1.2.1",
-    "electron-to-chromium": "^1.4.122",
+    "electron-to-chromium": "^1.4.328",
     "gulp": "^4.0.0",
     "gulp-posthtml": "^3.0.4",
     "gulp-replace": "^1.0.0",

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -39,7 +39,7 @@
     "@polymer/paper-tabs": "^3.0.0",
     "@polymer/paper-toast": "^3.0.0",
     "@polymer/paper-tooltip": "^3.0.0",
-    "@sentry/electron": "^2",
+    "@sentry/electron": "^4.3.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "circle-flags": "https://github.com/HatScripts/circle-flags",
     "clipboard-polyfill": "^2.4.6",
@@ -78,7 +78,7 @@
     "@types/semver": "^5.5.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.3",
-    "electron": "18.1.0",
+    "electron": "19.1.9",
     "electron-builder": "^23.6.0",
     "electron-icon-maker": "^0.0.4",
     "electron-notarize": "^1.2.1",
@@ -100,7 +100,8 @@
     "ts-loader": "^7.0.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.9.0"
+    "webpack-dev-server": "^4.9.0",
+    "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
     "inherits": "2.0.3",

--- a/src/server_manager/types/preload.d.ts
+++ b/src/server_manager/types/preload.d.ts
@@ -14,6 +14,9 @@
 
 // Functions made available to the renderer process via preload.ts.
 
+type SentryBreadcrumb = import('@sentry/electron').Breadcrumb;
+declare function redactSentryBreadcrumbUrl(breadcrumb: SentryBreadcrumb): SentryBreadcrumb;
+
 type HttpRequest = import('../infrastructure/path_api').HttpRequest;
 type HttpResponse = import('../infrastructure/path_api').HttpResponse;
 

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as sentry from '@sentry/electron';
+import * as Sentry from '@sentry/electron';
 import * as semver from 'semver';
 
 import * as digitalocean_api from '../cloud/digitalocean_api';
@@ -45,6 +45,16 @@ const KEY_SETTINGS_VERSION = '1.6.0';
 const MAX_ACCESS_KEY_DATA_LIMIT_BYTES = 50 * 10 ** 9; // 50GB
 const CANCELLED_ERROR = new Error('Cancelled');
 export const LAST_DISPLAYED_SERVER_STORAGE_KEY = 'lastDisplayedServer';
+
+// todo: we are referencing `@sentry/electron` which won't work for web_app.
+//       It's ok for now cuz we don't need to enable Sentry in web_app, but
+//       a better solution is to have separate two entry points: electron_main
+//       (uses `@sentry/electron`) and web_main (uses `@sentry/browser`).
+// For all other Sentry config see the main process.
+Sentry.init({
+  beforeBreadcrumb:
+    typeof redactSentryBreadcrumbUrl === 'function' ? redactSentryBreadcrumbUrl : null,
+});
 
 function displayDataAmountToDataLimit(
   dataAmount: DisplayDataAmount
@@ -272,7 +282,7 @@ export class App {
     appRoot.addEventListener('SubmitFeedback', (event: CustomEvent) => {
       const detail: FeedbackDetail = event.detail;
       try {
-        sentry.captureEvent({
+        Sentry.captureEvent({
           message: detail.userFeedback,
           user: {email: detail.userEmail},
           tags: {category: detail.feedbackCategory, cloudProvider: detail.cloudProvider},

--- a/src/server_manager/web_app/app.ts
+++ b/src/server_manager/web_app/app.ts
@@ -46,10 +46,11 @@ const MAX_ACCESS_KEY_DATA_LIMIT_BYTES = 50 * 10 ** 9; // 50GB
 const CANCELLED_ERROR = new Error('Cancelled');
 export const LAST_DISPLAYED_SERVER_STORAGE_KEY = 'lastDisplayedServer';
 
-// todo: we are referencing `@sentry/electron` which won't work for web_app.
-//       It's ok for now cuz we don't need to enable Sentry in web_app, but
-//       a better solution is to have separate two entry points: electron_main
-//       (uses `@sentry/electron`) and web_main (uses `@sentry/browser`).
+// todo (#1311): we are referencing `@sentry/electron` which won't work for
+//               web_app. It's ok for now cuz we don't need to enable Sentry in
+//               web_app, but a better solution is to have separate two entry
+//               points: electron_main (uses `@sentry/electron`) and web_main
+//               (uses `@sentry/browser`).
 // For all other Sentry config see the main process.
 Sentry.init({
   beforeBreadcrumb:

--- a/src/server_manager/web_app/ui_components/app-root.ts
+++ b/src/server_manager/web_app/ui_components/app-root.ts
@@ -392,8 +392,7 @@ export class AppRoot extends polymerElementWithLocalize {
           <!-- Links section -->
           <paper-listbox>
             <span on-tap="maybeCloseDrawer"><a href="https://support.getoutline.org/s/article/Data-collection">[[localize('nav-data-collection')]]</a></span>
-            <!-- TODO(daniellacosse): restore this once the feedback form is fixed -->
-            <!-- <span on-tap="submitFeedbackTapped">[[localize('nav-feedback')]]</span> -->
+            <span on-tap="submitFeedbackTapped">[[localize('nav-feedback')]]</span>
             <span on-tap="maybeCloseDrawer"><a href="https://s3.amazonaws.com/outline-vpn/index.html#/en/support/">[[localize('nav-help')]]</a></span>
             <span on-tap="aboutTapped">[[localize('nav-about')]]</span>
             <div id="links-footer">

--- a/src/server_manager/web_app/ui_components/outline-feedback-dialog.ts
+++ b/src/server_manager/web_app/ui_components/outline-feedback-dialog.ts
@@ -107,7 +107,6 @@ Polymer({
             id="feedbackCategoryListbox"
             slot="dropdown-content"
             class="dropdown-content"
-            selected="0"
           >
             <paper-item>[[localize('feedback-general')]]</paper-item>
             <paper-item>[[localize('feedback-install')]]</paper-item>
@@ -199,6 +198,13 @@ Polymer({
   },
 
   open(prepopulatedMessage: string, showInstallationFailed: boolean) {
+    // The localized category doesn't get displayed the first time opening the
+    // dialog (or after updating language) because the selected list item won't
+    // notice the localization change.
+    // This is a known issue and here is a workaround (force the selected item change):
+    //   https://github.com/PolymerElements/paper-dropdown-menu/issues/159#issuecomment-229958448
+    this.$.feedbackCategoryListbox.selected = undefined;
+
     // Clear all fields, in case feedback had already been entered.
     if (showInstallationFailed) {
       this.title = this.localize('feedback-title-install');
@@ -209,8 +215,6 @@ Polymer({
       this.title = this.localize('feedback-title-generic');
       this.feedbackExplanation = '';
       this.$.dialog.classList.remove('installationFailed');
-      // TODO(alalama): figure out why the localized category doesn't get displayed the first
-      // time opening the dialog.
       this.$.feedbackCategoryListbox.selected = this.feedbackCategories.GENERAL;
     }
     this.$.userFeedback.invalid = false;


### PR DESCRIPTION
In this PR, I integrated Outline Manager with the latest Sentry library and re-enabled the user feedback form. Sentry was not working because of two reasons:
1. Electron enabled sandbox to its `preload.js` script, therefore calling `Sentry.init` in `preload` is not enough (and not necessary), we must call `Sentry.init` in every renderer process as well
2. `SENTRY_DSN` is not injected into electron, we read it from `process.env.SENTRY_DSN`, but this is a runtime environment variable (which will be `undefined`)

So basically my fix is straightforward:
1. Calling `Sentry.init` in `web_app/app.ts`, which is the entrypoint of renderer process
2. Use `webpack` to inject `SENTRY_DSN_` variable into `electron_app/index.ts` during build

In order to be consistent (and to minify the result js file), I also introduced webpack to build the `preload.ts` script as well.

Finally I upgraded electron to the latest version that does not have [API restrictions](https://www.electronjs.org/docs/latest/breaking-changes#default-changed-renderers-without-nodeintegration-true-are-sandboxed-by-default) to `preload` script (we are using `crypto` package which will be forbidden). A refactoring is required in order to upgrade to any newer versions of electron.