### PR TITLE
chore(manager/web): clean up unused `_computeSideBarMarginClass`

### DIFF
--- a/src/server_manager/web_app/ui_components/app-root.ts
+++ b/src/server_manager/web_app/ui_components/app-root.ts
@@ -1094,10 +1094,6 @@ export class AppRoot extends polymerElementWithLocalize {
     }
   }
 
-  _computeSideBarMarginClass(shouldShowSideBar: boolean) {
-    return shouldShowSideBar ? 'side-bar-margin' : '';
-  }
-
   _accountServerFilter(account: AccountListEntry) {
     return (server: ServerListEntry) => account && server.accountId === account.id;
   }


### PR DESCRIPTION
Usage was removed in #1463.