### PR TITLE
fix(sentry_webhook): check if email is erroneously `[undefined]`

### DIFF
--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -74,7 +74,7 @@ const SALESFORCE_FORM_VALUES_PROD: SalesforceFormValues = {
 // Returns whether a Sentry event should be sent to Salesforce by checking that it contains an
 // email address.
 export function shouldPostEventToSalesforce(event: sentry.SentryEvent): boolean {
-  return !!event.user && !!event.user.email;
+  return !!event.user && !!event.user.email && event.user.email !== "[undefined]";
 }
 
 // Posts a Sentry event to Salesforce using predefined form data. Assumes


### PR DESCRIPTION
It seems we're getting a bunch of events coming in with the email set to the literal sequence of characters `[undefined]` - until we find the source of these events, this should stop them from flooding salesforce.