### PR TITLE
docs(metrics_server): add note about promoting the prod version

### DIFF
--- a/src/metrics_server/README.md
+++ b/src/metrics_server/README.md
@@ -74,6 +74,7 @@ task metrics_server:start
   ```sh
   task metrics_server:deploy:prod
   ```
+  Once deployed, you will need to manually migrate all traffic to the new version via the Google Cloud console.
 
 ## Test
 


### PR DESCRIPTION
When we [moved from Cloud Functions to GAE](https://github.com/Jigsaw-Code/outline-server/pull/577/files#diff-99b64d57d0ef44ed1c2d821cd7dc7129d3ccf7a727113973f045739f238c910a) the deployment was configured with [`--no-promote`](http://cloud/sdk/gcloud/reference/app/deploy#--promote), but the instructions were never updated.