### PR TITLE
test(server): fix integration test by downgrading to Alpine 3.18

### DIFF
--- a/.github/workflows/build_and_test_debug.yml
+++ b/.github/workflows/build_and_test_debug.yml
@@ -14,10 +14,9 @@ on:
       - master
 
 jobs:
-
-  shadowbox:
-    name: Shadowbox
-    runs-on: ubuntu-24.04
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -31,7 +30,90 @@ jobs:
       - name: Install NPM Dependencies
         run: npm ci
 
+      - name: Lint
+        run: ./task lint
+
+  shadowbox:
+    name: Shadowbox
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Shadowbox Debug Build
+        run: ./task shadowbox:build
+
+      - name: Shadowbox Unit Test
+        run: ./task shadowbox:test
 
       - name: Shadowbox Integration Test
-        run: docker version && ./task shadowbox:integration_test
+        run: ./task shadowbox:integration_test
 
+  manual-install-script:
+    name: Manual Install Script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      
+      - name: Install Outline Server
+        run: ./src/server_manager/install_scripts/install_server.sh --hostname localhost
+      
+      - name: Test API
+        run: 'curl --silent --fail --insecure $(grep "apiUrl" /opt/outline/access.txt | cut -d: -f 2-)/server'
+
+  metrics-server:
+    name: Metrics Server
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Metrics Server Debug Build
+        run: ./task metrics_server:build
+
+      - name: Metrics Server Test
+        run: ./task metrics_server:test
+
+  sentry-webhook:
+    name: Sentry Webhook
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Sentry Webhook Debug Build
+        run: ./task sentry_webhook:build
+
+      - name: Sentry Webhook Test
+        run: ./task sentry_webhook:test

--- a/.github/workflows/build_and_test_debug.yml
+++ b/.github/workflows/build_and_test_debug.yml
@@ -14,29 +14,10 @@ on:
       - master
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: npm
-
-      - name: Install NPM Dependencies
-        run: npm ci
-
-      - name: Lint
-        run: ./task lint
 
   shadowbox:
     name: Shadowbox
-    runs-on: ubuntu-latest
-    needs: lint
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -50,70 +31,7 @@ jobs:
       - name: Install NPM Dependencies
         run: npm ci
 
-      - name: Shadowbox Debug Build
-        run: ./task shadowbox:build
-
-      - name: Shadowbox Unit Test
-        run: ./task shadowbox:test
 
       - name: Shadowbox Integration Test
-        run: ./task shadowbox:integration_test
+        run: docker version && ./task shadowbox:integration_test
 
-  manual-install-script:
-    name: Manual Install Script
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      
-      - name: Install Outline Server
-        run: ./src/server_manager/install_scripts/install_server.sh --hostname localhost
-      
-      - name: Test API
-        run: 'curl --silent --fail --insecure $(grep "apiUrl" /opt/outline/access.txt | cut -d: -f 2-)/server'
-
-  metrics-server:
-    name: Metrics Server
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: npm
-
-      - name: Install NPM Dependencies
-        run: npm ci
-
-      - name: Metrics Server Debug Build
-        run: ./task metrics_server:build
-
-      - name: Metrics Server Test
-        run: ./task metrics_server:test
-
-  sentry-webhook:
-    name: Sentry Webhook
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: npm
-
-      - name: Install NPM Dependencies
-        run: npm ci
-
-      - name: Sentry Webhook Debug Build
-        run: ./task sentry_webhook:build
-
-      - name: Sentry Webhook Test
-        run: ./task sentry_webhook:test

--- a/src/shadowbox/integration_test/client/Dockerfile
+++ b/src/shadowbox/integration_test/client/Dockerfile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Alpine 3.19 curl is using the c-ares resolver instead of the system resolver,
+# which caused DNS issues. Upgrade once the Alpine image includes the fix. See
+# https://github.com/Jigsaw-Code/outline-server/pull/1566.
 FROM docker.io/golang:1-alpine3.18
 
 # curl for fetching pages using the local proxy

--- a/src/shadowbox/integration_test/client/Dockerfile
+++ b/src/shadowbox/integration_test/client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1-alpine
+FROM docker.io/golang:1-alpine3.18
 
 # curl for fetching pages using the local proxy
 RUN apk add --no-cache curl git


### PR DESCRIPTION
Alpine 3.19 curl is using the c-ares resolver instead of the system resolver. This is causing [DNS issues in the integration test](https://github.com/Jigsaw-Code/outline-server/actions/runs/9993257424/job/27620375345):

```
curl: (6) Could not resolve host: shadowbox
```

See https://github.com/curl/curl/issues/12558 and https://github.com/c-ares/c-ares/issues/683 for details.

