### PR TITLE
feat(sentry_webhook): update Salesforce record IDs for new contact form

### DIFF
--- a/src/sentry_webhook/post_sentry_event_to_salesforce.spec.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.spec.ts
@@ -57,7 +57,7 @@ describe('postSentryEventToSalesforce', () => {
         '&email=foo%40bar.com' +
         '&00N0b00000BqOA4=' +
         '&description=my%20message' +
-        '&type=Outline%20client'
+        '&00N5a00000DXxmr=I%20am%20using%20the%20Outline%20client%20application%20on%20my%20mobile%20or%20desktop%20device'
     );
     expect(mockRequest.end).toHaveBeenCalled();
   });
@@ -81,7 +81,7 @@ describe('postSentryEventToSalesforce', () => {
         '&email=foo%40bar.com' +
         '&00N3F000002Rqhq=' +
         '&description=my%20message' +
-        '&type=Outline%20client'
+        '&UNKNOWN=I%20am%20using%20the%20Outline%20client%20application%20on%20my%20mobile%20or%20desktop%20device'
     );
     expect(mockRequest.end).toHaveBeenCalled();
   });
@@ -92,8 +92,11 @@ describe('postSentryEventToSalesforce', () => {
       message: 'my message',
       tags: [
         ['category', 'no-server'],
+        ['subject', 'test subject'],
         ['os.name', 'Mac OS X'],
         ['sentry:release', 'test version'],
+        ['build.number', '0.0.0-debug'],
+        ['accessKeySource', 'test source'],
         ['unknown:tag', 'foo'],
       ],
     };
@@ -107,10 +110,13 @@ describe('postSentryEventToSalesforce', () => {
         '&email=foo%40bar.com' +
         '&00N0b00000BqOA4=' +
         '&description=my%20message' +
-        '&type=Outline%20client' +
+        '&00N5a00000DXxmr=I%20am%20using%20the%20Outline%20client%20application%20on%20my%20mobile%20or%20desktop%20device' +
         '&00N5a00000DXy19=I%20need%20an%20access%20key' +
+        '&subject=test%20subject' +
         '&00N5a00000DXxmo=MacOS' +
-        '&00N5a00000DXxmq=test%20version'
+        '&00N5a00000DXxmq=test%20version' +
+        '&00N5a00000DXy64=0.0.0-debug' +
+        '&00N5a00000DXxms=test%20source'
     );
     expect(mockRequest.end).toHaveBeenCalled();
   });

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.spec.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.spec.ts
@@ -91,7 +91,7 @@ describe('postSentryEventToSalesforce', () => {
       user: {email: 'foo@bar.com'},
       message: 'my message',
       tags: [
-        ['category', 'test category'],
+        ['category', 'no-server'],
         ['os.name', 'Mac OS X'],
         ['sentry:release', 'test version'],
         ['unknown:tag', 'foo'],
@@ -108,9 +108,9 @@ describe('postSentryEventToSalesforce', () => {
         '&00N0b00000BqOA4=' +
         '&description=my%20message' +
         '&type=Outline%20client' +
-        '&00N0b00000BqOA2=test%20category' +
-        '&00N0b00000BqOfW=macOs' +
-        '&00N0b00000BqOfR=test%20version'
+        '&00N5a00000DXy19=I%20need%20an%20access%20key' +
+        '&00N5a00000DXxmo=MacOS' +
+        '&00N5a00000DXxmq=test%20version'
     );
     expect(mockRequest.end).toHaveBeenCalled();
   });

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -21,7 +21,7 @@ interface SalesforceFormFields {
   recordType: string;
   email: string;
   description: string;
-  category: string;
+  issue: string;
   cloudProvider: string;
   sentryEventUrl: string;
   os: string;
@@ -43,7 +43,7 @@ const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
   recordType: 'recordType',
   email: 'email',
   description: 'description',
-  category: '00N3F000002Rqho',
+  issue: '00N3F000002Rqho',
   cloudProvider: '00N3F000002Rqhs',
   sentryEventUrl: '00N3F000002Rqhq',
   os: '00N3F000002cLcN',
@@ -55,11 +55,11 @@ const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   recordType: 'recordType',
   email: 'email',
   description: 'description',
-  category: '00N0b00000BqOA2',
-  cloudProvider: '00N0b00000BqOA7',
+  issue: '00N5a00000DXy19',
+  cloudProvider: '00N5a00000DXxmn',
   sentryEventUrl: '00N0b00000BqOA4',
-  os: '00N0b00000BqOfW',
-  version: '00N0b00000BqOfR',
+  os: '00N5a00000DXxmo',
+  version: '00N5a00000DXxmq',
   type: 'type',
 };
 const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
@@ -69,6 +69,15 @@ const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
 const SALESFORCE_FORM_VALUES_PROD: SalesforceFormValues = {
   orgId: '00D0b000000BrsN',
   recordType: '0120b0000006e8i',
+};
+
+const ISSUE_TYPE_TO_PICKLIST_VALUE: {[key: string]: string} = {
+  'cannot-add-server': 'I am having trouble adding a server using my access key',
+  connection: 'I am having trouble connecting to my Outline VPN server',
+  general: 'General feedback & suggestions',
+  managing: 'I need assistance managing my Outline VPN server or helping others connect to it',
+  'no-server': 'I need an access key',
+  performance: 'My internet access is slow while connected to my Outline VPN server',
 };
 
 // Returns whether a Sentry event should be sent to Salesforce by checking that it contains an
@@ -141,7 +150,7 @@ function getSalesforceFormData(
   form.push(encodeFormData(formFields.type, isClient ? 'Outline client' : 'Outline manager'));
   if (event.tags) {
     const tags = new Map<string, string>(event.tags);
-    form.push(encodeFormData(formFields.category, tags.get('category')));
+    form.push(encodeFormData(formFields.issue, toIssuePicklistValue(tags.get('category'))));
     form.push(encodeFormData(formFields.os, toOSPicklistValue(tags.get('os.name'))));
     form.push(encodeFormData(formFields.version, tags.get('sentry:release')));
     if (!isClient) {
@@ -169,9 +178,17 @@ function toOSPicklistValue(value: string | undefined): string | undefined {
     return 'Windows';
   }
   if (normalizedValue.includes('mac')) {
-    return 'macOs';
+    return 'MacOS';
   }
   return 'Linux';
+}
+
+function toIssuePicklistValue(value: string | undefined): string | undefined {
+  if (!value) {
+    console.warn('No issue type found');
+    return undefined;
+  }
+  return ISSUE_TYPE_TO_PICKLIST_VALUE[value];
 }
 
 function encodeFormData(field: string, value?: string) {

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -92,6 +92,13 @@ const ISSUE_TYPE_TO_PICKLIST_VALUE: {[key: string]: string} = {
   performance: 'My internet access is slow while connected to my Outline VPN server',
 };
 
+const CLOUD_PROVIDER_TO_PICKLIST_VALUE: {[key: string]: string} = {
+  aws: 'Amazon Web Services',
+  digitalocean: 'DigitalOcean',
+  gcloud: 'Google Cloud',
+  other: 'Other',
+};
+
 // Returns whether a Sentry event should be sent to Salesforce by checking that it contains an
 // email address.
 export function shouldPostEventToSalesforce(event: SentryEvent): boolean {
@@ -181,7 +188,12 @@ function getSalesforceFormData(
     if (isClient) {
       form.push(encodeFormData(formFields.accessKeySource, tags.get('accessKeySource')));
     } else {
-      form.push(encodeFormData(formFields.cloudProvider, tags.get('cloudProvider')));
+      form.push(
+        encodeFormData(
+          formFields.cloudProvider,
+          toCloudProviderPicklistValue(tags.get('cloudProvider'))
+        )
+      );
     }
   }
   return form.join('&');
@@ -217,6 +229,15 @@ function toIssuePicklistValue(value: string | undefined): string | undefined {
     return undefined;
   }
   return ISSUE_TYPE_TO_PICKLIST_VALUE[value];
+}
+
+// Returns a picklist value that is allowed by SalesForce for the cloud provider record.
+function toCloudProviderPicklistValue(value: string | undefined): string | undefined {
+  if (!value) {
+    console.warn('No cloud provider found');
+    return undefined;
+  }
+  return CLOUD_PROVIDER_TO_PICKLIST_VALUE[value];
 }
 
 function encodeFormData(field: string, value?: string) {

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -29,7 +29,7 @@ interface SalesforceFormFields {
   os: string;
   version: string;
   build: string;
-  type: string;
+  role: string;
   isUpdatedForm: string;
 }
 
@@ -55,7 +55,7 @@ const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
   os: '00N3F000002cLcN',
   version: '00N3F000002cLcI',
   build: '00N75000000wmdC',
-  type: 'type',
+  role: 'UNKNOWN',
   isUpdatedForm: '00N75000000wmd7',
 };
 const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
@@ -71,7 +71,7 @@ const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   os: '00N5a00000DXxmo',
   version: '00N5a00000DXxmq',
   build: '00N5a00000DXy64',
-  type: 'type',
+  role: '00N5a00000DXxmr',
   isUpdatedForm: '00N5a00000DXy5a',
 };
 const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
@@ -159,7 +159,14 @@ function getSalesforceFormData(
   form.push(encodeFormData(formFields.email, email));
   form.push(encodeFormData(formFields.sentryEventUrl, getSentryEventUrl(project, event.event_id)));
   form.push(encodeFormData(formFields.description, event.message));
-  form.push(encodeFormData(formFields.type, isClient ? 'Outline client' : 'Outline manager'));
+  form.push(
+    encodeFormData(
+      formFields.role,
+      isClient
+        ? 'I am using the Outline client application on my mobile or desktop device'
+        : 'I am an Outline server manager'
+    )
+  );
   if (event.tags) {
     const tags = new Map<string, string>(event.tags);
     form.push(encodeFormData(formFields.issue, toIssuePicklistValue(tags.get('category'))));
@@ -203,6 +210,7 @@ function toOSPicklistValue(value: string | undefined): string | undefined {
   return 'Linux';
 }
 
+// Returns a picklist value that is allowed by SalesForce for the issue record.
 function toIssuePicklistValue(value: string | undefined): string | undefined {
   if (!value) {
     console.warn('No issue type found');

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -20,6 +20,7 @@ interface SalesforceFormFields {
   orgId: string;
   recordType: string;
   email: string;
+  subject: string;
   description: string;
   issue: string;
   accessKeySource: string;
@@ -29,6 +30,7 @@ interface SalesforceFormFields {
   version: string;
   build: string;
   type: string;
+  isUpdatedForm: string;
 }
 
 // Defines the Salesforce form values.
@@ -44,6 +46,7 @@ const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
   orgId: 'orgid',
   recordType: 'recordType',
   email: 'email',
+  subject: 'subject',
   description: 'description',
   issue: '00N3F000002Rqho',
   accessKeySource: '00N75000000wYiY',
@@ -53,11 +56,13 @@ const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
   version: '00N3F000002cLcI',
   build: '00N75000000wmdC',
   type: 'type',
+  isUpdatedForm: '00N75000000wmd7',
 };
 const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   orgId: 'orgid',
   recordType: 'recordType',
   email: 'email',
+  subject: 'subject',
   description: 'description',
   issue: '00N5a00000DXy19',
   accessKeySource: '00N5a00000DXxms',
@@ -67,6 +72,7 @@ const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   version: '00N5a00000DXxmq',
   build: '00N5a00000DXy64',
   type: 'type',
+  isUpdatedForm: '00N5a00000DXy5a',
 };
 const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
   orgId: '00D750000004dFg',
@@ -157,9 +163,14 @@ function getSalesforceFormData(
   if (event.tags) {
     const tags = new Map<string, string>(event.tags);
     form.push(encodeFormData(formFields.issue, toIssuePicklistValue(tags.get('category'))));
+    form.push(encodeFormData(formFields.subject, tags.get('subject')));
     form.push(encodeFormData(formFields.os, toOSPicklistValue(tags.get('os.name'))));
     form.push(encodeFormData(formFields.version, tags.get('sentry:release')));
     form.push(encodeFormData(formFields.build, tags.get('build.number')));
+    const formVersion = Number(tags.get('formVersion') ?? 1);
+    if (formVersion === 2) {
+      form.push(encodeFormData(formFields.isUpdatedForm, 'true'));
+    }
     if (isClient) {
       form.push(encodeFormData(formFields.accessKeySource, tags.get('accessKeySource')));
     } else {

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -22,10 +22,12 @@ interface SalesforceFormFields {
   email: string;
   description: string;
   issue: string;
+  accessKeySource: string;
   cloudProvider: string;
   sentryEventUrl: string;
   os: string;
   version: string;
+  build: string;
   type: string;
 }
 
@@ -44,10 +46,12 @@ const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
   email: 'email',
   description: 'description',
   issue: '00N3F000002Rqho',
+  accessKeySource: '00N75000000wYiY',
   cloudProvider: '00N3F000002Rqhs',
   sentryEventUrl: '00N3F000002Rqhq',
   os: '00N3F000002cLcN',
   version: '00N3F000002cLcI',
+  build: '00N75000000wmdC',
   type: 'type',
 };
 const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
@@ -56,10 +60,12 @@ const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   email: 'email',
   description: 'description',
   issue: '00N5a00000DXy19',
+  accessKeySource: '00N5a00000DXxms',
   cloudProvider: '00N5a00000DXxmn',
   sentryEventUrl: '00N0b00000BqOA4',
   os: '00N5a00000DXxmo',
   version: '00N5a00000DXxmq',
+  build: '00N5a00000DXy64',
   type: 'type',
 };
 const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
@@ -153,7 +159,10 @@ function getSalesforceFormData(
     form.push(encodeFormData(formFields.issue, toIssuePicklistValue(tags.get('category'))));
     form.push(encodeFormData(formFields.os, toOSPicklistValue(tags.get('os.name'))));
     form.push(encodeFormData(formFields.version, tags.get('sentry:release')));
-    if (!isClient) {
+    form.push(encodeFormData(formFields.build, tags.get('build.number')));
+    if (isClient) {
+      form.push(encodeFormData(formFields.accessKeySource, tags.get('accessKeySource')));
+    } else {
       form.push(encodeFormData(formFields.cloudProvider, tags.get('cloudProvider')));
     }
   }


### PR DESCRIPTION
Tested successfully with the dev webhook with both the old and new in-app contact form. The resulting cases look identical to the new webform created ones as they now use the same fields.

There is one outstanding UAT record ID, which I've requested and will update before merging.