### PR TITLE
build(manager): detect platform before shifting the arg array in package action

### DIFF
--- a/src/server_manager/electron_app/package.action.sh
+++ b/src/server_manager/electron_app/package.action.sh
@@ -93,7 +93,7 @@ function main() {
       exit 1
       ;;
     *)  # Only supports having one positional argument.
-      PLATFORM="${i?Platform missing}"
+      PLATFORM="${i}"
       ;;
     esac
   done


### PR DESCRIPTION
`shift` mutates the `$@` array, so by the time the script was getting here, `$PLATFORM` was the wrong thing:

![Screenshot 2024-02-05 at 8 28 51 PM](https://github.com/Jigsaw-Code/outline-server/assets/3759828/1325c352-a909-4b62-8992-3d27c017127e)
