### PR TITLE
feat(server): extend key creation API to allow specifying a port

### DIFF
--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -59,6 +59,8 @@ export interface AccessKeyCreateParams {
   readonly password?: string;
   // The data transfer limit to apply to the access key.
   readonly dataLimit?: DataLimit;
+  // The port number to use for the access key.
+  readonly portNumber?: number;
 }
 
 export interface AccessKeyRepository {

--- a/src/shadowbox/model/errors.ts
+++ b/src/shadowbox/model/errors.ts
@@ -24,15 +24,14 @@ class OutlineError extends Error {
 }
 
 export class InvalidPortNumber extends OutlineError {
-  // Since this is the error when a non-numeric value is passed to `port`, it takes type `string`.
-  constructor(public port: string) {
-    super(port);
+  constructor(public port: number) {
+    super(`Port ${port} is invalid: must be an integer in range [0, 65353]`);
   }
 }
 
 export class PortUnavailable extends OutlineError {
   constructor(public port: number) {
-    super(port.toString());
+    super(`Port ${port} is unavailable`);
   }
 }
 

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -154,13 +154,13 @@ paths:
                   type: string
                 port:
                   type: integer
-                dataLimit:
+                limit:
                   $ref: "#/components/schemas/DataLimit"
             examples:
               'No params specified':
                 value: '{"method":"aes-192-gcm"}'
               'Provide params':
-                value: '{"method":"aes-192-gcm","name":"First","password":"8iu8V8EeoFVpwQvQeS9wiD","limit":{"bytes":10000}}'
+                value: '{"method":"aes-192-gcm","name":"First","password":"8iu8V8EeoFVpwQvQeS9wiD","port": 12345,"limit":{"bytes":10000}}'
       responses:
         '201':
           description: The newly created access key
@@ -196,11 +196,11 @@ paths:
                   type: string
                 port:
                   type: integer
-                dataLimit:
+                limit:
                   $ref: "#/components/schemas/DataLimit"
             examples:
               '0':
-                value: '{"id":"123","method":"aes-192-gcm","name":"First","password":"8iu8V8EeoFVpwQvQeS9wiD","limit":{"bytes":10000}}'
+                value: '{"id":"123","method":"aes-192-gcm","name":"First","password":"8iu8V8EeoFVpwQvQeS9wiD","port": 12345,"limit":{"bytes":10000}}'
       responses:
         '201':
           description: The newly created access key

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -579,6 +579,7 @@ describe('ShadowsocksManagerService', () => {
             await serviceMethod({params: {id: accessKeyId, port: NEW_PORT}}, res, (error) => {
               expect(error.statusCode).toEqual(409);
               responseProcessed = true; // required for afterEach to pass.
+              server.close();
               done();
             });
           });
@@ -681,6 +682,7 @@ describe('ShadowsocksManagerService', () => {
       const server = new net.Server();
       server.listen(NEW_PORT, async () => {
         await service.setPortForNewAccessKeys({params: {port: NEW_PORT}}, res, next);
+        server.close();
       });
     });
 

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -456,6 +456,8 @@ export class ShadowsocksManagerService {
         return next(new restifyErrors.InvalidArgumentError({statusCode: 400}, error.message));
       } else if (error instanceof errors.PortUnavailable) {
         return next(new restifyErrors.ConflictError(error.message));
+      } else if (error instanceof restifyErrors.HttpError) {
+        return next(error);
       }
       return next(new restifyErrors.InternalServerError(error));
     }

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -439,17 +439,10 @@ export class ShadowsocksManagerService {
   ): Promise<void> {
     try {
       logging.debug(`setPortForNewAccessKeys request ${JSON.stringify(req.params)}`);
-      const port = req.params.port;
-      if (!port) {
+      const port = validateNumberParam(req.params.port, 'port');
+      if (port === undefined) {
         return next(
           new restifyErrors.MissingParameterError({statusCode: 400}, 'Parameter `port` is missing')
-        );
-      } else if (typeof port !== 'number') {
-        return next(
-          new restifyErrors.InvalidArgumentError(
-            {statusCode: 400},
-            `Expected a numeric port, instead got ${port} of type ${typeof port}`
-          )
         );
       }
       await this.accessKeys.setPortForNewAccessKeys(port);

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -189,7 +189,7 @@ function validateAccessKeyId(accessKeyId: unknown): string {
   return accessKeyId;
 }
 
-function validateDataLimit(limit: unknown): DataLimit {
+function validateDataLimit(limit: unknown): DataLimit | undefined {
   if (typeof limit === 'undefined') {
     return undefined;
   }
@@ -204,7 +204,7 @@ function validateDataLimit(limit: unknown): DataLimit {
   return limit as DataLimit;
 }
 
-function validateStringParam(param: unknown, paramName: string): string {
+function validateStringParam(param: unknown, paramName: string): string | undefined {
   if (typeof param === 'undefined') {
     return undefined;
   }
@@ -218,7 +218,7 @@ function validateStringParam(param: unknown, paramName: string): string {
   return param;
 }
 
-function validateNumberParam(param: unknown, paramName: string): number {
+function validateNumberParam(param: unknown, paramName: string): number | undefined {
   if (typeof param === 'undefined') {
     return undefined;
   }

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -129,7 +129,7 @@ describe('ServerAccessKeyRepository', () => {
     done();
   });
 
-  it('createNewAccessKey rejects ports in use', async (done) => {
+  it('createNewAccessKey rejects specified ports in use', async (done) => {
     const portProvider = new PortProvider();
     const port = await portProvider.reserveNewPort();
     const repo = new RepoBuilder().build();

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -99,6 +99,77 @@ describe('ServerAccessKeyRepository', () => {
     });
   });
 
+  it('createNewAccessKey throws on creating keys with invalid port', async (done) => {
+    const repo = new RepoBuilder().build();
+    await expectAsyncThrow(
+      repo.createNewAccessKey.bind(repo, {portNumber: -123}),
+      errors.InvalidPortNumber
+    );
+    done();
+  });
+
+  it('createNewAccessKey rejects invalid port numbers', async (done) => {
+    const repo = new RepoBuilder().build();
+    await expectAsyncThrow(
+      repo.createNewAccessKey.bind(repo, {portNumber: 0}),
+      errors.InvalidPortNumber
+    );
+    await expectAsyncThrow(
+      repo.createNewAccessKey.bind(repo, {portNumber: -1}),
+      errors.InvalidPortNumber
+    );
+    await expectAsyncThrow(
+      repo.createNewAccessKey.bind(repo, {portNumber: 100.1}),
+      errors.InvalidPortNumber
+    );
+    await expectAsyncThrow(
+      repo.createNewAccessKey.bind(repo, {portNumber: 65536}),
+      errors.InvalidPortNumber
+    );
+    done();
+  });
+
+  it('createNewAccessKey rejects ports in use', async (done) => {
+    const portProvider = new PortProvider();
+    const port = await portProvider.reserveNewPort();
+    const repo = new RepoBuilder().build();
+    const server = new net.Server();
+    server.listen(port, async () => {
+      try {
+        await repo.createNewAccessKey({portNumber: port});
+        fail(`createNewAccessKey should reject already used port ${port}.`);
+      } catch (error) {
+        expect(error instanceof errors.PortUnavailable);
+      }
+      server.close();
+      done();
+    });
+  });
+
+  it('createNewAccessKey creates keys with the correct default port', async (done) => {
+    const portProvider = new PortProvider();
+    const defaultPort = await portProvider.reserveNewPort();
+    const repo = new RepoBuilder().port(defaultPort).build();
+    repo.createNewAccessKey().then((accessKey) => {
+      expect(accessKey).toBeDefined();
+      expect(accessKey.proxyParams.portNumber).toEqual(defaultPort);
+      done();
+    });
+  });
+
+  it('createNewAccessKey creates keys with the port correctly', async (done) => {
+    const portProvider = new PortProvider();
+    const defaultPort = await portProvider.reserveNewPort();
+    const newPort = await portProvider.reserveNewPort();
+    const repo = new RepoBuilder().port(defaultPort).build();
+    repo.createNewAccessKey({portNumber: newPort}).then((accessKey) => {
+      expect(accessKey).toBeDefined();
+      expect(accessKey.proxyParams.portNumber).not.toEqual(defaultPort);
+      expect(accessKey.proxyParams.portNumber).toEqual(newPort);
+      done();
+    });
+  });
+
   it('Creates access keys under limit', async (done) => {
     const repo = new RepoBuilder().build();
     const accessKey = await repo.createNewAccessKey();
@@ -596,7 +667,7 @@ describe('ServerAccessKeyRepository', () => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo1 = new RepoBuilder().keyConfig(config).build();
     // Create 2 new access keys
-    await Promise.all([repo1.createNewAccessKey(), repo1.createNewAccessKey()]);
+    await repo1.createNewAccessKey().then(() => repo1.createNewAccessKey());
     // Modify properties
     repo1.renameAccessKey('1', 'name');
     repo1.setAccessKeyDataLimit('0', {bytes: 1});

--- a/src/shadowbox/server/server_access_key.spec.ts
+++ b/src/shadowbox/server/server_access_key.spec.ts
@@ -667,7 +667,7 @@ describe('ServerAccessKeyRepository', () => {
     const config = new InMemoryConfig<AccessKeyConfigJson>({accessKeys: [], nextId: 0});
     const repo1 = new RepoBuilder().keyConfig(config).build();
     // Create 2 new access keys
-    await repo1.createNewAccessKey().then(() => repo1.createNewAccessKey());
+    await Promise.all([repo1.createNewAccessKey(), repo1.createNewAccessKey()]);
     // Modify properties
     repo1.renameAccessKey('1', 'name');
     repo1.setAccessKeyDataLimit('0', {bytes: 1});

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -206,18 +206,22 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
     }
     const metricsId = uuidv4();
     const password = params?.password ?? generatePassword();
-    const encryptionMethod = params?.encryptionMethod || this.NEW_USER_ENCRYPTION_METHOD;
-    const portNumber = params?.portNumber ?? this.portForNewAccessKeys;
 
-    // Validate encryption method and port number.
-    if (!isValidCipher(encryptionMethod)) {
-      throw new errors.InvalidCipher(encryptionMethod);
+    const encryptionMethod = params?.encryptionMethod || this.NEW_USER_ENCRYPTION_METHOD;
+    if (encryptionMethod !== this.NEW_USER_ENCRYPTION_METHOD) {
+      if (!isValidCipher(encryptionMethod)) {
+        throw new errors.InvalidCipher(encryptionMethod);
+      }
     }
-    if (!isValidPort(portNumber)) {
-      throw new errors.InvalidPortNumber(portNumber);
-    }
-    if (portNumber !== this.portForNewAccessKeys && !(await this.isPortAvailable(portNumber))) {
-      throw new errors.PortUnavailable(portNumber);
+
+    const portNumber = params?.portNumber ?? this.portForNewAccessKeys;
+    if (portNumber !== this.portForNewAccessKeys) {
+      if (!isValidPort(portNumber)) {
+        throw new errors.InvalidPortNumber(portNumber);
+      }
+      if (!(await this.isPortAvailable(portNumber))) {
+        throw new errors.PortUnavailable(portNumber);
+      }
     }
 
     const proxyParams = {

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -106,6 +106,10 @@ function isValidCipher(cipher: string): boolean {
   return true;
 }
 
+function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port > 0 && port <= 65535;
+}
+
 // AccessKeyRepository that keeps its state in a config file and uses ShadowsocksServer
 // to start and stop per-access-key Shadowsocks instances.  Requires external validation
 // that portForNewAccessKeys is valid.
@@ -161,15 +165,19 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
     });
   }
 
+  private async isPortAvailable(port: number): Promise<boolean> {
+    return this.isExistingAccessKeyPort(port) || !(await isPortUsed(port));
+  }
+
   setHostname(hostname: string): void {
     this.proxyHostname = hostname;
   }
 
   async setPortForNewAccessKeys(port: number): Promise<void> {
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      throw new errors.InvalidPortNumber(port.toString());
+    if (!isValidPort(port)) {
+      throw new errors.InvalidPortNumber(port);
     }
-    if (!this.isExistingAccessKeyPort(port) && (await isPortUsed(port))) {
+    if (!(await this.isPortAvailable(port))) {
       throw new errors.PortUnavailable(port);
     }
     this.portForNewAccessKeys = port;
@@ -199,14 +207,22 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
     const metricsId = uuidv4();
     const password = params?.password ?? generatePassword();
     const encryptionMethod = params?.encryptionMethod || this.NEW_USER_ENCRYPTION_METHOD;
+    const portNumber = params?.portNumber ?? this.portForNewAccessKeys;
 
-    // Validate encryption method.
+    // Validate encryption method and port number.
     if (!isValidCipher(encryptionMethod)) {
       throw new errors.InvalidCipher(encryptionMethod);
     }
+    if (!isValidPort(portNumber)) {
+      throw new errors.InvalidPortNumber(portNumber);
+    }
+    if (!(await this.isPortAvailable(portNumber))) {
+      throw new errors.PortUnavailable(portNumber);
+    }
+
     const proxyParams = {
       hostname: this.proxyHostname,
-      portNumber: this.portForNewAccessKeys,
+      portNumber,
       encryptionMethod,
       password,
     };

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -216,7 +216,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
     if (!isValidPort(portNumber)) {
       throw new errors.InvalidPortNumber(portNumber);
     }
-    if (!(await this.isPortAvailable(portNumber))) {
+    if (portNumber !== this.portForNewAccessKeys && !(await this.isPortAvailable(portNumber))) {
       throw new errors.PortUnavailable(portNumber);
     }
 


### PR DESCRIPTION
This was documented as part of #1273 and #1473 but not actually implemented. See https://github.com/Jigsaw-Code/outline-server/pull/1273#discussion_r1478851542.