### PR TITLE
add subjectAltName field into self signed certificate

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -265,6 +265,7 @@ function generate_certificate() {
   declare -a openssl_req_flags=(
     -x509 -nodes -days 36500 -newkey rsa:4096
     -subj "/CN=${PUBLIC_HOSTNAME}"
+    -addext "subjectAltName = IP.1:${PUBLIC_HOSTNAME}"
     -keyout "${SB_PRIVATE_KEY_FILE}" -out "${SB_CERTIFICATE_FILE}"
   )
   openssl req "${openssl_req_flags[@]}" >&2


### PR DESCRIPTION
Current install script only fills CN field with PUBLIC_HOST value. When trying to access api and provide the self signed certificate to verify server certificate, the request will fail with SSL: CERTIFICATE_VERIFY_FAILED error.

To prevent this error, the install script should add "subjectAltName = IP.1:${PUBLIC_HOST}" when generating self signed certificate.

```python
import requests
requests.get('https://${API_PREFIX}/access-keys',verify='shadowbox-selfsigned.crt')
```