### PR TITLE
feat(server): enable log rotation and start script

### DIFF
--- a/src/server_manager/install_scripts/do_install_server.sh
+++ b/src/server_manager/install_scripts/do_install_server.sh
@@ -54,7 +54,7 @@ function post_sentry_report() {
     SENTRY_PAYLOAD="{\"message\": \"Install error:\n$(awk '{printf "%s\\n", $0}' < "${SENTRY_LOG_FILE}" | tail --bytes "${SENTRY_PAYLOAD_BYTE_LIMIT}")\"}"
     # See Sentry documentation at:
     # https://media.readthedocs.org/pdf/sentry/7.1.0/sentry.pdf
-    curl "${SENTRY_API_URL}" -H "Origin: shadowbox" --data-binary "${SENTRY_PAYLOAD}"
+    curl -sSL "${SENTRY_API_URL}" -H "Origin: shadowbox" --data-binary "${SENTRY_PAYLOAD}"
   fi
 }
 
@@ -73,7 +73,7 @@ fi
 readonly DO_METADATA_URL="http://169.254.169.254/metadata/v1"
 
 function cloud::public_ip() {
-  curl "${DO_METADATA_URL}/interfaces/public/0/ipv4/address"
+  curl -sSL "${DO_METADATA_URL}/interfaces/public/0/ipv4/address"
 }
 
 # Applies a tag to this droplet.
@@ -83,9 +83,9 @@ function cloud::add_tag() {
                         -H "Authorization: Bearer ${DO_ACCESS_TOKEN}")
   local -r TAGS_URL='https://api.digitalocean.com/v2/tags'
   # Create the tag
-  curl "${base_flags[@]}" -d "{\"name\":\"${tag}\"}" "${TAGS_URL}"
+  curl -sSL "${base_flags[@]}" -d "{\"name\":\"${tag}\"}" "${TAGS_URL}"
   local droplet_id
