### PR TITLE
chore(manager): deprecate SB_DEFAULT_SERVER_NAME on install

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -551,20 +551,19 @@ function escape_json_string() {
     local char="${input:i:1}"
     local escaped="${char}"
     case "${char}" in
-        # List from https://www.json.org/.
-        $'"' ) escaped="\\\"";;
-        $'\\') escaped="\\\\";;
-        $'/' ) escaped="\\/";;
-        $'\b') escaped="\\b";;
-        $'\f') escaped="\\f";;
-        $'\n') escaped="\\n";;
-        $'\r') escaped="\\r";;
-        $'\t') escaped="\\t";;
-        *) 
-          if [[ "${char}" < $'\x20' ]]; then
-            escaped=$(printf "\u%04X" "'${char}")
-          fi
-          ;;
+      $'"' ) escaped="\\\"";;
+      $'\\') escaped="\\\\";;
+      *)
+        if [[ "${char}" < $'\x20' ]]; then
+          case "${char}" in 
+            $'\b') escaped="\\b";;
+            $'\f') escaped="\\f";;
+            $'\n') escaped="\\n";;
+            $'\r') escaped="\\r";;
+            $'\t') escaped="\\t";;
+            *) escaped=$(printf "\u%04X" "'${char}")
+          esac
+        fi;;
     esac
     echo -n "${escaped}"
   done

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -550,17 +550,20 @@ function escape_json_string() {
   for ((i = 0; i < ${#input}; i++)); do
     local char="${input:i:1}"
     local escaped="${char}"
-    case "${char}" in
-      # List from https://www.json.org/json-en.html.
-      $'"' ) escaped="\\\"";;
-      $'\\') escaped="\\\\";;
-      $'/' ) escaped="\\/";;
-      $'\b') escaped="\\b";;
-      $'\f') escaped="\\f";;
-      $'\n') escaped="\\n";;
-      $'\r') escaped="\\r";;
-      $'\t') escaped="\\t";;
-    esac
+    if [[ "${char}" < $'\x20' ]]; then
+      case "${char}" in
+        # List from https://www.json.org/json-en.html.
+        $'"' ) escaped="\\\"";;
+        $'\\') escaped="\\\\";;
+        $'/' ) escaped="\\/";;
+        $'\b') escaped="\\b";;
+        $'\f') escaped="\\f";;
+        $'\n') escaped="\\n";;
+        $'\r') escaped="\\r";;
+        $'\t') escaped="\\t";;
+        *) escaped=$(printf "\u%04X" "'${char}")
+      esac
+    fi
     echo -n "${escaped}"
   done
 }

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -293,8 +293,10 @@ function write_config() {
   if (( FLAGS_KEYS_PORT != 0 )); then
     config+=("\"portForNewAccessKeys\": ${FLAGS_KEYS_PORT}")
   fi
-  # Use printf to escape (%q) the hostname.
-  config+=("$(printf '"hostname": "%q"' "${PUBLIC_HOSTNAME}")")
+  if [[ -n "${SB_DEFAULT_SERVER_NAME:-}" ]]; then
+    config+=("\"name\": \"$(escape_json_string "${SB_DEFAULT_SERVER_NAME}")\"")   
+  fi
+  config+=("\"hostname\": \"$(escape_json_string "${PUBLIC_HOSTNAME}")\"")
   echo "{$(join , "${config[@]}")}" > "${STATE_DIR}/shadowbox_server_config.json"
 }
 
@@ -341,9 +343,6 @@ docker_command=(
 
   # Where to report metrics to, if opted-in.
   -e "SB_METRICS_URL=${SB_METRICS_URL:-}"
-
-  # The default server name, if not set in the config.
-  -e "SB_DEFAULT_SERVER_NAME=${SB_DEFAULT_SERVER_NAME:-}"
 
   # The Outline server image to run.
   "${SB_IMAGE}"
@@ -544,6 +543,26 @@ END_OF_SERVER_OUTPUT
 
 function is_valid_port() {
   (( 0 < "$1" && "$1" <= 65535 ))
+}
+
+function escape_json_string() {
+  local input=$1
+  for ((i = 0; i < ${#input}; i++)); do
+    local char="${input:i:1}"
+    local escaped="${char}"
+    case "${char}" in
+      # List from https://www.json.org/json-en.html.
+      $'"' ) escaped="\\\"";;
+      $'\\') escaped="\\\\";;
+      $'/' ) escaped="\\/";;
+      $'\b') escaped="\\b";;
+      $'\f') escaped="\\f";;
+      $'\n') escaped="\\n";;
+      $'\r') escaped="\\r";;
+      $'\t') escaped="\\t";;
+    esac
+    echo -n "${escaped}"
+  done
 }
 
 function parse_flags() {

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -550,8 +550,7 @@ function escape_json_string() {
   for ((i = 0; i < ${#input}; i++)); do
     local char="${input:i:1}"
     local escaped="${char}"
-    if [[ "${char}" < $'\x20' ]]; then
-      case "${char}" in
+    case "${char}" in
         # List from https://www.json.org/json-en.html.
         $'"' ) escaped="\\\"";;
         $'\\') escaped="\\\\";;
@@ -561,9 +560,12 @@ function escape_json_string() {
         $'\n') escaped="\\n";;
         $'\r') escaped="\\r";;
         $'\t') escaped="\\t";;
-        *) escaped=$(printf "\u%04X" "'${char}")
-      esac
-    fi
+        *) 
+          if [[ "${char}" < $'\x20' ]]; then
+            escaped=$(printf "\u%04X" "'${char}")
+          fi
+          ;;
+    esac
     echo -n "${escaped}"
   done
 }

--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -551,7 +551,7 @@ function escape_json_string() {
     local char="${input:i:1}"
     local escaped="${char}"
     case "${char}" in
-        # List from https://www.json.org/json-en.html.
+        # List from https://www.json.org/.
         $'"' ) escaped="\\\"";;
         $'\\') escaped="\\\\";;
         $'/' ) escaped="\\/";;


### PR DESCRIPTION
Small cleanup: use the config instead of the `SB_DEFAULT_SERVER_NAME` env var to specify the server name. Having two mechanisms is confusing, and this further simplifies the docker run command.