### PR TITLE
fix(server): switch to maintained watchtower fork

### DIFF
--- a/src/server_manager/install_scripts/install_server.sh
+++ b/src/server_manager/install_scripts/install_server.sh
@@ -376,7 +376,7 @@ function start_watchtower() {
       -v /var/run/docker.sock:/var/run/docker.sock)
   # By itself, local messes up the return code.
   local STDERR_OUTPUT
-  STDERR_OUTPUT="$(docker run -d "${docker_watchtower_flags[@]}" nicholas-fedor/watchtower --cleanup --label-enable --scope=outline --tlsverify --interval "${WATCHTOWER_REFRESH_SECONDS}" 2>&1 >/dev/null)" && return
+  STDERR_OUTPUT="$(docker run -d "${docker_watchtower_flags[@]}" nickfedor/watchtower --cleanup --label-enable --scope=outline --tlsverify --interval "${WATCHTOWER_REFRESH_SECONDS}" 2>&1 >/dev/null)" && return
   readonly STDERR_OUTPUT
   log_error "FAILED"
   if docker_container_exists watchtower; then


### PR DESCRIPTION
Fix for https://github.com/OutlineFoundation/outline-server/issues/1684

[`containrrr/watchtower`](https://github.com/containrrr/watchtower) is no longer maintained, and has a breaking issue at https://github.com/containrrr/watchtower/issues/2122

https://github.com/nicholas-fedor/watchtower is the new maintained fork the community is moving to.