### PR TITLE
fix: improve Docker container existence detection in install_server.sh

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -172,7 +172,7 @@ function start_docker() {
 }
 
 function docker_container_exists() {
-  docker ps | grep --quiet "$1"
+  docker ps -a --format '{{.Names}}'| grep --quiet "^$1$"
 }
 
 function remove_shadowbox_container() {


### PR DESCRIPTION
This PR aims to enhance the `docker_container_exists` function in `install_server.sh`. The previous implementation had issues with false negatives, making it unreliable in recognizing containers that were not currently running. In some cases, it even failed to recognize running containers. (I encountered this issue when using the script as a basis for a script that restarts Outline server containers.)