### PR TITLE
fix(manager/electron): replace turned down OmahaProxy with ChromiumDash

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "typescript": "^4"
   },
   "engines": {
-    "node": "^18.16.0",
-    "npm": "^9.5.1"
+    "node": "18.x.x"
   },
   "scripts": {
     "action": "bash ./scripts/run_action.sh",

--- a/src/server_manager/electron_and_karma_chromium.spec.ts
+++ b/src/server_manager/electron_and_karma_chromium.spec.ts
@@ -22,7 +22,7 @@ import {config} from './package.json';
 
 describe('Karma', () => {
   it('uses the correct Chromium version', async (done) => {
-    const electronChromiumVersionInfo = <{chromium_base_position?: string}>(
+    const electronChromiumVersionInfo = <{chromium_main_branch_position?: string}>(
       await (
         await fetch(
           `https://chromiumdash.appspot.com/fetch_version?version=${electronToChromium(

--- a/src/server_manager/electron_and_karma_chromium.spec.ts
+++ b/src/server_manager/electron_and_karma_chromium.spec.ts
@@ -22,7 +22,7 @@ import {config} from './package.json';
 
 describe('Karma', () => {
   it('uses the correct Chromium version', async (done) => {
-    const electronChromiumVersionInfo = <{chromium_main_branch_position?: string}>(
+    const electronChromiumVersionInfo = <{chromium_main_branch_position?: number}>(
       await (
         await fetch(
           `https://chromiumdash.appspot.com/fetch_version?version=${electronToChromium(

--- a/src/server_manager/electron_and_karma_chromium.spec.ts
+++ b/src/server_manager/electron_and_karma_chromium.spec.ts
@@ -22,6 +22,8 @@ import {config} from './package.json';
 
 describe('Karma', () => {
   it('uses the correct Chromium version', async (done) => {
+    // ChromiumDash is a service maintained by the Chrome team which serves metadata about current
+    // and legacy Chrome versions.
     const electronChromiumVersionInfo = <{chromium_main_branch_position?: number}>(
       await (
         await fetch(

--- a/src/server_manager/electron_and_karma_chromium.spec.ts
+++ b/src/server_manager/electron_and_karma_chromium.spec.ts
@@ -22,16 +22,16 @@ import {config} from './package.json';
 
 describe('Karma', () => {
   it('uses the correct Chromium version', async (done) => {
-    // Omaha Proxy is a service maintained by the Chrome team which serves metadata about current
-    // and legacy Chrome versions.
     const electronChromiumVersionInfo = <{chromium_base_position?: string}>(
       await (
         await fetch(
-          `http://omahaproxy.appspot.com/deps.json?version=${electronToChromium(electronVersion)}`
+          `https://chromiumdash.appspot.com/fetch_version?version=${electronToChromium(
+            electronVersion
+          )}`
         )
       ).json()
     );
-    const electronChromeRevision = electronChromiumVersionInfo.chromium_base_position;
+    const electronChromeRevision = electronChromiumVersionInfo.chromium_main_branch_position;
     expect(electronChromeRevision).toEqual(config.PUPPETEER_CHROMIUM_REVISION);
     done();
   });

--- a/src/server_manager/package.json
+++ b/src/server_manager/package.json
@@ -59,7 +59,7 @@
       "PUPPETEER_CHROMIUM_REVISION": [
         "The Chromium revision number used by Karma.  This should always be the revision number of",
         "the bundled Chromium in our version of Electron.  Whenever upgrading Electron, run the",
-        "server_manager tests.  You'll get a failure that looks like <Expected '812852' to equal '693954>.",
+        "server_manager tests.  You'll get a failure that looks like <Expected 812852 to equal 693954>.",
         "Set PUPPETEER_CHROMIUM_REVISION to the first of those numbers to get the correct revision",
         "and `npm ci` to re-install puppeteer, causing it to download the new",
         "Chromium version."
@@ -67,7 +67,7 @@
     }
   },
   "config": {
-    "PUPPETEER_CHROMIUM_REVISION": "992738"
+    "PUPPETEER_CHROMIUM_REVISION": 992738
   },
   "devDependencies": {
     "@types/node": "^16.11.29",


### PR DESCRIPTION
This service is turned down. See https://groups.google.com/a/chromium.org/g/chromium-dev/c/uH-nFrOLWtE.

It's currently returning:

    *** Service Permanently Offline ***
    
    OmahaProxy has been turned down.
    Please migrate to <https://chromiumdash.appspot.com>.

ChromiumDash is meant to replace this functionality.