### PR TITLE
feat(sentry_webhook): handle `outreachConsent` Sentry tag

### DIFF
--- a/src/sentry_webhook/README.md
+++ b/src/sentry_webhook/README.md
@@ -1,6 +1,6 @@
 # Outline Sentry Webhook
 
-The Outline Sentry webhook is a [Google Cloud Function](https://cloud.google.com/functions/) that receives a Sentry event and posts it to Salesforce.
+The Outline Sentry webhook is a [Google Cloud Run functions](https://cloud.google.com/functions/) that receives a Sentry event and posts it to Salesforce.
 
 ## Requirements
 

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.spec.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.spec.ts
@@ -98,6 +98,7 @@ describe('postSentryEventToSalesforce', () => {
         ['build.number', '0.0.0-debug'],
         ['accessKeySource', 'test source'],
         ['unknown:tag', 'foo'],
+        ['outreachConsent', 'True'],
       ],
     };
 
@@ -116,8 +117,22 @@ describe('postSentryEventToSalesforce', () => {
         '&00N5a00000DXxmo=MacOS' +
         '&00N5a00000DXxmq=test%20version' +
         '&00N5a00000DXy64=0.0.0-debug' +
+        '&00N5a00000DbyEw=true' +
         '&00N5a00000DXxms=test%20source'
     );
+    expect(mockRequest.end).toHaveBeenCalled();
+  });
+
+  it('drops "False" values for `outreachConsent`', () => {
+    const event: SentryEvent = {
+      user: {email: 'foo@bar.com'},
+      message: 'my message',
+      tags: [['outreachConsent', 'False']],
+    };
+
+    postSentryEventToSalesforce(event, 'outline-clients');
+
+    expect(mockRequest.write.calls.argsFor(0)[0]).not.toContain('00N5a00000DbyEw');
     expect(mockRequest.end).toHaveBeenCalled();
   });
 });

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -31,6 +31,7 @@ interface SalesforceFormFields {
   build: string;
   role: string;
   isUpdatedForm: string;
+  outreachConsent: string;
 }
 
 // Defines the Salesforce form values.
@@ -57,6 +58,7 @@ const SALESFORCE_FORM_FIELDS_DEV: SalesforceFormFields = {
   build: '00N75000000wmdC',
   role: '00N75000000wYiX',
   isUpdatedForm: '00N75000000wmd7',
+  outreachConsent: '',
 };
 const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   orgId: 'orgid',
@@ -73,6 +75,7 @@ const SALESFORCE_FORM_FIELDS_PROD: SalesforceFormFields = {
   build: '00N5a00000DXy64',
   role: '00N5a00000DXxmr',
   isUpdatedForm: '00N5a00000DXy5a',
+  outreachConsent: '00N5a00000DbyEw',
 };
 const SALESFORCE_FORM_VALUES_DEV: SalesforceFormValues = {
   orgId: '00D750000004dFg',
@@ -181,6 +184,10 @@ function getSalesforceFormData(
     form.push(encodeFormData(formFields.os, toOSPicklistValue(tags.get('os.name'))));
     form.push(encodeFormData(formFields.version, tags.get('sentry:release')));
     form.push(encodeFormData(formFields.build, tags.get('build.number')));
+    const outreachConsent = (tags.get('outreachConsent') ?? 'False').toLowerCase();
+    if (outreachConsent == 'true') {
+      form.push(encodeFormData(formFields.outreachConsent, outreachConsent));
+    }
     const formVersion = Number(tags.get('formVersion') ?? 1);
     if (formVersion === 2) {
       form.push(encodeFormData(formFields.isUpdatedForm, 'true'));

--- a/src/sentry_webhook/post_sentry_event_to_salesforce.ts
+++ b/src/sentry_webhook/post_sentry_event_to_salesforce.ts
@@ -185,7 +185,7 @@ function getSalesforceFormData(
     form.push(encodeFormData(formFields.version, tags.get('sentry:release')));
     form.push(encodeFormData(formFields.build, tags.get('build.number')));
     const outreachConsent = (tags.get('outreachConsent') ?? 'False').toLowerCase();
-    if (outreachConsent == 'true') {
+    if (outreachConsent === 'true') {
       form.push(encodeFormData(formFields.outreachConsent, outreachConsent));
     }
     const formVersion = Number(tags.get('formVersion') ?? 1);


### PR DESCRIPTION
This is a new tag that will be set by the user on the Contact Us form in the Client and Manager apps in the near future, to mirror the new option in the https://support.getoutline.org form. It allows users to opt-in to being contacted in the future.