### PR TITLE
chore(server): set `Content-Type` header on Prom metrics endpoint

### DIFF
--- a/src/shadowbox/server/main.ts
+++ b/src/shadowbox/server/main.ts
@@ -48,6 +48,7 @@ const MMDB_LOCATION_ASN = '/var/lib/libmaxminddb/ip-asn.mmdb';
 async function exportPrometheusMetrics(registry: prometheus.Registry, port): Promise<http.Server> {
   return new Promise<http.Server>((resolve, _) => {
     const server = http.createServer((_, res) => {
+      res.setHeader('Content-Type', registry.contentType);
       res.write(registry.metrics());
       res.end();
     });


### PR DESCRIPTION
This will unblock upgrading to Prometheus v3.

"Prometheus v3 is more strict concerning the `Content-Type` header received when scraping. Prometheus v2 would default to the standard Prometheus text protocol if the target being scraped did not specify a Content-Type header or if the header was unparsable or unrecognised. This could lead to incorrect data being parsed in the scrape. Prometheus v3 will now fail the scrape in such cases." See https://prometheus.io/docs/prometheus/latest/migration/#scrape-protocols.