### PR TITLE
ci(sentry_webhook): pin Ubuntu due to Chromium bug (via Puppeteer)

### DIFF
--- a/.github/workflows/build_and_test_debug.yml
+++ b/.github/workflows/build_and_test_debug.yml
@@ -119,7 +119,8 @@ jobs:
 
   sentry-webhook:
     name: Sentry Webhook
-    runs-on: ubuntu-latest
+    # TODO(puppeteer/puppeteer#12818): Update when chromium bug is resolved.
+    runs-on: ubuntu-22.04
     needs: lint
     steps:
       - name: Checkout


### PR DESCRIPTION
This fixes the Sentry webhook CI job. See https://github.com/puppeteer/puppeteer/issues/12818 for details on the error.