### PR TITLE
feat(server): use `rate()` over `increase()` for bandwidth calculations

### DIFF
--- a/src/shadowbox/server/manager_metrics.spec.ts
+++ b/src/shadowbox/server/manager_metrics.spec.ts
@@ -41,7 +41,7 @@ describe('PrometheusManagerMetrics', () => {
     const managerMetrics = new PrometheusManagerMetrics(
       new QueryMapPrometheusClient(
         {
-          'sum(increase(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
+          'sum(rate(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
             resultType: 'vector',
             result: [
               {
@@ -106,7 +106,7 @@ describe('PrometheusManagerMetrics', () => {
           },
         },
         {
-          'sum(increase(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
+          'sum(rate(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
             resultType: 'matrix',
             result: [
               {
@@ -161,12 +161,12 @@ describe('PrometheusManagerMetrics', () => {
     "tunnelTime": {
       "seconds": 1000
     },
-    "dataTransferred": {
-      "total": {
-        "bytes": 1000
-      },
+    "bandwidth": {
       "current": {
-        "bytes": 1234
+        "data": {
+          "bytes": 1234
+        },
+        "timestamp": 1739284734
       },
       "peak": {
         "data": {
@@ -216,7 +216,7 @@ describe('PrometheusManagerMetrics', () => {
     const managerMetrics = new PrometheusManagerMetrics(
       new QueryMapPrometheusClient(
         {
-          'sum(increase(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
+          'sum(rate(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
             resultType: 'vector',
             result: [
               {
@@ -279,7 +279,7 @@ describe('PrometheusManagerMetrics', () => {
           },
         },
         {
-          'sum(increase(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
+          'sum(rate(shadowsocks_data_bytes_per_location{dir=~"c<p|p>t"}[300s]))': {
             resultType: 'matrix',
             result: [
               {
@@ -334,12 +334,12 @@ describe('PrometheusManagerMetrics', () => {
     "tunnelTime": {
       "seconds": 1000
     },
-    "dataTransferred": {
-      "total": {
-        "bytes": 1000
-      },
+    "bandwidth": {
       "current": {
-        "bytes": 1234
+        "data": {
+          "bytes": 1234
+        },
+        "timestamp": 1739284734
       },
       "peak": {
         "data": {

--- a/src/shadowbox/server/manager_metrics.spec.ts
+++ b/src/shadowbox/server/manager_metrics.spec.ts
@@ -161,6 +161,9 @@ describe('PrometheusManagerMetrics', () => {
     "tunnelTime": {
       "seconds": 1000
     },
+    "dataTransferred": {
+      "bytes": 1000
+    },
     "bandwidth": {
       "current": {
         "data": {
@@ -333,6 +336,9 @@ describe('PrometheusManagerMetrics', () => {
   "server": {
     "tunnelTime": {
       "seconds": 1000
+    },
+    "dataTransferred": {
+      "bytes": 1000
     },
     "bandwidth": {
       "current": {

--- a/src/shadowbox/server/manager_metrics.ts
+++ b/src/shadowbox/server/manager_metrics.ts
@@ -47,6 +47,7 @@ interface BandwidthStats {
 
 interface ServerMetricsServerEntry {
   tunnelTime: Duration;
+  dataTransferred: Data;
   bandwidth: BandwidthStats;
   locations: ServerMetricsLocationEntry[];
 }
@@ -158,6 +159,7 @@ export class PrometheusManagerMetrics implements ManagerMetrics {
 
     const serverMetrics: ServerMetricsServerEntry = {
       tunnelTime: {seconds: 0},
+      dataTransferred: {bytes: 0},
       bandwidth: {
         current: {data: {bytes: 0}, timestamp: null},
         peak: {data: {bytes: 0}, timestamp: null},
@@ -192,7 +194,9 @@ export class PrometheusManagerMetrics implements ManagerMetrics {
     }
     for (const result of dataTransferredByLocation.result) {
       const entry = getServerMetricsLocationEntry(locationMap, result.metric);
-      entry.dataTransferred.bytes = result.value ? parseFloat(result.value[1]) : 0;
+      const bytes = result.value ? parseFloat(result.value[1]) : 0;
+      entry.dataTransferred.bytes = bytes;
+      serverMetrics.dataTransferred.bytes += bytes;
     }
     serverMetrics.locations = Array.from(locationMap.values());
 


### PR DESCRIPTION
Also slightly changed the shape to avoid confusion between data transferred (total) and bandwidth (rate per second).