### PR TITLE
fix(manager): adjust app container on narrow devices to make room for sidebar

### DIFF
--- a/src/server_manager/web_app/ui_components/app-root.ts
+++ b/src/server_manager/web_app/ui_components/app-root.ts
@@ -372,6 +372,11 @@ export class AppRoot extends polymerElementWithLocalize {
       #getConnectedDialog .buttons {
         margin-top: -5px; /* undo spacing added after iframe */
       }
+      @media (max-width: 887px) {
+        .app-container {
+          margin-left: 50px;
+        }
+      }
     </style>
 
     <outline-tos-view id="tosView" has-accepted-terms-of-service="{{userAcceptedTos}}" hidden\$="{{hasAcceptedTos}}" localize="[[localize]]"></outline-tos-view>

--- a/src/server_manager/web_app/ui_components/outline-step-view.ts
+++ b/src/server_manager/web_app/ui_components/outline-step-view.ts
@@ -56,11 +56,6 @@ Polymer({
         justify-content: flex-end;
         flex: 1;
       }
-      @media (max-width: 887px) {
-        .step-container {
-          margin-left: 50px;
-        }
-      }
     </style>
     <div class="step-container">
       <div class="step-header">


### PR DESCRIPTION
this is horrible, I feel like god told me to kill my own brother

the sidebar and the main page for whatever reason are on different layers. I would have to restructure the UI and (possibly) rip out some of the components we're using to do it properly (they should be in a flex layout on the same layer). for now, to unblock the release I am simply using a grotesque media query to make room for the sidebar when the app is narrow.

my guess is this behavior started when our dependencies were updated at some point