### PR TITLE
fix(manager/electron): adds hardened runtime and notarization options to the MacOS build

### DIFF
--- a/src/server_manager/electron_app/electron_builder.json
+++ b/src/server_manager/electron_app/electron_builder.json
@@ -4,25 +4,37 @@
   "linux": {
     "icon": "icons/png",
     "category": "Network",
-    "target": [{
-      "target": "AppImage",
-      "arch": ["x64"]
-    }]
+    "target": [
+      {
+        "target": "AppImage",
+        "arch": ["x64"]
+      }
+    ]
   },
   "win": {
     "icon": "icons/win/icon.ico",
     "sign": "src/server_manager/electron_app/windows/electron_builder_signing_plugin.cjs",
     "signingHashAlgorithms": ["sha256"],
-    "target": [{
-      "target": "nsis",
-      "arch": "ia32"
-    }]
+    "target": [
+      {
+        "target": "nsis",
+        "arch": "ia32"
+      }
+    ]
   },
   "mac": {
+    "hardenedRuntime": true,
+    "entitlements": "src/server_manager/electron_app/release/macos.entitlements",
+    "entitlementsInherit": "src/server_manager/electron_app/release/macos.entitlements",
     "icon": "icons/mac/icon.icns",
-    "target": [{
-      "target": "dmg",
-      "arch": "universal"
-    }]
+    "target": [
+      {
+        "target": "dmg",
+        "arch": "universal"
+      }
+    ],
+    "notarize": {
+      "teamId": "QT8Z3Q9V3A"
+    }
   }
 }

--- a/src/server_manager/electron_app/release/macos.entitlements
+++ b/src/server_manager/electron_app/release/macos.entitlements
@@ -4,6 +4,8 @@
   <dict>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>


### PR DESCRIPTION
context provided here: https://github.com/Jigsaw-Code/outline-server/pull/1508#issuecomment-1942000793