### PR TITLE
refactor(server): remove unneeded access key metrics ID

### DIFF
--- a/src/shadowbox/model/access_key.ts
+++ b/src/shadowbox/model/access_key.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 export type AccessKeyId = string;
-export type AccessKeyMetricsId = string;
 
 // Parameters needed to access a Shadowsocks proxy.
 export interface ProxyParams {
@@ -38,8 +37,6 @@ export interface AccessKey {
   readonly id: AccessKeyId;
   // Admin-controlled, editable name for this access key.
   readonly name: string;
-  // Used in metrics reporting to decouple from the real id. Can change.
-  readonly metricsId: AccessKeyMetricsId;
   // Parameters to access the proxy
   readonly proxyParams: ProxyParams;
   // Whether the access key has exceeded the data transfer limit.
@@ -78,8 +75,6 @@ export interface AccessKeyRepository {
   setHostname(hostname: string): void;
   // Apply the specified update to the specified access key. Throws on failure.
   renameAccessKey(id: AccessKeyId, name: string): void;
-  // Gets the metrics id for a given Access Key.
-  getMetricsId(id: AccessKeyId): AccessKeyMetricsId | undefined;
   // Sets a data transfer limit for all access keys.
   setDefaultDataLimit(limit: DataLimit): void;
   // Removes the access key data transfer limit.

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -216,13 +216,6 @@ async function main() {
   );
 
   const metricsReader = new PrometheusUsageMetrics(prometheusClient);
-  const toMetricsId = (id: AccessKeyId) => {
-    try {
-      return accessKeyRepository.getMetricsId(id);
-    } catch (e) {
-      logging.warn(`Failed to get metrics id for access key ${id}: ${e}`);
-    }
-  };
   const managerMetrics = new PrometheusManagerMetrics(prometheusClient);
   const metricsCollector = new RestMetricsCollectorClient(metricsCollectorUrl);
   const metricsPublisher: SharedMetricsPublisher = new OutlineSharedMetricsPublisher(
@@ -230,7 +223,6 @@ async function main() {
     serverConfig,
     accessKeyConfig,
     metricsReader,
-    toMetricsId,
     metricsCollector
   );
   const managerService = new ShadowsocksManagerService(

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -26,7 +26,6 @@ import * as json_config from '../infrastructure/json_config';
 import * as logging from '../infrastructure/logging';
 import {PrometheusClient, startPrometheus} from '../infrastructure/prometheus_scraper';
 import {RolloutTracker} from '../infrastructure/rollout';
-import {AccessKeyId} from '../model/access_key';
 import * as version from './version';
 
 import {PrometheusManagerMetrics} from './manager_metrics';

--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as randomstring from 'randomstring';
-import * as uuidv4 from 'uuid/v4';
 
 import {Clock} from '../infrastructure/clock';
 import {isPortUsed} from '../infrastructure/get_port';

--- a/src/shadowbox/server/shared_metrics.spec.ts
+++ b/src/shadowbox/server/shared_metrics.spec.ts
@@ -58,7 +58,6 @@ describe('OutlineSharedMetricsPublisher', () => {
         serverConfig,
         null,
         null,
-        null,
         null
       );
       expect(publisher.isSharingEnabled()).toBeTruthy();
@@ -70,14 +69,12 @@ describe('OutlineSharedMetricsPublisher', () => {
       let startTime = clock.nowMs;
       const serverConfig = new InMemoryConfig<ServerConfigJson>({serverId: 'server-id'});
       const usageMetrics = new ManualUsageMetrics();
-      const toMetricsId = (id: AccessKeyId) => `M(${id})`;
       const metricsCollector = new FakeMetricsCollector();
       const publisher = new OutlineSharedMetricsPublisher(
         clock,
         serverConfig,
         null,
         usageMetrics,
-        toMetricsId,
         metricsCollector
       );
 
@@ -130,14 +127,12 @@ describe('OutlineSharedMetricsPublisher', () => {
       const startTime = clock.nowMs;
       const serverConfig = new InMemoryConfig<ServerConfigJson>({serverId: 'server-id'});
       const usageMetrics = new ManualUsageMetrics();
-      const toMetricsId = (id: AccessKeyId) => `M(${id})`;
       const metricsCollector = new FakeMetricsCollector();
       const publisher = new OutlineSharedMetricsPublisher(
         clock,
         serverConfig,
         null,
         usageMetrics,
-        toMetricsId,
         metricsCollector
       );
 
@@ -177,7 +172,6 @@ describe('OutlineSharedMetricsPublisher', () => {
     const makeKeyJson = (dataLimit?: DataLimit) => {
       return {
         id: (keyId++).toString(),
-        metricsId: 'id',
         name: 'name',
         password: 'pass',
         port: 12345,
@@ -193,7 +187,6 @@ describe('OutlineSharedMetricsPublisher', () => {
       serverConfig,
       keyConfig,
       new ManualUsageMetrics(),
-      (_id: AccessKeyId) => '',
       metricsCollector
     );
 

--- a/src/shadowbox/server/shared_metrics.spec.ts
+++ b/src/shadowbox/server/shared_metrics.spec.ts
@@ -14,7 +14,7 @@
 
 import {ManualClock} from '../infrastructure/clock';
 import {InMemoryConfig} from '../infrastructure/json_config';
-import {AccessKeyId, DataLimit} from '../model/access_key';
+import {DataLimit} from '../model/access_key';
 import * as version from './version';
 import {AccessKeyConfigJson} from './server_access_key';
 

--- a/src/shadowbox/server/shared_metrics.spec.ts
+++ b/src/shadowbox/server/shared_metrics.spec.ts
@@ -38,7 +38,6 @@ describe('OutlineSharedMetricsPublisher', () => {
         serverConfig,
         null,
         null,
-        null,
         null
       );
       expect(publisher.isSharingEnabled()).toBeFalsy();
@@ -235,7 +234,6 @@ describe('OutlineSharedMetricsPublisher', () => {
       serverConfig,
       new InMemoryConfig<AccessKeyConfigJson>({}),
       new ManualUsageMetrics(),
-      (_id: AccessKeyId) => '',
       metricsCollector
     );
 

--- a/src/shadowbox/server/shared_metrics.ts
+++ b/src/shadowbox/server/shared_metrics.ts
@@ -17,7 +17,6 @@ import * as follow_redirects from '../infrastructure/follow_redirects';
 import {JsonConfig} from '../infrastructure/json_config';
 import * as logging from '../infrastructure/logging';
 import {PrometheusClient} from '../infrastructure/prometheus_scraper';
-import {AccessKeyId, AccessKeyMetricsId} from '../model/access_key';
 import * as version from './version';
 import {AccessKeyConfigJson} from './server_access_key';
 
@@ -148,14 +147,12 @@ export class OutlineSharedMetricsPublisher implements SharedMetricsPublisher {
   // serverConfig: where the enabled/disable setting is persisted
   // keyConfig: where access keys are persisted
   // usageMetrics: where we get the metrics from
-  // toMetricsId: maps Access key ids to metric ids
   // metricsUrl: where to post the metrics
   constructor(
     private clock: Clock,
     private serverConfig: JsonConfig<ServerConfigJson>,
     private keyConfig: JsonConfig<AccessKeyConfigJson>,
     usageMetrics: UsageMetrics,
-    private toMetricsId: (accessKeyId: AccessKeyId) => AccessKeyMetricsId,
     private metricsCollector: MetricsCollectorClient
   ) {
     // Start timer


### PR DESCRIPTION
We no longer use the access key metrics ID, as we stopped sending it in https://github.com/Jigsaw-Code/outline-server/pull/1529.