### PR TITLE
chore: update PR name linter

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v6.1.0
         with:
-          node-version: 24
+          node-version: 18
           cache: npm
 
       - name: Install NPM Dependencies


### PR DESCRIPTION
Fixing setup for https://github.com/JulienKode/pull-request-name-linter-action which was failing.

Fixing this unblocks https://github.com/OutlineFoundation/outline-server/pull/1690

This is currently blocked on the CLA check which is broken. I'm waiting on Maddy to remove that.