-  droplet_id="$(curl "${DO_METADATA_URL}/id")"
+  droplet_id="$(curl -sSL "${DO_METADATA_URL}/id")"
   printf -v droplet_obj '
 {
   "resources": [{
@@ -94,7 +94,7 @@ function cloud::add_tag() {
   }]
 }' "${droplet_id}"
   # Link the tag to this droplet
-  curl "${base_flags[@]}" -d "${droplet_obj}" "${TAGS_URL}/${tag}/resources"
+  curl -sSL "${base_flags[@]}" -d "${droplet_obj}" "${TAGS_URL}/${tag}/resources"
 }
 
 # Adds a key-value tag to the droplet.

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -311,7 +311,7 @@ function start_shadowbox() {
 set -eu
 
 docker stop "${CONTAINER_NAME}" 2> /dev/null || true
-docker rm "${CONTAINER_NAME}" 2> /dev/null || true
+docker rm -f "${CONTAINER_NAME}" 2> /dev/null || true
 
 docker_command=(
   docker

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -301,21 +301,55 @@ function write_config() {
 function start_shadowbox() {
   # TODO(fortuna): Write API_PORT to config file,
   # rather than pass in the environment.
-  local -ar docker_shadowbox_flags=(
-    --name "${CONTAINER_NAME}" --restart always --net host
-    --label 'com.centurylinklabs.watchtower.enable=true'
-    -v "${STATE_DIR}:${STATE_DIR}"
-    -e "SB_STATE_DIR=${STATE_DIR}"
-    -e "SB_API_PORT=${API_PORT}"
-    -e "SB_API_PREFIX=${SB_API_PREFIX}"
-    -e "SB_CERTIFICATE_FILE=${SB_CERTIFICATE_FILE}"
-    -e "SB_PRIVATE_KEY_FILE=${SB_PRIVATE_KEY_FILE}"
-    -e "SB_METRICS_URL=${SB_METRICS_URL:-}"
-    -e "SB_DEFAULT_SERVER_NAME=${SB_DEFAULT_SERVER_NAME:-}"
-  )
-  # By itself, local messes up the return code.
+  local -r START_SCRIPT="${STATE_DIR}/start_container.sh"
+  cat <<-EOF > "${START_SCRIPT}"
+# This script starts the Outline server container ("Shadowbox").
+# If you need to customize how the server is run, you can edit this script, then:
+#
+#     docker stop "${CONTAINER_NAME}" && docker rm "${CONTAINER_NAME}"
+#     "${START_SCRIPT}"
+
+docker_command=(
+  docker
+  run
+  -d
+  --name "${CONTAINER_NAME}" --restart always --net host
+
+  # Used by Watchtower to know which containers to monitor.
+  --label 'com.centurylinklabs.watchtower.enable=true'
+  
+  # Use log rotation. See https://docs.docker.com/config/containers/logging/configure/.
+  --log-driver local
+
+  # The state that is persisted across restarts.
+  -v "${STATE_DIR}:${STATE_DIR}"
+    
+  # Where the container keeps its persistent state.
+  -e "SB_STATE_DIR=${STATE_DIR}"
+
+  # Port number and path prefix used by the server manager API.
+  -e "SB_API_PORT=${API_PORT}"
+  -e "SB_API_PREFIX=${SB_API_PREFIX}"
+
+  # Location of the API TLS certificate and key.
+  -e "SB_CERTIFICATE_FILE=${SB_CERTIFICATE_FILE}"
+  -e "SB_PRIVATE_KEY_FILE=${SB_PRIVATE_KEY_FILE}"
+
+  # Where to report metrics to, if opted-in.
+  -e "SB_METRICS_URL=${SB_METRICS_URL:-}"
+
+  # The default server name, if not set in the config.
+  -e "SB_DEFAULT_SERVER_NAME=${SB_DEFAULT_SERVER_NAME:-}"
+
+  # The Outline server image to run.
+  "${SB_IMAGE}"
+)
+"\${docker_command[@]}"
+EOF
+  chmod +x "${START_SCRIPT}"
+  # Declare then assign. Assigning on declaration messes up the return code.
   local STDERR_OUTPUT
-  STDERR_OUTPUT="$(docker run -d "${docker_shadowbox_flags[@]}" "${SB_IMAGE}" 2>&1 >/dev/null)" && return
+  STDERR_OUTPUT="$({ "${START_SCRIPT}" >/dev/null; } 2>&1)" && return
   readonly STDERR_OUTPUT
   log_error "FAILED"
   if docker_container_exists "${CONTAINER_NAME}"; then
@@ -332,7 +366,7 @@ function start_watchtower() {
   # Set watchtower to refresh every 30 seconds if a custom SB_IMAGE is used (for
   # testing).  Otherwise refresh every hour.
   local -ir WATCHTOWER_REFRESH_SECONDS="${WATCHTOWER_REFRESH_SECONDS:-3600}"
-  local -ar docker_watchtower_flags=(--name watchtower --restart always \
+  local -ar docker_watchtower_flags=(--name watchtower --log-driver local --restart always \
       -v /var/run/docker.sock:/var/run/docker.sock)
   # By itself, local messes up the return code.
   local STDERR_OUTPUT

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -290,6 +290,9 @@ function join() {
 
 function write_config() {
   local -a config=()
+  if [[ "${SB_DEFAULT_SERVER_NAME:-}" != "" ]]; then
+    config+=("\"name\": ${SB_DEFAULT_SERVER_NAME}")
+  fi
   if (( FLAGS_KEYS_PORT != 0 )); then
     config+=("\"portForNewAccessKeys\": ${FLAGS_KEYS_PORT}")
   fi
@@ -337,9 +340,6 @@ docker_command=(
 
   # Where to report metrics to, if opted-in.
   -e "SB_METRICS_URL=${SB_METRICS_URL:-}"
-
-  # The default server name, if not set in the config.
-  -e "SB_DEFAULT_SERVER_NAME=${SB_DEFAULT_SERVER_NAME:-}"
 
   # The Outline server image to run.
   "${SB_IMAGE}"

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -291,12 +291,13 @@ function join() {
 function write_config() {
   local -a config=()
   if [[ "${SB_DEFAULT_SERVER_NAME:-}" != "" ]]; then
-    config+=("\"name\": ${SB_DEFAULT_SERVER_NAME}")
+    # Use printf to escape (%q) the server name.
+    config+=("$(printf '"name": "%q"' "${SB_DEFAULT_SERVER_NAME}")")
   fi
   if (( FLAGS_KEYS_PORT != 0 )); then
     config+=("\"portForNewAccessKeys\": ${FLAGS_KEYS_PORT}")
   fi
-  # printf is needed to escape the hostname.
+  # Use printf to escape (%q) the hostname.
   config+=("$(printf '"hostname": "%q"' "${PUBLIC_HOSTNAME}")")
   echo "{$(join , "${config[@]}")}" > "${STATE_DIR}/shadowbox_server_config.json"
 }


### PR DESCRIPTION
This PR makes the Manager use `--log-driver local` in the docker run, which is a log driver that does log rotation, unlike the default driver that keeps growing on disk and can make the server stop working after some time ([details](https://docs.docker.com/config/containers/logging/configure)). This is important, because some people may think the server gets blocked after some time.

This PR also creates a run script. That will help providers understand how to run the Outline server with Docker, and allow them to tweak how it is run. They can more easily change the API port, for instance. It's also a lot easier to change a server to the canary image. This is what is output on a standard installation:

```bash
# This script starts the Outline server container ("Shadowbox").
# If you need to customize how the server is run, you can edit this script, then restart with:
#
#     "/root/shadowbox/persisted-state/start_container.sh"

set -eu

docker stop "shadowbox" 2> /dev/null || true
docker rm -f "shadowbox" 2> /dev/null || true

docker_command=(
  docker
  run
  -d
  --name "shadowbox" --restart always --net host

  # Used by Watchtower to know which containers to monitor.
  --label 'com.centurylinklabs.watchtower.enable=true'
  
  # Use log rotation. See https://docs.docker.com/config/containers/logging/configure/.
  --log-driver local

  # The state that is persisted across restarts.
  -v "/root/shadowbox/persisted-state:/root/shadowbox/persisted-state"
    
  # Where the container keeps its persistent state.
  -e "SB_STATE_DIR=/root/shadowbox/persisted-state"

  # Port number and path prefix used by the server manager API.
  -e "SB_API_PORT=26770"
  -e "SB_API_PREFIX=1W3UislDWAmZLggSTR0nWQ"

  # Location of the API TLS certificate and key.
  -e "SB_CERTIFICATE_FILE=/root/shadowbox/persisted-state/shadowbox-selfsigned.crt"
  -e "SB_PRIVATE_KEY_FILE=/root/shadowbox/persisted-state/shadowbox-selfsigned.key"

  # Where to report metrics to, if opted-in.
  -e "SB_METRICS_URL="

  # The default server name, if not set in the config.
  -e "SB_DEFAULT_SERVER_NAME=Outline Server London"

  # The Outline server image to run.
  "quay.io/outline/shadowbox:stable"
)
"${docker_command[@]}"
```

~~In the process I replaced the setting of `SB_DEFAULT_SERVER_NAME` with setting the server name directly in the config. That's a lot less confusing (history context: the env var existed before the config setting was introduced).~~ (had issues, will figure out later)
