### PR TITLE
chore: remove lastConnected property and update OpenAPI spec

### DIFF
--- a/src/shadowbox/server/api.yml
+++ b/src/shadowbox/server/api.yml
@@ -146,46 +146,94 @@ paths:
                 type: object
                 properties:
                   server:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        location:
-                          type: string
-                        asn:
-                          type: number
-                        asOrg:
-                          type: string
-                        tunnelTime:
+                    type: object
+                    properties:
+                      tunnelTime:
+                        type: object
+                        properties:
+                          seconds:
+                            type: number
+                      dataTransferred:
+                        type: object
+                        properties:
+                          bytes:
+                            type: number
+                      bandwidth:
+                        type: object
+                        properties:
+                          current:
+                            type: object
+                            properties:
+                              data:
+                                type: object
+                                properties:
+                                  bytes:
+                                    type: number
+                              timestamp:
+                                type: integer
+                          peak:
+                            type: object
+                            properties:
+                              data:
+                                type: object
+                                properties:
+                                  bytes:
+                                    type: number
+                              timestamp:
+                                type: integer
+                      locations:
+                        type: array
+                        items:
                           type: object
                           properties:
-                            seconds: 
+                            location:
+                              type: string
+                            asn:
                               type: number
-                        dataTransferred:
-                          type: object
-                          properties:
-                            bytes:
-                              type: number
+                            asOrg:
+                              type: string
+                            tunnelTime:
+                              type: object
+                              properties:
+                                seconds:
+                                  type: number
+                            dataTransferred:
+                              type: object
+                              properties:
+                                bytes:
+                                  type: number
                   accessKeys:
                     type: array
                     items:
                       type: object
                       properties:
                         accessKeyId:
-                          type: string
+                          type: integer
                         tunnelTime:
                           type: object
                           properties:
-                            seconds: 
+                            seconds:
                               type: number
                         dataTransferred:
                           type: object
                           properties:
-                            bytes: 
+                            bytes:
                               type: number
+                        connection:
+                          type: object
+                          properties:
+                            lastTrafficSeen:
+                              type: number
+                            peakDeviceCount:
+                              type: object
+                              properties:
+                                data:
+                                  type: integer
+                                timestamp:
+                                  type: integer
               examples:
                 '0':
-                  value: '{"server":[{"location":"US","asn":null,"asOrg":null,"tunnelTime":{"seconds":100},"dataTransferred":{"bytes":100}}],"accessKeys":[{"accessKeyId":"0","tunnelTime":{"seconds":100},"dataTransferred":{"bytes":100}}]}'
+                  value: '{"server":{"tunnelTime":{"seconds":100},"dataTransferred":{"bytes":100},"bandwidth": {"current": {"data": {"bytes": 10},"timestamp": 1739284734},"peak": {"data": {"bytes": 80},"timestamp": 1738959398}},"locations": [{"location": "US","asn": null,"asOrg": null,"dataTransferred": {"bytes": 100},"tunnelTime": {"seconds": 100}}]},"accessKeys":[{"accessKeyId":0,"tunnelTime":{"seconds":100},"dataTransferred":{"bytes":100},"connection": {"lastTrafficSeen": 1739284734,"peakDeviceCount": {"data": 4,"timestamp": 1738959398}}}]}'
   /name:
     put:
       description: Renames the server

--- a/src/shadowbox/server/manager_metrics.spec.ts
+++ b/src/shadowbox/server/manager_metrics.spec.ts
@@ -202,7 +202,6 @@ describe('PrometheusManagerMetrics', () => {
         "seconds": 1000
       },
       "connection": {
-        "lastConnected": 1738959398,
         "lastTrafficSeen": 1739284734,
         "peakDeviceCount": {
           "data": 4,
@@ -389,7 +388,6 @@ describe('PrometheusManagerMetrics', () => {
         "seconds": 1000
       },
       "connection": {
-        "lastConnected": null,
         "lastTrafficSeen": null,
         "peakDeviceCount": {
           "data": 0,
@@ -406,7 +404,6 @@ describe('PrometheusManagerMetrics', () => {
         "seconds": 0
       },
       "connection": {
-        "lastConnected": 1738959398,
         "lastTrafficSeen": 1738959398,
         "peakDeviceCount": {
           "data": 4,

--- a/src/shadowbox/server/manager_metrics.ts
+++ b/src/shadowbox/server/manager_metrics.ts
@@ -35,7 +35,6 @@ interface TimedData<T> {
 }
 
 interface ConnectionStats {
-  lastConnected: number | null;
   lastTrafficSeen: number | null;
   peakDeviceCount: TimedData<number>;
 }
@@ -211,8 +210,6 @@ export class PrometheusManagerMetrics implements ManagerMetrics {
     }
     for (const result of tunnelTimeByAccessKeyRange.result) {
       const entry = getServerMetricsAccessKeyEntry(accessKeyMap, result.metric);
-      const lastConnected = findLastNonZero(result.values ?? []);
-      entry.connection.lastConnected = lastConnected ? Math.min(now, lastConnected[0]) : null;
       const peakTunnelTimeSec = findPeak(result.values ?? []);
       if (peakTunnelTimeSec !== null) {
         const peakValue = parseFloat(peakTunnelTimeSec[1]);
@@ -268,7 +265,6 @@ function getServerMetricsAccessKeyEntry(
       dataTransferred: {bytes: 0},
       tunnelTime: {seconds: 0},
       connection: {
-        lastConnected: null,
         lastTrafficSeen: null,
         peakDeviceCount: {
           data: 0,


### PR DESCRIPTION
We decided not to show "last connected" in the UI, so I'm removing it for now on the endpoint so we don't continue to unnecessarily support this datapoint.