### PR TITLE
feat: roll out ASN metrics to all servers

### DIFF
--- a/src/shadowbox/model/shadowsocks_server.ts
+++ b/src/shadowbox/model/shadowsocks_server.ts
@@ -21,9 +21,6 @@ export interface ShadowsocksAccessKey {
 }
 
 export interface ShadowsocksServer {
-  // Annotates the Prometheus data metrics with ASN.
-  enableAsnMetrics(enable: boolean);
-
   // Updates the server to accept only the given access keys.
   update(keys: ShadowsocksAccessKey[]): Promise<void>;
 }

--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -457,29 +457,6 @@ paths:
           description: Setting successful
         '400':
           description: Invalid request
-  /experimental/asn-metrics/enabled:
-    put:
-      description: Annotates Prometheus data metrics with autonomous system numbers (ASN).
-      tags:
-        - Server
-        - Experimental
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                asnMetricsEnabled:
-                  type: boolean
-            examples:
-              '0':
-                value: '{"asnMetricsEnabled": true}'
-      responses:
-        '204':
-          description: Setting successful
-        '400':
-          description: Invalid request
   /experimental/access-key-data-limit:
     put:
       deprecated: true

--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -160,9 +160,6 @@ async function main() {
   }
   if (fs.existsSync(MMDB_LOCATION_ASN)) {
     shadowsocksServer.configureAsnMetrics(MMDB_LOCATION_ASN);
-    if (serverConfig.data().experimental?.asnMetricsEnabled) {
-      shadowsocksServer.enableAsnMetrics(true);
-    }
   }
 
   const isReplayProtectionEnabled = createRolloutTracker(serverConfig).isRolloutEnabled(

--- a/src/shadowbox/server/manager_service.spec.ts
+++ b/src/shadowbox/server/manager_service.spec.ts
@@ -1077,47 +1077,6 @@ describe('ShadowsocksManagerService', () => {
       );
     });
   });
