### PR TITLE
feat(server): remove ulimit

### DIFF
--- a/src/shadowbox/docker/cmd.sh
+++ b/src/shadowbox/docker/cmd.sh
@@ -20,25 +20,6 @@ export SB_METRICS_URL="${SB_METRICS_URL:-https://prod.metrics.getoutline.org}"
 # Make sure we don't leak readable files to other users.
 umask 0007
 
-# The maximum number of files that can be opened by ss-server greatly
-# influence on performance, as described here:
-#   https://shadowsocks.org/en/config/advanced.html
-#
-# The steps described in that page do *not* work for processes running
-# under Docker, at least on modern Debian/Ubuntu-like systems whose init
-# daemons allow per-service limits and ignore completely
-# /etc/security/limits.conf. On those systems, the Shadowbox container
-# will, by default, inherit the limits configured for the Docker service:
-#   https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container-ulimit
-#
-# Interestingly, we observed poor performance with large values such as 524288
-# and 1048576, the default values in recent releases of Ubuntu. Our
-# non-exhaustive testing indicates a performance cliff for Outline after values
-# around 270k; to stay well below of this cliff we've semi-handwaved-ly settled
-# upon a limit of 32k files.
-# shellcheck disable=SC2039 # ulimit -n is in bash and busybox but not POSIX
-ulimit -n 32768
-
 # Start cron, which is used to check for updates to the IP-to-country database
 crond
 


### PR DESCRIPTION
This is unnecessarily restricting the server, which limits the number of connections we can support. This affected one of our partners. The call also can't raise the ulimit, since the host impose a cap on the container.

Those measurements were done when we uses ss-server, which we haven't used for several years.

Service providers can still set the ulimit on their host if they want to.