### PR TITLE
Fix isOverDataLimit logic to stop allowing 0 traffic byte

### DIFF
--- a/src/shadowbox/server/server_access_key.ts
+++ b/src/shadowbox/server/server_access_key.ts
@@ -313,7 +313,7 @@ export class ServerAccessKeyRepository implements AccessKeyRepository {
       if (limitBytes === undefined) {
         limitBytes = Number.POSITIVE_INFINITY;
       }
-      accessKey.isOverDataLimit = usageBytes > limitBytes;
+      accessKey.isOverDataLimit = usageBytes >= limitBytes;
       limitStatusChanged = accessKey.isOverDataLimit !== wasOverDataLimit || limitStatusChanged;
     }
     if (limitStatusChanged) {


### PR DESCRIPTION
[issue #1515 ](https://github.com/Jigsaw-Code/outline-server/issues/1515)

This if statement is just wrong and doesn't block access when traffic limit is set to 0 byte. This one character fixes it.

Now if we create a new access key, set the limit to 0 before first usage, the client no longer will be able to connect.