### PR TITLE
chore(sentry_webhook): use Node.js 18 runtime version

### DIFF
--- a/src/sentry_webhook/deploy.action.sh
+++ b/src/sentry_webhook/deploy.action.sh
@@ -17,4 +17,9 @@
 npm run action sentry_webhook/build
 
 cp src/sentry_webhook/package.json build/sentry_webhook/
-gcloud --project=uproxysite functions deploy postSentryEventToSalesforce --runtime=nodejs12 --trigger-http --source=build/sentry_webhook --entry-point=postSentryEventToSalesforce
+gcloud functions deploy postSentryEventToSalesforce \
+  --project=uproxysite \
+  --runtime=nodejs18 \
+  --trigger-http \
+  --source=build/sentry_webhook \
+  --entry-point=postSentryEventToSalesforce


### PR DESCRIPTION
Node.js 12 will be deprecated on Jan 30, 2024. This changes the runtime to Node.js 18, which is listed as the recommended version at https://cloud.google.com/functions/docs/concepts/nodejs-runtime.