-  describe('enableAsnMetrics', () => {
-    it('Enables ASN metrics on the Shadowsocks Server', (done) => {
-      const serverConfig = new InMemoryConfig({} as ServerConfigJson);
-      const shadowsocksServer = new FakeShadowsocksServer();
-      spyOn(shadowsocksServer, 'enableAsnMetrics');
-      const service = new ShadowsocksManagerServiceBuilder()
-        .serverConfig(serverConfig)
-        .shadowsocksServer(shadowsocksServer)
-        .build();
-      service.enableAsnMetrics(
-        {params: {asnMetricsEnabled: true}},
-        {
-          send: (httpCode, _) => {
-            expect(httpCode).toEqual(204);
-            expect(shadowsocksServer.enableAsnMetrics).toHaveBeenCalledWith(true);
-            responseProcessed = true;
-          },
-        },
-        done
-      );
-    });
-    it('Sets value in the config', (done) => {
-      const serverConfig = new InMemoryConfig({} as ServerConfigJson);
-      const shadowsocksServer = new FakeShadowsocksServer();
-      const service = new ShadowsocksManagerServiceBuilder()
-        .serverConfig(serverConfig)
-        .shadowsocksServer(shadowsocksServer)
-        .build();
-      service.enableAsnMetrics(
-        {params: {asnMetricsEnabled: true}},
-        {
-          send: (httpCode, _) => {
-            expect(httpCode).toEqual(204);
-            expect(serverConfig.mostRecentWrite.experimental.asnMetricsEnabled).toBeTrue();
-            responseProcessed = true;
-          },
-        },
-        done
-      );
-    });
-  });
 });
 
 describe('bindService', () => {

--- a/src/shadowbox/server/manager_service.ts
+++ b/src/shadowbox/server/manager_service.ts
@@ -161,11 +161,6 @@ export function bindService(
 
   // Experimental APIs.
 
-  apiServer.put(
-    `${apiPrefix}/experimental/asn-metrics/enabled`,
-    service.enableAsnMetrics.bind(service)
-  );
-
   // Redirect former experimental APIs
   apiServer.put(
     `${apiPrefix}/experimental/access-key-data-limit`,
@@ -637,38 +632,5 @@ export class ShadowsocksManagerService {
     }
     res.send(HttpSuccess.NO_CONTENT);
     next();
-  }
-
-  enableAsnMetrics(req: RequestType, res: ResponseType, next: restify.Next): void {
-    try {
-      logging.debug(`enableAsnMetrics request ${JSON.stringify(req.params)}`);
-      const asnMetricsEnabled = req.params.asnMetricsEnabled;
-      if (asnMetricsEnabled === undefined || asnMetricsEnabled === null) {
-        return next(
-          new restifyErrors.MissingParameterError(
-            {statusCode: 400},
-            'Parameter `asnMetricsEnabled` is missing'
-          )
-        );
-      } else if (typeof asnMetricsEnabled !== 'boolean') {
-        return next(
-          new restifyErrors.InvalidArgumentError(
-            {statusCode: 400},
-            'Parameter `asnMetricsEnabled` must be a boolean'
-          )
-        );
-      }
-      this.shadowsocksServer.enableAsnMetrics(asnMetricsEnabled);
-      if (this.serverConfig.data().experimental === undefined) {
-        this.serverConfig.data().experimental = {};
-      }
-      this.serverConfig.data().experimental.asnMetricsEnabled = asnMetricsEnabled;
-      this.serverConfig.write();
-      res.send(HttpSuccess.NO_CONTENT);
-      return next();
-    } catch (error) {
-      logging.error(error);
-      return next(new restifyErrors.InternalServerError());
-    }
   }
 }

--- a/src/shadowbox/server/mocks/mocks.ts
+++ b/src/shadowbox/server/mocks/mocks.ts
@@ -38,8 +38,6 @@ export class InMemoryFile implements TextFile {
 export class FakeShadowsocksServer implements ShadowsocksServer {
   private accessKeys: ShadowsocksAccessKey[] = [];
 
-  enableAsnMetrics(_: boolean) {}
-
   update(keys: ShadowsocksAccessKey[]) {
     this.accessKeys = keys;
     return Promise.resolve();

--- a/src/shadowbox/server/outline_shadowsocks_server.ts
+++ b/src/shadowbox/server/outline_shadowsocks_server.ts
@@ -60,18 +60,6 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     return this;
   }
 
-  /** Annotates the Prometheus data metrics with ASN. */
-  enableAsnMetrics(enable: boolean) {
-    if (enable && !this.ipAsnFilename) {
-      throw new Error('Cannot enable ASN metrics: no ASN database filename set');
-    }
-    const valueChanged = this.isAsnMetricsEnabled != enable;
-    this.isAsnMetricsEnabled = enable;
-    if (valueChanged && this.ssProcess) {
-      this.ssProcess.kill('SIGTERM');
-    }
-  }
-
   enableReplayProtection(): OutlineShadowsocksServer {
     this.isReplayProtectionEnabled = true;
     return this;
@@ -121,7 +109,7 @@ export class OutlineShadowsocksServer implements ShadowsocksServer {
     if (this.ipCountryFilename) {
       commandArguments.push('-ip_country_db', this.ipCountryFilename);
     }
-    if (this.isAsnMetricsEnabled && this.ipAsnFilename) {
+    if (this.ipAsnFilename) {
       commandArguments.push('-ip_asn_db', this.ipAsnFilename);
     }
     if (this.verbose) {

--- a/src/shadowbox/server/server_config.ts
+++ b/src/shadowbox/server/server_config.ts
@@ -41,7 +41,7 @@ export interface ServerConfigJson {
   // Experimental configuration options that are expected to be short-lived.
   experimental?: {
     // Whether ASN metric annotation for Prometheus is enabled.
-    asnMetricsEnabled?: boolean;
+    asnMetricsEnabled?: boolean;  // DEPRECATED
   };
 }
 


### PR DESCRIPTION
I left a reference behind in `server_config.ts` so we can identify existing values in server configs. Everything else has been removed.