### PR TITLE
chore: update api.yml

### DIFF
--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -207,7 +207,7 @@ paths:
         - name: id
           in: path
           required: true
-          description: The id to get the access key
+          description: The id for which to create an access key
           schema:
             type: string
       requestBody:

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -203,6 +203,13 @@ paths:
       description: Creates a new access key with a specific identifer
       tags:
         - Access Key
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id to get the access key
+          schema:
+            type: string
       requestBody:
         required: false
         content:


### PR DESCRIPTION
Semantic error at paths./access-keys/{id}
Declared path parameter "id" needs to be defined within every operation in the path (missing in "put")

fix error from swagger editor and another open api viewers